### PR TITLE
feat(design-data)!: nest token lifecycle fields under lifecycle object

### DIFF
--- a/.changeset/backfill-deprecated-versions.md
+++ b/.changeset/backfill-deprecated-versions.md
@@ -1,0 +1,14 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Backfill the `deprecated: "unknown"` migration placeholder with the real `@adobe/spectrum-tokens`
+release version each token was deprecated in (closes spectrum-design-data-3xf). Legacy output is
+unchanged — `deprecated` stays truthy either way.
+
+- **packages/design-data/tokens/\*.tokens.json** (7 of 8 files): 1,323 tokens' deprecation
+  version replaced `"unknown"` with the release version recovered from
+  `packages/tokens/CHANGELOG.md`'s "Newly Deprecated" history (1,242 tokens) or git
+  archaeology on `packages/tokens/src/*.json` (81 tokens).
+- **packages/design-data/scripts/backfill-deprecated-versions.js**: new re-runnable recovery script
+  documenting the two-source resolution method.

--- a/.changeset/nest-token-lifecycle-fields.md
+++ b/.changeset/nest-token-lifecycle-fields.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": major
+---
+
+Nest token lifecycle fields under a single `lifecycle` object, matching the component
+schema's existing `lifecycle` pattern (closes spectrum-design-data-u6w). `deprecated`
+is renamed to `lifecycle.deprecatedIn` — the old name read as boolean-ish even though
+it holds a version string. Legacy output (`@adobe/spectrum-tokens`) is unchanged;
+`deprecated`/`deprecated_comment`/`renamed` there stay flat.
+
+- **packages/design-data-spec/schemas/token.schema.json**: new `$defs.lifecycle`
+  (`introduced`, `deprecatedIn`, `deprecatedComment`, `replacedBy`, `plannedRemoval`),
+  referenced from `tokenWithValue`/`tokenWithRef` in place of the 5 removed flat fields.
+- **packages/design-data-spec/schemas/component.schema.json**: renamed the existing
+  `lifecycle.deprecated` to `lifecycle.deprecatedIn` so token and component schemas match.
+- **packages/design-data/tokens/\*.tokens.json** (7 of 8 files): 1,323 tokens migrated
+  from flat `deprecated`/`deprecated_comment`/`replaced_by`/`plannedRemoval`/`introduced`
+  into the nested `lifecycle` object.
+- **packages/design-data/scripts/migrate-lifecycle-nesting.js**: new re-runnable
+  migration script.
+- **sdk/core/src** (`legacy.rs`, `migrate.rs`, `diff.rs`, `authoring/{lifecycle,session}.rs`,
+  `validate/rules/spec0{10,11,12,13,14,36,37}.rs`): retargeted to `lifecycle.*`.

--- a/packages/design-data-spec/conformance/diff/cross-format/expected.json
+++ b/packages/design-data-spec/conformance/diff/cross-format/expected.json
@@ -6,9 +6,9 @@
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
       "property_changes": [
         {
-          "path": "name",
+          "path": "name.property",
           "change_type": "added",
-          "new_value": { "property": "background-color-default" }
+          "new_value": "background-color-default"
         },
         {
           "path": "value",

--- a/packages/design-data-spec/conformance/diff/deprecated-new-token/new/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/diff/deprecated-new-token/new/tokens.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "name": { "property": "deprecated-token" },
-    "deprecated": true,
+    "lifecycle": { "deprecatedIn": true },
     "value": "#999999",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001"
   }

--- a/packages/design-data-spec/conformance/diff/matched-gaining-deprecated/expected.json
+++ b/packages/design-data-spec/conformance/diff/matched-gaining-deprecated/expected.json
@@ -10,9 +10,9 @@
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
       "property_changes": [
         {
-          "path": "deprecated",
+          "path": "lifecycle",
           "change_type": "added",
-          "new_value": true
+          "new_value": { "deprecatedIn": true }
         }
       ]
     }

--- a/packages/design-data-spec/conformance/diff/matched-gaining-deprecated/expected.json
+++ b/packages/design-data-spec/conformance/diff/matched-gaining-deprecated/expected.json
@@ -10,9 +10,9 @@
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
       "property_changes": [
         {
-          "path": "lifecycle",
+          "path": "lifecycle.deprecatedIn",
           "change_type": "added",
-          "new_value": { "deprecatedIn": true }
+          "new_value": true
         }
       ]
     }

--- a/packages/design-data-spec/conformance/diff/matched-gaining-deprecated/new/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/diff/matched-gaining-deprecated/new/tokens.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "name": { "property": "gaining-deprecated" },
-    "deprecated": true,
+    "lifecycle": { "deprecatedIn": true },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001"
   }

--- a/packages/design-data-spec/conformance/diff/replaced-by-pairing/expected.json
+++ b/packages/design-data-spec/conformance/diff/replaced-by-pairing/expected.json
@@ -6,25 +6,19 @@
       "uuid": "aaaaaaaa-0002-4000-8000-000000000001",
       "property_changes": [
         {
-          "path": "deprecated",
+          "path": "lifecycle",
           "change_type": "deleted",
-          "original_value": "3.0.0"
-        },
-        {
-          "path": "deprecated_comment",
-          "change_type": "deleted",
-          "original_value": "Use action-background-default instead."
+          "original_value": {
+            "deprecatedIn": "3.0.0",
+            "deprecatedComment": "Use action-background-default instead.",
+            "replacedBy": "aaaaaaaa-0002-4000-8000-000000000001"
+          }
         },
         {
           "path": "name.property",
           "change_type": "updated",
           "new_value": "action-background-default",
           "original_value": "old-button-bg"
-        },
-        {
-          "path": "replaced_by",
-          "change_type": "deleted",
-          "original_value": "aaaaaaaa-0002-4000-8000-000000000001"
         },
         {
           "path": "uuid",

--- a/packages/design-data-spec/conformance/diff/replaced-by-pairing/expected.json
+++ b/packages/design-data-spec/conformance/diff/replaced-by-pairing/expected.json
@@ -6,13 +6,19 @@
       "uuid": "aaaaaaaa-0002-4000-8000-000000000001",
       "property_changes": [
         {
-          "path": "lifecycle",
+          "path": "lifecycle.deprecatedComment",
           "change_type": "deleted",
-          "original_value": {
-            "deprecatedIn": "3.0.0",
-            "deprecatedComment": "Use action-background-default instead.",
-            "replacedBy": "aaaaaaaa-0002-4000-8000-000000000001"
-          }
+          "original_value": "Use action-background-default instead."
+        },
+        {
+          "path": "lifecycle.deprecatedIn",
+          "change_type": "deleted",
+          "original_value": "3.0.0"
+        },
+        {
+          "path": "lifecycle.replacedBy",
+          "change_type": "deleted",
+          "original_value": "aaaaaaaa-0002-4000-8000-000000000001"
         },
         {
           "path": "name.property",

--- a/packages/design-data-spec/conformance/diff/replaced-by-pairing/old/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/diff/replaced-by-pairing/old/tokens.tokens.json
@@ -3,8 +3,10 @@
     "name": { "property": "old-button-bg" },
     "value": "#0265dc",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-    "deprecated": "3.0.0",
-    "deprecated_comment": "Use action-background-default instead.",
-    "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001"
+    "lifecycle": {
+      "deprecatedIn": "3.0.0",
+      "deprecatedComment": "Use action-background-default instead.",
+      "replacedBy": "aaaaaaaa-0002-4000-8000-000000000001"
+    }
   }
 ]

--- a/packages/design-data-spec/conformance/diff/reverted-token/old/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/diff/reverted-token/old/tokens.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "name": { "property": "reverted-prop" },
-    "deprecated": true,
+    "lifecycle": { "deprecatedIn": true },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001"
   }

--- a/packages/design-data-spec/conformance/generation/deprecated-token/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/generation/deprecated-token/input/tokens.tokens.json
@@ -4,8 +4,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgb(255, 0, 0)",
     "uuid": "dddddddd-0001-4000-8000-000000000001",
-    "deprecated": "2.0",
-    "deprecated_comment": "Use color-blue-100 instead",
-    "plannedRemoval": "3.0"
+    "lifecycle": {
+      "deprecatedIn": "2.0",
+      "deprecatedComment": "Use color-blue-100 instead",
+      "plannedRemoval": "3.0"
+    }
   }
 ]

--- a/packages/design-data-spec/conformance/generation/mode-set-edit/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/generation/mode-set-edit/input/tokens.tokens.json
@@ -11,8 +11,10 @@
     "uuid": "11111111-0001-4000-8000-000000000001",
     "set_uuid": "11111111-0003-4000-8000-000000000003",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "deprecated": true,
-    "replaced_by": "11111111-0004-4000-8000-000000000004"
+    "lifecycle": {
+      "deprecatedIn": true,
+      "replacedBy": "11111111-0004-4000-8000-000000000004"
+    }
   },
   {
     "name": {
@@ -26,8 +28,10 @@
     "uuid": "11111111-0002-4000-8000-000000000002",
     "set_uuid": "11111111-0003-4000-8000-000000000003",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "deprecated": true,
-    "replaced_by": "11111111-0004-4000-8000-000000000004"
+    "lifecycle": {
+      "deprecatedIn": true,
+      "replacedBy": "11111111-0004-4000-8000-000000000004"
+    }
   },
   {
     "name": { "property": "color", "colorFamily": "accent-new-400" },

--- a/packages/design-data-spec/conformance/generation/renamed-token/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/generation/renamed-token/input/tokens.tokens.json
@@ -4,8 +4,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgb(128, 128, 128)",
     "uuid": "eeeeeeee-0001-4000-8000-000000000001",
-    "deprecated": true,
-    "replaced_by": "eeeeeeee-0002-4000-8000-000000000002"
+    "lifecycle": {
+      "deprecatedIn": true,
+      "replacedBy": "eeeeeeee-0002-4000-8000-000000000002"
+    }
   },
   {
     "name": { "property": "color", "colorFamily": "neutral" },

--- a/packages/design-data-spec/conformance/invalid/SPEC-010/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-010/dataset.json
@@ -4,8 +4,10 @@
       "name": { "property": "deprecated-token" },
       "value": "#ffffff",
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-      "deprecated": "3.0.0",
-      "replaced_by": "bbbbbbbb-9999-4000-8000-000000000099"
+      "lifecycle": {
+        "deprecatedIn": "3.0.0",
+        "replacedBy": "bbbbbbbb-9999-4000-8000-000000000099"
+      }
     }
   ],
   "components": []

--- a/packages/design-data-spec/conformance/invalid/SPEC-010/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-010/expected-errors.json
@@ -4,7 +4,7 @@
     {
       "rule_id": "SPEC-010",
       "severity": "error",
-      "message_pattern": "replaced_by target UUID not found"
+      "message_pattern": "lifecycle\\.replacedBy target UUID not found"
     }
   ]
 }

--- a/packages/design-data-spec/conformance/invalid/SPEC-010/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-010/tokens.tokens.json
@@ -3,7 +3,9 @@
     "name": { "property": "deprecated-token" },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-    "deprecated": "3.0.0",
-    "replaced_by": "bbbbbbbb-9999-4000-8000-000000000099"
+    "lifecycle": {
+      "deprecatedIn": "3.0.0",
+      "replacedBy": "bbbbbbbb-9999-4000-8000-000000000099"
+    }
   }
 ]

--- a/packages/design-data-spec/conformance/invalid/SPEC-011/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-011/dataset.json
@@ -4,11 +4,13 @@
       "name": { "property": "split-token" },
       "value": "#ffffff",
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-      "deprecated": "3.0.0",
-      "replaced_by": [
-        "aaaaaaaa-0002-4000-8000-000000000001",
-        "aaaaaaaa-0003-4000-8000-000000000001"
-      ]
+      "lifecycle": {
+        "deprecatedIn": "3.0.0",
+        "replacedBy": [
+          "aaaaaaaa-0002-4000-8000-000000000001",
+          "aaaaaaaa-0003-4000-8000-000000000001"
+        ]
+      }
     },
     {
       "name": { "property": "replacement-a" },

--- a/packages/design-data-spec/conformance/invalid/SPEC-011/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-011/expected-errors.json
@@ -4,7 +4,7 @@
     {
       "rule_id": "SPEC-011",
       "severity": "error",
-      "message_pattern": "replaced_by is an array but deprecated_comment is missing"
+      "message_pattern": "lifecycle\\.replacedBy is an array but lifecycle\\.deprecatedComment is missing"
     }
   ]
 }

--- a/packages/design-data-spec/conformance/invalid/SPEC-011/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-011/tokens.tokens.json
@@ -3,11 +3,13 @@
     "name": { "property": "split-token" },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-    "deprecated": "3.0.0",
-    "replaced_by": [
-      "aaaaaaaa-0002-4000-8000-000000000001",
-      "aaaaaaaa-0003-4000-8000-000000000001"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "3.0.0",
+      "replacedBy": [
+        "aaaaaaaa-0002-4000-8000-000000000001",
+        "aaaaaaaa-0003-4000-8000-000000000001"
+      ]
+    }
   },
   {
     "name": { "property": "replacement-a" },

--- a/packages/design-data-spec/conformance/invalid/SPEC-012/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-012/dataset.json
@@ -4,7 +4,7 @@
       "name": { "property": "not-deprecated-but-replaced" },
       "value": "#ffffff",
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-      "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001"
+      "lifecycle": { "replacedBy": "aaaaaaaa-0002-4000-8000-000000000001" }
     },
     {
       "name": { "property": "replacement" },

--- a/packages/design-data-spec/conformance/invalid/SPEC-012/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-012/expected-errors.json
@@ -4,7 +4,7 @@
     {
       "rule_id": "SPEC-012",
       "severity": "error",
-      "message_pattern": "has replaced_by but is not marked deprecated"
+      "message_pattern": "has lifecycle\\.replacedBy but is not marked deprecated"
     }
   ]
 }

--- a/packages/design-data-spec/conformance/invalid/SPEC-012/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-012/tokens.tokens.json
@@ -3,7 +3,7 @@
     "name": { "property": "not-deprecated-but-replaced" },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-    "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001"
+    "lifecycle": { "replacedBy": "aaaaaaaa-0002-4000-8000-000000000001" }
   },
   {
     "name": { "property": "replacement" },

--- a/packages/design-data-spec/conformance/invalid/SPEC-013/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-013/dataset.json
@@ -4,7 +4,7 @@
       "name": { "property": "not-deprecated-but-planned-removal" },
       "value": "#ffffff",
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-      "plannedRemoval": "4.0.0"
+      "lifecycle": { "plannedRemoval": "4.0.0" }
     }
   ],
   "components": []

--- a/packages/design-data-spec/conformance/invalid/SPEC-013/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-013/tokens.tokens.json
@@ -3,6 +3,6 @@
     "name": { "property": "not-deprecated-but-planned-removal" },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-    "plannedRemoval": "4.0.0"
+    "lifecycle": { "plannedRemoval": "4.0.0" }
   }
 ]

--- a/packages/design-data-spec/conformance/invalid/SPEC-014/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-014/dataset.json
@@ -4,7 +4,7 @@
       "name": { "property": "last-modified-before-introduced" },
       "value": "#ffffff",
       "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-      "introduced": "2.0.0",
+      "lifecycle": { "introduced": "2.0.0" },
       "lastModified": "1.5.0"
     }
   ],

--- a/packages/design-data-spec/conformance/invalid/SPEC-014/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-014/tokens.tokens.json
@@ -3,7 +3,7 @@
     "name": { "property": "last-modified-before-introduced" },
     "value": "#ffffff",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-    "introduced": "2.0.0",
+    "lifecycle": { "introduced": "2.0.0" },
     "lastModified": "1.5.0"
   }
 ]

--- a/packages/design-data-spec/conformance/invalid/SPEC-036/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-036/dataset.json
@@ -18,7 +18,7 @@
         "documentationUrl": "https://spectrum.adobe.com/page/old-widget/"
       },
       "lifecycle": {
-        "deprecated": "1.0.0-draft",
+        "deprecatedIn": "1.0.0-draft",
         "deprecatedComment": "Superseded by new-widget."
       }
     }

--- a/packages/design-data-spec/conformance/invalid/SPEC-037/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-037/dataset.json
@@ -38,7 +38,7 @@
         {
           "name": "handle",
           "lifecycle": {
-            "deprecated": "1.0.0-draft",
+            "deprecatedIn": "1.0.0-draft",
             "deprecatedComment": "Renamed to thumb."
           }
         }
@@ -56,7 +56,7 @@
         {
           "name": "pressed",
           "lifecycle": {
-            "deprecated": "1.0.0-draft",
+            "deprecatedIn": "1.0.0-draft",
             "deprecatedComment": "Use active instead."
           }
         }
@@ -74,7 +74,7 @@
             {
               "value": "cta",
               "lifecycle": {
-                "deprecated": "1.0.0-draft",
+                "deprecatedIn": "1.0.0-draft",
                 "deprecatedComment": "Use primary instead."
               }
             }

--- a/packages/design-data-spec/conformance/valid/SPEC-014/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-014/dataset.json
@@ -4,7 +4,7 @@
       "name": { "property": "accent-color" },
       "value": "#0d66d0",
       "uuid": "aaaaaaaa-0014-4000-8000-000000000001",
-      "introduced": "1.0.0",
+      "lifecycle": { "introduced": "1.0.0" },
       "lastModified": "1.2.0"
     }
   ],

--- a/packages/design-data-spec/conformance/valid/SPEC-036/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-036/dataset.json
@@ -13,7 +13,7 @@
         "property": "color"
       },
       "value": "#000000",
-      "deprecated": "1.0.0-draft"
+      "lifecycle": { "deprecatedIn": "1.0.0-draft" }
     }
   ],
   "components": [
@@ -35,7 +35,7 @@
         "documentationUrl": "https://spectrum.adobe.com/page/old-widget/"
       },
       "lifecycle": {
-        "deprecated": "1.0.0-draft",
+        "deprecatedIn": "1.0.0-draft",
         "deprecatedComment": "Superseded by new-widget."
       }
     }

--- a/packages/design-data-spec/conformance/valid/SPEC-037/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-037/dataset.json
@@ -15,7 +15,7 @@
         "property": "background-color"
       },
       "value": "#0265dc",
-      "deprecated": "1.0.0-draft"
+      "lifecycle": { "deprecatedIn": "1.0.0-draft" }
     },
     {
       "name": {
@@ -32,7 +32,7 @@
         "property": "background-color"
       },
       "value": "#cccccc",
-      "deprecated": "1.0.0-draft"
+      "lifecycle": { "deprecatedIn": "1.0.0-draft" }
     },
     {
       "name": {
@@ -49,7 +49,7 @@
         "property": "background-color"
       },
       "value": "#0265dc",
-      "deprecated": "1.0.0-draft"
+      "lifecycle": { "deprecatedIn": "1.0.0-draft" }
     }
   ],
   "components": [
@@ -68,7 +68,7 @@
         {
           "name": "handle",
           "lifecycle": {
-            "deprecated": "1.0.0-draft",
+            "deprecatedIn": "1.0.0-draft",
             "deprecatedComment": "Renamed to thumb."
           }
         }
@@ -89,7 +89,7 @@
         {
           "name": "pressed",
           "lifecycle": {
-            "deprecated": "1.0.0-draft",
+            "deprecatedIn": "1.0.0-draft",
             "deprecatedComment": "Use active instead."
           }
         }
@@ -107,7 +107,7 @@
             {
               "value": "cta",
               "lifecycle": {
-                "deprecated": "1.0.0-draft",
+                "deprecatedIn": "1.0.0-draft",
                 "deprecatedComment": "Use primary instead."
               }
             }

--- a/packages/design-data-spec/conformance/valid/lifecycle-with-last-modified.json
+++ b/packages/design-data-spec/conformance/valid/lifecycle-with-last-modified.json
@@ -7,6 +7,6 @@
   },
   "value": "#0265dc",
   "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-  "introduced": "1.0.0",
+  "lifecycle": { "introduced": "1.0.0" },
   "lastModified": "2.1.0"
 }

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -179,7 +179,7 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle",
-          "description": "Version lifecycle metadata for this value. Set lifecycle.deprecated to signal that tokens referencing this value should migrate (SPEC-037)."
+          "description": "Version lifecycle metadata for this value. Set lifecycle.deprecatedIn to signal that tokens referencing this value should migrate (SPEC-037)."
         }
       },
       "additionalProperties": false
@@ -234,7 +234,7 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle",
-          "description": "Version lifecycle metadata for this anatomy part. Set lifecycle.deprecated to signal that tokens referencing this part should migrate."
+          "description": "Version lifecycle metadata for this anatomy part. Set lifecycle.deprecatedIn to signal that tokens referencing this part should migrate."
         }
       },
       "additionalProperties": false
@@ -284,7 +284,7 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle",
-          "description": "Version lifecycle metadata for this state. Set lifecycle.deprecated to signal that tokens referencing this state should migrate."
+          "description": "Version lifecycle metadata for this state. Set lifecycle.deprecatedIn to signal that tokens referencing this state should migrate."
         }
       },
       "additionalProperties": false
@@ -314,7 +314,7 @@
           "type": "string",
           "description": "Spec version when this component declaration was added (e.g. '1.0.0-draft')."
         },
-        "deprecated": {
+        "deprecatedIn": {
           "type": "string",
           "description": "Spec version when this component was deprecated. Truthy = deprecated."
         },

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -114,6 +114,40 @@
         "type": "string"
       }
     },
+    "lifecycle": {
+      "type": "object",
+      "description": "Version lifecycle metadata, mirroring the component lifecycle pattern (see component.schema.json).",
+      "properties": {
+        "introduced": {
+          "type": "string",
+          "description": "Spec version when this token was added (e.g. \"1.0.0-draft\")."
+        },
+        "deprecatedIn": {
+          "type": "string",
+          "description": "Spec version when the token was deprecated (e.g. \"3.2.0\"). Truthy = deprecated."
+        },
+        "deprecatedComment": {
+          "type": "string",
+          "description": "Human-readable deprecation explanation and migration guidance."
+        },
+        "replacedBy": {
+          "oneOf": [
+            { "type": "string", "format": "uuid" },
+            {
+              "type": "array",
+              "items": { "type": "string", "format": "uuid" },
+              "minItems": 1
+            }
+          ],
+          "description": "UUID(s) of the replacement token(s). Array form requires deprecatedComment."
+        },
+        "plannedRemoval": {
+          "type": "string",
+          "description": "Spec version when token will be removed."
+        }
+      },
+      "additionalProperties": false
+    },
     "tokenWithValue": {
       "type": "object",
       "required": ["name", "value"],
@@ -166,30 +200,8 @@
           "type": "string",
           "format": "uuid"
         },
-        "introduced": {
-          "type": "string"
-        },
-        "deprecated": {
-          "type": "string",
-          "description": "Spec version when token was deprecated (e.g. \"3.2.0\"). Truthy = deprecated."
-        },
-        "deprecated_comment": {
-          "type": "string"
-        },
-        "replaced_by": {
-          "oneOf": [
-            { "type": "string", "format": "uuid" },
-            {
-              "type": "array",
-              "items": { "type": "string", "format": "uuid" },
-              "minItems": 1
-            }
-          ],
-          "description": "UUID(s) of the replacement token(s). Array form requires deprecated_comment."
-        },
-        "plannedRemoval": {
-          "type": "string",
-          "description": "Spec version when token will be removed."
+        "lifecycle": {
+          "$ref": "#/$defs/lifecycle"
         },
         "private": {
           "type": "boolean"
@@ -250,30 +262,8 @@
           "type": "string",
           "format": "uuid"
         },
-        "introduced": {
-          "type": "string"
-        },
-        "deprecated": {
-          "type": "string",
-          "description": "Spec version when token was deprecated (e.g. \"3.2.0\"). Truthy = deprecated."
-        },
-        "deprecated_comment": {
-          "type": "string"
-        },
-        "replaced_by": {
-          "oneOf": [
-            { "type": "string", "format": "uuid" },
-            {
-              "type": "array",
-              "items": { "type": "string", "format": "uuid" },
-              "minItems": 1
-            }
-          ],
-          "description": "UUID(s) of the replacement token(s). Array form requires deprecated_comment."
-        },
-        "plannedRemoval": {
-          "type": "string",
-          "description": "Spec version when token will be removed."
+        "lifecycle": {
+          "$ref": "#/$defs/lifecycle"
         },
         "private": {
           "type": "boolean"

--- a/packages/design-data-spec/spec/authoring-workflow.md
+++ b/packages/design-data-spec/spec/authoring-workflow.md
@@ -56,19 +56,19 @@ The following table defines the **target token-authoring contract**: the complet
 
 ### Token lifecycle operations
 
-| Operation               | Description                                                                                                                      | Required fields                        |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| **create**              | Introduce a new token to the dataset. Assign a fresh UUID. Populate name object, value or alias `$ref`, `introduced` version.    | `uuid`, `name`, `value` or `$ref`      |
-| **edit**                | Update a token's value, alias target, rationale, or name-object fields. Preserve UUID.                                           | `uuid` (for identity lookup)           |
-| **deprecate**           | Set `deprecated` to the current spec version string; optionally set `replaced_by` and `deprecated_comment`.                      | `deprecated`, `uuid`                   |
-| **rename**              | Assign a new name object. Introduce a `replaced_by` pointer on the old token (or retire it). Preserve UUID on the renamed token. | Name-object fields, `replaced_by`      |
-| **alias-rewire**        | Change the `$ref` target UUID of an alias token. Verify the new target resolves in the cascade.                                  | `$ref`                                 |
-| **mode-set management** | Add, rename, or remove a mode-set entry. Update affected `mode` fields across tokens.                                            | Mode-set file + affected token entries |
-| **remove**              | Delete a token that has passed its migration window. Verify no `$ref` in the dataset resolves to the removed UUID.               | n/a                                    |
+| Operation               | Description                                                                                                                               | Required fields                            |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **create**              | Introduce a new token to the dataset. Assign a fresh UUID. Populate name object, value or alias `$ref`, `lifecycle.introduced` version.   | `uuid`, `name`, `value` or `$ref`          |
+| **edit**                | Update a token's value, alias target, rationale, or name-object fields. Preserve UUID.                                                    | `uuid` (for identity lookup)               |
+| **deprecate**           | Set `lifecycle.deprecatedIn` to the current spec version string; optionally set `lifecycle.replacedBy` and `lifecycle.deprecatedComment`. | `lifecycle.deprecatedIn`, `uuid`           |
+| **rename**              | Assign a new name object. Introduce a `lifecycle.replacedBy` pointer on the old token (or retire it). Preserve UUID on the renamed token. | Name-object fields, `lifecycle.replacedBy` |
+| **alias-rewire**        | Change the `$ref` target UUID of an alias token. Verify the new target resolves in the cascade.                                           | `$ref`                                     |
+| **mode-set management** | Add, rename, or remove a mode-set entry. Update affected `mode` fields across tokens.                                                     | Mode-set file + affected token entries     |
+| **remove**              | Delete a token that has passed its migration window. Verify no `$ref` in the dataset resolves to the removed UUID.                        | n/a                                        |
 
-**NORMATIVE:** A conforming authoring tool MUST assign UUIDs at creation time and MUST NOT change the UUID of an existing token during any edit, deprecate, rename, or alias-rewire operation. UUID stability is the identity contract that allows `$ref`, `replaced_by`, and external consumers to reference tokens across versions.
+**NORMATIVE:** A conforming authoring tool MUST assign UUIDs at creation time and MUST NOT change the UUID of an existing token during any edit, deprecate, rename, or alias-rewire operation. UUID stability is the identity contract that allows `$ref`, `lifecycle.replacedBy`, and external consumers to reference tokens across versions.
 
-**NORMATIVE:** A conforming authoring tool MUST write a valid `introduced` version on create, using the declared spec version of the active dataset (`specVersion` field in `dataset.json` or `.design-data.toml`).
+**NORMATIVE:** A conforming authoring tool MUST write a valid `lifecycle.introduced` version on create, using the declared spec version of the active dataset (`specVersion` field in `dataset.json` or `.design-data.toml`).
 
 **NORMATIVE:** A conforming authoring tool MUST validate the written dataset against Layer 1 (JSON Schema) and Layer 2 (semantic rules) before persisting the write. A write operation that produces a Layer 1 error MUST be rejected.
 
@@ -95,13 +95,13 @@ Tokens are authored in `tokens/**/*.tokens.json`. Files may be nested arbitraril
 
 **Required at creation:** A conforming authoring tool MUST write:
 
-| Field             | Requirement            | Notes                                                                                                                                          |
-| ----------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`            | REQUIRED               | Name object with at least `property`; MUST be decomposed via the `fields/` catalog — see [Taxonomy-aware authoring](#taxonomy-aware-authoring) |
-| `uuid`            | REQUIRED               | Fresh UUID v4 assigned by the tool; MUST NOT change for the lifetime of the token                                                              |
-| `value` or `$ref` | REQUIRED (exactly one) | Literal value or alias reference to another token's UUID                                                                                       |
-| `$schema`         | RECOMMENDED            | Token-type schema URI (e.g. `color.json`, `typography.json`) from `packages/design-data-spec/schemas/`                                         |
-| `introduced`      | RECOMMENDED            | Spec version string of the active dataset at creation time                                                                                     |
+| Field                  | Requirement            | Notes                                                                                                                                          |
+| ---------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | REQUIRED               | Name object with at least `property`; MUST be decomposed via the `fields/` catalog — see [Taxonomy-aware authoring](#taxonomy-aware-authoring) |
+| `uuid`                 | REQUIRED               | Fresh UUID v4 assigned by the tool; MUST NOT change for the lifetime of the token                                                              |
+| `value` or `$ref`      | REQUIRED (exactly one) | Literal value or alias reference to another token's UUID                                                                                       |
+| `$schema`              | RECOMMENDED            | Token-type schema URI (e.g. `color.json`, `typography.json`) from `packages/design-data-spec/schemas/`                                         |
+| `lifecycle.introduced` | RECOMMENDED            | Spec version string of the active dataset at creation time                                                                                     |
 
 **Validation gate:** SPEC-001–017 (name, value, lifecycle, tech-debt), SPEC-041 (mode-set
 conformance), SPEC-042 (field-scope), SPEC-043 (domain-required-fields).
@@ -261,7 +261,7 @@ authoring is Phase C scope; vocabulary additions today follow the manual process
 
 1. Write all authored artifacts to the dataset root's registered directories (not to legacy output files).
 2. Assign UUIDs at creation time and preserve them across all subsequent operations.
-3. Write a valid `introduced` version on all created artifacts.
+3. Write a valid `lifecycle.introduced` version on all created artifacts.
 4. Validate written artifacts against Layer 1 (JSON Schema) and Layer 2 (semantic rules) before persisting.
 5. Support structured name-object field decomposition using the `fields/` catalog for token creation.
 

--- a/packages/design-data-spec/spec/evolution.md
+++ b/packages/design-data-spec/spec/evolution.md
@@ -12,36 +12,36 @@ Tokens progress through the following lifecycle stages:
 introduced → active → deprecated → planned removal → removed
 ```
 
-| Stage               | Token state                                                                                                                                                                    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Introduced**      | Token first appears in the dataset. `introduced` field records the version.                                                                                                    |
-| **Active**          | Token is current and recommended for use. No `deprecated` field.                                                                                                               |
-| **Deprecated**      | Token is no longer recommended. `deprecated` records the version. Consumers receive warnings. `replaced_by` points to the successor token(s) when a direct replacement exists. |
-| **Planned removal** | `plannedRemoval` records the target version. The token remains in the dataset but consumers should complete migration.                                                         |
-| **Removed**         | Token is deleted from the dataset. Consumers that still reference it will break.                                                                                               |
+| Stage               | Token state                                                                                                                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Introduced**      | Token first appears in the dataset. `lifecycle.introduced` field records the version.                                                                                                               |
+| **Active**          | Token is current and recommended for use. No `lifecycle` field (or no `deprecatedIn` within it).                                                                                                    |
+| **Deprecated**      | Token is no longer recommended. `lifecycle.deprecatedIn` records the version. Consumers receive warnings. `lifecycle.replacedBy` points to the successor token(s) when a direct replacement exists. |
+| **Planned removal** | `lifecycle.plannedRemoval` records the target version. The token remains in the dataset but consumers should complete migration.                                                                    |
+| **Removed**         | Token is deleted from the dataset. Consumers that still reference it will break.                                                                                                                    |
 
 ### Lifecycle fields
 
 See [Token format — Lifecycle and metadata](token-format.md#lifecycle-and-metadata) for the full field definitions and normative rules.
 
-### What `replaced_by` guarantees
+### What `lifecycle.replacedBy` guarantees
 
-When a token carries `replaced_by`:
+When a token carries `lifecycle.replacedBy`:
 
 * Each target UUID **MUST** resolve to an existing token in the dataset (rule `SPEC-010`).
 * The target token **SHOULD NOT** itself be deprecated. Chains of replacements (A replaced by B, B replaced by C) are discouraged; authors should point directly to the final replacement.
 * For a single UUID (1:1 replacement), consumers can mechanically rewrite references.
-* For an array of UUIDs (one-to-many split), the `deprecated_comment` **MUST** explain which replacement applies in which context.
+* For an array of UUIDs (one-to-many split), the `lifecycle.deprecatedComment` **MUST** explain which replacement applies in which context.
 
 ## Migration windows
 
-**NORMATIVE:** A deprecated token **MUST** remain in the published dataset for at least **two minor versions** after the version recorded in `deprecated` before it may be removed.
+**NORMATIVE:** A deprecated token **MUST** remain in the published dataset for at least **two minor versions** after the version recorded in `lifecycle.deprecatedIn` before it may be removed.
 
 **EXAMPLE:** A token deprecated in `3.2.0` may not be removed until `3.4.0` at the earliest. Removal in a major version (e.g. `4.0.0`) is always permitted regardless of how recently the token was deprecated.
 
 **RATIONALE:** Two minor versions gives consumers at least two release cycles to migrate. The major-version escape hatch allows accumulated deprecations to be cleaned up in a coordinated breaking release.
 
-If `plannedRemoval` is set, it overrides the default window — the token will be removed in the specified version (which must not precede the `deprecated` version).
+If `lifecycle.plannedRemoval` is set, it overrides the default window — the token will be removed in the specified version (which must not precede the `deprecatedIn` version).
 
 ## Change classification
 
@@ -52,7 +52,7 @@ The specification follows [Semantic Versioning](https://semver.org/) for its pub
 * New tokens added to the dataset
 * New optional fields added to token schema
 * New validation rules added to the rule catalog
-* Tokens deprecated (with `deprecated` field)
+* Tokens deprecated (with `lifecycle.deprecatedIn` field)
 * Rule severity relaxed (error → warning)
 * New enum values added to registries
 
@@ -79,13 +79,13 @@ The `@adobe/spectrum-tokens` package continues to publish tokens in the **legacy
 
 ### Lifecycle field mapping
 
-| Cascade format                         | Legacy format                         |
-| -------------------------------------- | ------------------------------------- |
-| `deprecated: "3.2.0"` (version string) | `deprecated: true` (boolean)          |
-| `replaced_by: "<uuid>"`                | `renamed: "<target-token-name>"`      |
-| `introduced`                           | Not emitted                           |
-| `plannedRemoval`                       | Not emitted                           |
-| `deprecated_comment`                   | `deprecated_comment` (passed through) |
+| Cascade format                                     | Legacy format                         |
+| -------------------------------------------------- | ------------------------------------- |
+| `lifecycle.deprecatedIn: "3.2.0"` (version string) | `deprecated: true` (boolean)          |
+| `lifecycle.replacedBy: "<uuid>"`                   | `renamed: "<target-token-name>"`      |
+| `lifecycle.introduced`                             | Not emitted                           |
+| `lifecycle.plannedRemoval`                         | Not emitted                           |
+| `lifecycle.deprecatedComment`                      | `deprecated_comment` (passed through) |
 
 ### Output-generator determinism
 

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -134,18 +134,25 @@ When **`value`** is present, it **MUST** conform to the declared value type for 
 
 ### Lifecycle and metadata
 
-The following OPTIONAL fields implement the token lifecycle model described in [#623](https://github.com/adobe/spectrum-design-data/discussions/623) and the evolution policy in [Evolution](evolution.md). Inspired by Swift's `@available` attribute, Kotlin's `@Deprecated`, and OpenAPI 3.3's deprecation model.
+Version lifecycle fields are grouped under an OPTIONAL nested `lifecycle` object, mirroring the
+component schema's `lifecycle` pattern (see [Component format](component-format.md)). This
+implements the token lifecycle model described in
+[#623](https://github.com/adobe/spectrum-design-data/discussions/623) and the evolution policy in
+[Evolution](evolution.md). Inspired by Swift's `@available` attribute, Kotlin's `@Deprecated`, and
+OpenAPI 3.3's deprecation model.
 
-| Field                | Type                                    | Description                                                                                                                    |
-| -------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `uuid`               | string (UUID)                           | Stable unique id for rename tracking and diffs.                                                                                |
-| `introduced`         | string (version)                        | Spec version when the token was first added (e.g. `"1.0.0"`).                                                                  |
-| `deprecated`         | string (version)                        | Spec version when the token was deprecated (e.g. `"3.2.0"`). Truthy = deprecated.                                              |
-| `deprecated_comment` | string                                  | Human-readable deprecation explanation and migration guidance.                                                                 |
-| `replaced_by`        | string (UUID) or array of string (UUID) | UUID(s) of the replacement token(s). Single string for 1:1 replacement; array for one-to-many splits.                          |
-| `plannedRemoval`     | string (version)                        | Spec version when the token will be removed. If omitted, defaults to the next major version after `deprecated`.                |
-| `private`            | boolean                                 | Not part of public API surface.                                                                                                |
-| `rationale`          | string                                  | Why this token has its current value. Intended for product-layer authoring context; see [Product context](product-context.md). |
+| Field                         | Type                                    | Description                                                                                                                    |
+| ----------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `uuid`                        | string (UUID)                           | Stable unique id for rename tracking and diffs.                                                                                |
+| `lifecycle.introduced`        | string (version)                        | Spec version when the token was first added (e.g. `"1.0.0"`).                                                                  |
+| `lifecycle.deprecatedIn`      | string (version)                        | Spec version when the token was deprecated (e.g. `"3.2.0"`). Truthy = deprecated.                                              |
+| `lifecycle.deprecatedComment` | string                                  | Human-readable deprecation explanation and migration guidance.                                                                 |
+| `lifecycle.replacedBy`        | string (UUID) or array of string (UUID) | UUID(s) of the replacement token(s). Single string for 1:1 replacement; array for one-to-many splits.                          |
+| `lifecycle.plannedRemoval`    | string (version)                        | Spec version when the token will be removed. If omitted, defaults to the next major version after `deprecatedIn`.              |
+| `private`                     | boolean                                 | Not part of public API surface.                                                                                                |
+| `rationale`                   | string                                  | Why this token has its current value. Intended for product-layer authoring context; see [Product context](product-context.md). |
+
+`private` and `rationale` stay flat (not version-lifecycle concepts).
 
 #### Lifecycle example
 
@@ -154,38 +161,43 @@ The following OPTIONAL fields implement the token lifecycle model described in [
   "name": { "component": "button", "object": "background", "property": "color", "variant": "primary" },
   "value": "#0265dc",
   "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-  "introduced": "1.0.0",
-  "deprecated": "3.2.0",
-  "deprecated_comment": "Use action-background-default instead.",
-  "replaced_by": "bbbbbbbb-0002-4000-8000-000000000001",
-  "plannedRemoval": "4.0.0"
+  "lifecycle": {
+    "introduced": "1.0.0",
+    "deprecatedIn": "3.2.0",
+    "deprecatedComment": "Use action-background-default instead.",
+    "replacedBy": "bbbbbbbb-0002-4000-8000-000000000001",
+    "plannedRemoval": "4.0.0"
+  }
 }
 ```
 
 #### Normative rules
 
-**NORMATIVE:** If `deprecated` is present, `deprecated_comment` **SHOULD** be present.
+**NORMATIVE:** If `lifecycle.deprecatedIn` is present, `lifecycle.deprecatedComment` **SHOULD** be present.
 
-**NORMATIVE:** If `replaced_by` is an array, `deprecated_comment` is **REQUIRED** — the comment **MUST** explain which replacement applies in which context.
+**NORMATIVE:** If `lifecycle.replacedBy` is an array, `lifecycle.deprecatedComment` is **REQUIRED** — the comment **MUST** explain which replacement applies in which context.
 
-**NORMATIVE:** If `replaced_by` is present, `deprecated` **MUST** be present.
+**NORMATIVE:** If `lifecycle.replacedBy` is present, `lifecycle.deprecatedIn` **MUST** be present.
 
-**NORMATIVE:** If `plannedRemoval` is present, `deprecated` **MUST** be present, and the `plannedRemoval` version **MUST NOT** precede the `deprecated` version.
+**NORMATIVE:** If `lifecycle.plannedRemoval` is present, `lifecycle.deprecatedIn` **MUST** be present, and the `plannedRemoval` version **MUST NOT** precede the `deprecatedIn` version.
 
-**NORMATIVE:** Each UUID in `replaced_by` **MUST** resolve to an existing token in the dataset (see rule `SPEC-010`).
+**NORMATIVE:** Each UUID in `lifecycle.replacedBy` **MUST** resolve to an existing token in the dataset (see rule `SPEC-010`).
 
 #### Legacy format mapping
 
 When generating legacy-format output from cascade tokens:
 
-* `deprecated: "3.2.0"` maps to `deprecated: true`
-* `replaced_by: "<uuid>"` maps to `renamed: "<target-token-name>"` (resolved via UUID lookup)
-* `introduced` and `plannedRemoval` have no legacy equivalent and are not emitted
+* `lifecycle.deprecatedIn: "3.2.0"` (or any truthy value) maps to flat `deprecated: true`
+* `lifecycle.deprecatedComment` maps to flat `deprecated_comment` (copied verbatim)
+* `lifecycle.replacedBy: "<uuid>"` maps to flat `renamed: "<target-token-name>"` (resolved via UUID lookup)
+* `lifecycle.plannedRemoval` and `lifecycle.introduced` have no legacy equivalent and are not emitted
+* The `lifecycle` wrapper itself is never emitted — legacy format has no nested wrapper
 
 When migrating legacy-format tokens to cascade:
 
-* `deprecated: true` maps to `deprecated: "unknown"` (authors should backfill the actual version)
-* `renamed: "<name>"` maps to `replaced_by: "<uuid>"` (resolved via name lookup across all files in the migrated input set). If the rename target is not found in the scanned corpus, the field is dropped — `replaced_by` must be set manually in that case
+* `deprecated: true` maps to `lifecycle.deprecatedIn: "unknown"` (authors should backfill the actual version)
+* `deprecated_comment` maps to `lifecycle.deprecatedComment` (copied verbatim)
+* `renamed: "<name>"` maps to `lifecycle.replacedBy: "<uuid>"` (resolved via name lookup across all files in the migrated input set). If the rename target is not found in the scanned corpus, the field is dropped — `lifecycle.replacedBy` must be set manually in that case
 
 ### `specVersion`
 

--- a/packages/design-data/scripts/backfill-deprecated-versions.js
+++ b/packages/design-data/scripts/backfill-deprecated-versions.js
@@ -1,0 +1,311 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Backfills `deprecated: "unknown"` placeholders (left over from the legacy->cascade
+ * migration, see design-data-spec/spec/token-format.md's migration note) with the
+ * real `@adobe/spectrum-tokens` release version each token was deprecated in.
+ *
+ * Recovery has two sources, tried in order per token:
+ *   1. `packages/tokens/CHANGELOG.md` "Newly Deprecated (N)" release-note blocks,
+ *      matched by the token's legacy name.
+ *   2. Git archaeology: the commit that first set `deprecated: true` on the token
+ *      in `packages/tokens/src/*.json`, resolved to the earliest containing
+ *      `@adobe/spectrum-tokens@X.Y.Z` tag.
+ *
+ * A cascade token's legacy name is recovered by matching its `uuid` (or, for
+ * per-mode set tokens, `set_uuid`) against every `uuid` found anywhere inside each
+ * legacy token object (legacy set tokens nest a `uuid` per mode under `sets.*`).
+ *
+ * Tokens that resolve via neither source are left as `"unknown"` and reported
+ * rather than guessed at.
+ *
+ * Writes are surgical (line-level text substitution of the exact
+ * `"deprecated": "unknown"` line for a given uuid), not a full JSON re-serialize —
+ * `JSON.stringify` does not round-trip these files byte-for-byte (e.g. it expands
+ * single-line arrays), which would otherwise produce a repo-wide formatting diff.
+ *
+ * Usage: node packages/design-data/scripts/backfill-deprecated-versions.js [--dry-run]
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..", "..");
+const cascadeTokensDir = join(repoRoot, "packages", "design-data", "tokens");
+const legacyTokensDir = join(repoRoot, "packages", "tokens", "src");
+const changelogPath = join(repoRoot, "packages", "tokens", "CHANGELOG.md");
+
+const dryRun = process.argv.includes("--dry-run");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+/** Map every `uuid` found anywhere inside a legacy token object to its top-level name. */
+function buildLegacyUuidToNameMap() {
+  const map = new Map();
+  for (const file of readdirSync(legacyTokensDir).filter((f) =>
+    f.endsWith(".json"),
+  )) {
+    const data = readJson(join(legacyTokensDir, file));
+    for (const [name, token] of Object.entries(data)) {
+      const stack = [token];
+      while (stack.length) {
+        const cur = stack.pop();
+        if (cur && typeof cur === "object") {
+          if (typeof cur.uuid === "string") {
+            if (!map.has(cur.uuid)) map.set(cur.uuid, []);
+            map.get(cur.uuid).push(name);
+          }
+          for (const v of Object.values(cur)) {
+            if (v && typeof v === "object") stack.push(v);
+          }
+        }
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * Parse `Newly Deprecated (N)` / `Newly "Un-deprecated" (N)` blocks from the legacy
+ * CHANGELOG, walked newest-to-oldest (the file's natural order), keeping only the
+ * first (i.e. most recent) event per legacy token name.
+ */
+function buildChangelogEventsByName() {
+  const lines = readFileSync(changelogPath, "utf8").split("\n");
+  const events = new Map();
+  let currentVersion = null;
+  let block = null; // "deprecated" | "undeprecated" | null
+  for (const line of lines) {
+    const versionMatch = line.match(/^## (\d+\.\d+\.\d+(?:-[\w.]+)?)/);
+    if (versionMatch) {
+      currentVersion = versionMatch[1];
+      block = null;
+      continue;
+    }
+    if (/Newly Deprecated \(\d+\)/.test(line)) {
+      block = "deprecated";
+      continue;
+    }
+    if (/Newly .Un-deprecated. \(\d+\)/.test(line)) {
+      block = "undeprecated";
+      continue;
+    }
+    if (/<\/details>/.test(line)) {
+      block = null;
+      continue;
+    }
+    const tokenMatch = line.match(/^\s*-\s*`([^`]+)`\s*$/);
+    if (tokenMatch && currentVersion && block && !events.has(tokenMatch[1])) {
+      events.set(tokenMatch[1], { version: currentVersion, action: block });
+    }
+  }
+  return events;
+}
+
+/**
+ * Find the commit that first set `deprecated: true` on `legacyName` inside `file`,
+ * then resolve it to the earliest `@adobe/spectrum-tokens@X.Y.Z` tag whose commit
+ * timestamp is >= that commit's timestamp. Returns null if no transition is found.
+ */
+function resolveViaGitForensics(legacyName, file, sortedTags) {
+  const relPath = `packages/tokens/src/${file}`;
+  let commits;
+  try {
+    commits = execFileSync(
+      "git",
+      ["log", "--format=%H", "--diff-filter=M", "--", relPath],
+      { cwd: repoRoot, encoding: "utf8" },
+    )
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+
+  const isDeprecated = (commit) => {
+    let content;
+    try {
+      content = execFileSync("git", ["show", `${commit}:${relPath}`], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      return null; // token/file didn't exist at this commit (e.g. pre-rename)
+    }
+    try {
+      const token = JSON.parse(content)[legacyName];
+      return token ? Boolean(token.deprecated) : false;
+    } catch {
+      return null;
+    }
+  };
+
+  for (let i = commits.length - 1; i >= 0; i--) {
+    const commit = commits[i];
+    const older = commits[i + 1];
+    if (isDeprecated(commit) && !(older && isDeprecated(older))) {
+      const ts = parseInt(
+        execFileSync("git", ["log", "-1", "--format=%ct", commit], {
+          cwd: repoRoot,
+          encoding: "utf8",
+        }).trim(),
+        10,
+      );
+      const tag = sortedTags.find((t) => t.ts >= ts);
+      return tag ? tag.version : null;
+    }
+  }
+  return null;
+}
+
+function buildSortedSpectrumTokensTags() {
+  const tagNames = execFileSync(
+    "git",
+    ["tag", "-l", "@adobe/spectrum-tokens@*"],
+    { cwd: repoRoot, encoding: "utf8" },
+  )
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  return tagNames
+    .map((tag) => ({
+      version: tag.split("@").pop(),
+      ts: parseInt(
+        execFileSync("git", ["log", "-1", "--format=%ct", tag], {
+          cwd: repoRoot,
+          encoding: "utf8",
+        }).trim(),
+        10,
+      ),
+    }))
+    .sort((a, b) => a.ts - b.ts);
+}
+
+/** Build a map of legacy name -> file, for locating a token's source file. */
+function buildLegacyNameToFileMap() {
+  const map = new Map();
+  for (const file of readdirSync(legacyTokensDir).filter((f) =>
+    f.endsWith(".json"),
+  )) {
+    const data = readJson(join(legacyTokensDir, file));
+    for (const name of Object.keys(data)) map.set(name, file);
+  }
+  return map;
+}
+
+/** Surgically replace the `"deprecated": "unknown"` line belonging to `uuid` in-place. */
+function applySurgicalReplacement(filePath, uuid, version) {
+  const text = readFileSync(filePath, "utf8");
+  const lines = text.split("\n");
+  const uuidLineIdx = lines.findIndex((l) => l.includes(`"uuid": "${uuid}"`));
+  if (uuidLineIdx === -1) return false;
+  for (
+    let i = uuidLineIdx + 1;
+    i < Math.min(uuidLineIdx + 10, lines.length);
+    i++
+  ) {
+    if (/"uuid":/.test(lines[i])) break; // reached the next token object
+    if (/"deprecated":\s*"unknown"/.test(lines[i])) {
+      lines[i] = lines[i].replace(/"unknown"/, `"${version}"`);
+      writeFileSync(filePath, lines.join("\n"));
+      return true;
+    }
+  }
+  return false;
+}
+
+function main() {
+  const legacyUuidToName = buildLegacyUuidToNameMap();
+  const legacyNameToFile = buildLegacyNameToFileMap();
+  const changelogEvents = buildChangelogEventsByName();
+  let sortedTags = null; // built lazily — expensive, only needed on changelog misses
+
+  const cascadeFiles = readdirSync(cascadeTokensDir).filter((f) =>
+    f.endsWith(".tokens.json"),
+  );
+
+  const report = { changelog: 0, gitForensic: 0, unresolved: [] };
+
+  for (const file of cascadeFiles) {
+    const filePath = join(cascadeTokensDir, file);
+    const tokens = readJson(filePath);
+    for (const token of tokens) {
+      if (token.deprecated !== "unknown") continue;
+
+      const names =
+        legacyUuidToName.get(token.uuid) ??
+        (token.set_uuid ? legacyUuidToName.get(token.set_uuid) : undefined) ??
+        [];
+
+      let version = null;
+      let source = null;
+      for (const name of names) {
+        const event = changelogEvents.get(name);
+        if (event && event.action !== "undeprecated") {
+          version = event.version;
+          source = "changelog";
+          break;
+        }
+      }
+
+      if (!version) {
+        sortedTags ??= buildSortedSpectrumTokensTags();
+        for (const name of names) {
+          const legacyFile = legacyNameToFile.get(name);
+          if (!legacyFile) continue;
+          const resolved = resolveViaGitForensics(name, legacyFile, sortedTags);
+          if (resolved) {
+            version = resolved;
+            source = "git-forensic";
+            break;
+          }
+        }
+      }
+
+      if (!version) {
+        report.unresolved.push({ file, uuid: token.uuid, names });
+        continue;
+      }
+
+      report[source === "changelog" ? "changelog" : "gitForensic"]++;
+      if (!dryRun) {
+        const applied = applySurgicalReplacement(filePath, token.uuid, version);
+        if (!applied) {
+          report.unresolved.push({
+            file,
+            uuid: token.uuid,
+            names,
+            note: "resolved a version but surgical replacement failed",
+          });
+        }
+      }
+    }
+  }
+
+  console.log(`Resolved via CHANGELOG:   ${report.changelog}`);
+  console.log(`Resolved via git history: ${report.gitForensic}`);
+  console.log(`Unresolved:               ${report.unresolved.length}`);
+  if (report.unresolved.length > 0) {
+    console.log(JSON.stringify(report.unresolved, null, 2));
+  }
+  if (dryRun) console.log("\n(dry run — no files written)");
+}
+
+main();

--- a/packages/design-data/scripts/migrate-lifecycle-nesting.js
+++ b/packages/design-data/scripts/migrate-lifecycle-nesting.js
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * One-time migration: nests flat token lifecycle fields (`deprecated`,
+ * `deprecated_comment`, `replaced_by`, `plannedRemoval`, `introduced`) into a single
+ * `lifecycle` object, renaming `deprecated` -> `deprecatedIn` and the snake_case
+ * fields to camelCase, so the token schema matches the component schema's existing
+ * nested `lifecycle` pattern. See design-data-spec/spec/token-format.md.
+ *
+ * Also renames the existing nested `lifecycle.deprecated` -> `lifecycle.deprecatedIn`
+ * on components (root, anatomy[], states[], options.*.values[]) for the same reason —
+ * a no-op today (no component currently has this field set) but kept for correctness
+ * as the schema changed.
+ *
+ * Each token's `lifecycle` object is inserted at the position of the first flat
+ * lifecycle field it replaces, preserving surrounding key order so the diff stays
+ * minimal. Run `prettier --write` on the touched files afterward — this repo's
+ * default prettier config reproduces the on-disk token format byte-for-byte, so the
+ * resulting diff shows only the intended lifecycle changes.
+ *
+ * Usage: node packages/design-data/scripts/migrate-lifecycle-nesting.js [--dry-run]
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..", "..");
+const tokensDir = join(repoRoot, "packages", "design-data", "tokens");
+const componentsDir = join(repoRoot, "packages", "design-data", "components");
+
+const dryRun = process.argv.includes("--dry-run");
+
+// Token flat field -> lifecycle key, in the canonical order the nested object
+// should be written in.
+const TOKEN_LIFECYCLE_FIELD_MAP = [
+  ["introduced", "introduced"],
+  ["deprecated", "deprecatedIn"],
+  ["deprecated_comment", "deprecatedComment"],
+  ["replaced_by", "replacedBy"],
+  ["plannedRemoval", "plannedRemoval"],
+];
+const TOKEN_LIFECYCLE_FLAT_KEYS = new Set(
+  TOKEN_LIFECYCLE_FIELD_MAP.map(([flat]) => flat),
+);
+
+/**
+ * Rebuild a token object with its flat lifecycle fields nested under `lifecycle`,
+ * inserted at the position of the first such field, preserving all other key order.
+ * Returns the original object unchanged (same reference) if it has none of the
+ * flat lifecycle fields.
+ */
+function nestTokenLifecycle(token) {
+  const keys = Object.keys(token);
+  if (!keys.some((k) => TOKEN_LIFECYCLE_FLAT_KEYS.has(k))) return token;
+
+  const lifecycle = {};
+  for (const [flat, nested] of TOKEN_LIFECYCLE_FIELD_MAP) {
+    if (Object.hasOwn(token, flat)) lifecycle[nested] = token[flat];
+  }
+
+  const rebuilt = {};
+  let inserted = false;
+  for (const key of keys) {
+    if (TOKEN_LIFECYCLE_FLAT_KEYS.has(key)) {
+      if (!inserted) {
+        rebuilt.lifecycle = lifecycle;
+        inserted = true;
+      }
+      continue;
+    }
+    rebuilt[key] = token[key];
+  }
+  return rebuilt;
+}
+
+/**
+ * Rename `lifecycle.deprecated` -> `lifecycle.deprecatedIn` in place, if present.
+ * Returns whether a rename occurred, so callers can avoid rewriting (and thereby
+ * reformatting) files with no actual change.
+ */
+function renameNestedDeprecated(obj) {
+  if (
+    obj &&
+    typeof obj === "object" &&
+    obj.lifecycle &&
+    typeof obj.lifecycle === "object" &&
+    Object.hasOwn(obj.lifecycle, "deprecated")
+  ) {
+    const { deprecated, ...rest } = obj.lifecycle;
+    obj.lifecycle = { deprecatedIn: deprecated, ...rest };
+    return true;
+  }
+  return false;
+}
+
+/** Returns whether any nested `lifecycle.deprecated` was renamed. */
+function migrateComponent(component) {
+  let changed = renameNestedDeprecated(component);
+  for (const part of component.anatomy ?? []) {
+    changed = renameNestedDeprecated(part) || changed;
+  }
+  for (const state of component.states ?? []) {
+    changed = renameNestedDeprecated(state) || changed;
+  }
+  for (const option of Object.values(component.options ?? {})) {
+    for (const value of option.values ?? []) {
+      changed = renameNestedDeprecated(value) || changed;
+    }
+  }
+  return changed;
+}
+
+function main() {
+  let tokensChanged = 0;
+  let filesChanged = [];
+
+  for (const file of readdirSync(tokensDir).filter((f) =>
+    f.endsWith(".tokens.json"),
+  )) {
+    const filePath = join(tokensDir, file);
+    const tokens = JSON.parse(readFileSync(filePath, "utf8"));
+    let changedInFile = 0;
+    const migrated = tokens.map((token) => {
+      const result = nestTokenLifecycle(token);
+      if (result !== token) changedInFile++;
+      return result;
+    });
+    if (changedInFile > 0) {
+      tokensChanged += changedInFile;
+      filesChanged.push(filePath);
+      if (!dryRun) {
+        writeFileSync(filePath, JSON.stringify(migrated, null, 2) + "\n");
+      }
+    }
+  }
+
+  let componentsChanged = 0;
+  for (const file of readdirSync(componentsDir).filter((f) =>
+    f.endsWith(".json"),
+  )) {
+    const filePath = join(componentsDir, file);
+    const component = JSON.parse(readFileSync(filePath, "utf8"));
+    if (migrateComponent(component)) {
+      componentsChanged++;
+      filesChanged.push(filePath);
+      if (!dryRun) {
+        writeFileSync(filePath, JSON.stringify(component, null, 2) + "\n");
+      }
+    }
+  }
+
+  console.log(`Tokens migrated:      ${tokensChanged}`);
+  console.log(`Components migrated:  ${componentsChanged}`);
+  console.log(`Files touched:        ${filesChanged.length}`);
+  if (dryRun) {
+    console.log("\n(dry run — no files written)");
+  } else if (filesChanged.length > 0) {
+    console.log(
+      "\nRun `npx prettier --write <files>` on the touched files to normalize formatting.",
+    );
+  }
+}
+
+main();

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1438,13 +1438,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5c0f0543-7e9b-43d6-9fea-c771b9b524c6",
     "uuid": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with drop-shadow-color-100",
-    "replaced_by": [
-      "5c0f0543-7e9b-43d6-9fea-c771b9b524c6",
-      "8d7e0eb7-c3c7-485e-896c-d5d5107e3b8f",
-      "4110e60c-efd6-421d-9c5c-0356cfff8697"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.29",
+      "deprecatedComment": "Replaced with drop-shadow-color-100",
+      "replacedBy": [
+        "5c0f0543-7e9b-43d6-9fea-c771b9b524c6",
+        "8d7e0eb7-c3c7-485e-896c-d5d5107e3b8f",
+        "4110e60c-efd6-421d-9c5c-0356cfff8697"
+      ]
+    }
   },
   {
     "name": {

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -218,9 +218,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
     "uuid": "97dfaf7f-ac2d-4517-84cc-6f692f712fc5",
-    "deprecated": "unknown",
-    "deprecated_comment": "Express does not need a separate design for Color loupe and Color handle components",
-    "replaced_by": "be45ace6-9227-41d1-80be-0c58c3f8b3cb"
+    "lifecycle": {
+      "deprecatedIn": "12.6.0",
+      "deprecatedComment": "Express does not need a separate design for Color loupe and Color handle components",
+      "replacedBy": "be45ace6-9227-41d1-80be-0c58c3f8b3cb"
+    }
   },
   {
     "name": {
@@ -280,7 +282,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f3487a86-3aea-4527-8b5c-287c0bddad6c",
     "uuid": "86caa027-9e9e-4a5f-aa38-058f0a96bc9d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -292,9 +296,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e475981f-97af-479c-859b-7619dd87c448",
     "uuid": "918b8089-d89f-45d2-8c9c-f3f13f81b0b9",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use `drop-shadow-elevated-color` instead",
-    "replaced_by": "e475981f-97af-479c-859b-7619dd87c448"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.29",
+      "deprecatedComment": "Use `drop-shadow-elevated-color` instead",
+      "replacedBy": "e475981f-97af-479c-859b-7619dd87c448"
+    }
   },
   {
     "name": {
@@ -306,7 +312,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "45f313a5-1749-4b95-b5e3-20944adbea84",
     "uuid": "c9af5d60-11b1-4fc3-972e-6a607120657b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -429,9 +437,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0",
     "uuid": "f843b1b7-4b2f-496e-a679-b0372e49d575",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use `floating-action-button-drop-shadow-color` instead",
-    "replaced_by": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0"
+    "lifecycle": {
+      "deprecatedIn": "12.9.0",
+      "deprecatedComment": "Use `floating-action-button-drop-shadow-color` instead",
+      "replacedBy": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0"
+    }
   },
   {
     "name": {

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -1298,7 +1298,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
     "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -11,9 +11,11 @@
     "uuid": "7a576841-a2a5-4443-9d31-03a12c7a2efd",
     "set_uuid": "92fef7e7-45bc-4dcd-91c2-c42e696263a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -27,9 +29,11 @@
     "uuid": "70e6d9e7-2a8e-4f0d-96d6-aac7cde829bd",
     "set_uuid": "92fef7e7-45bc-4dcd-91c2-c42e696263a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -43,9 +47,11 @@
     "uuid": "40f76138-1a69-45ed-8df5-db8bc9792383",
     "set_uuid": "21208d7c-2fd2-48d2-afd6-0b50e9f5ea38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -59,9 +65,11 @@
     "uuid": "b4f92e98-694f-46cc-91be-8e0e2d5a17a4",
     "set_uuid": "21208d7c-2fd2-48d2-afd6-0b50e9f5ea38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -75,9 +83,11 @@
     "uuid": "c73f4637-7a33-4598-9498-8eb4a9e9e863",
     "set_uuid": "4e3a7c0a-d52a-43a8-b05f-6c98b7bb4859",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -91,9 +101,11 @@
     "uuid": "97b9278a-11d0-4470-99c3-e2d47ca5a714",
     "set_uuid": "4e3a7c0a-d52a-43a8-b05f-6c98b7bb4859",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -107,9 +119,11 @@
     "uuid": "524cb169-a9c1-4d3c-864e-dba03df6eac9",
     "set_uuid": "c9702adb-1f13-477c-b13c-79c4d8709856",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -123,9 +137,11 @@
     "uuid": "af95123b-2ab5-49bb-a070-1ca48b498f58",
     "set_uuid": "c9702adb-1f13-477c-b13c-79c4d8709856",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -141,9 +157,11 @@
     "uuid": "47f2bc45-5fa5-439a-a705-ef965c6ea010",
     "set_uuid": "3f045028-2598-426a-91bd-443549a4c5f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -159,9 +177,11 @@
     "uuid": "5ce86cfe-434b-42ab-b334-c574bae01e6f",
     "set_uuid": "3f045028-2598-426a-91bd-443549a4c5f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -177,9 +197,11 @@
     "uuid": "7ec7fa3a-5ab0-41e8-816a-bdd63b7d9d82",
     "set_uuid": "036e6eac-cf81-4563-b4ea-f9610de674a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -195,9 +217,11 @@
     "uuid": "7db5a087-c361-4080-be50-8e4864436108",
     "set_uuid": "036e6eac-cf81-4563-b4ea-f9610de674a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -213,9 +237,11 @@
     "uuid": "c0f14d75-a7a7-4325-b891-76d055e6371f",
     "set_uuid": "071af591-5387-4a04-b00a-3451bb1f102d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -231,9 +257,11 @@
     "uuid": "abbcad5f-be29-4ca4-b48f-6b0eab7f9942",
     "set_uuid": "071af591-5387-4a04-b00a-3451bb1f102d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -244,7 +272,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3f045028-2598-426a-91bd-443549a4c5f1",
     "uuid": "8c199212-a745-414c-8f6b-22d2445ade3c",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -255,7 +285,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "036e6eac-cf81-4563-b4ea-f9610de674a8",
     "uuid": "f484838e-1f0c-4125-9298-beb4ddc0fd53",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -266,7 +298,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "071af591-5387-4a04-b00a-3451bb1f102d",
     "uuid": "2d6fa243-5f7e-41a8-840b-27a6432f54bc",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -277,7 +311,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "13a9d984-2e46-4319-a466-d59fce44fef3",
     "uuid": "d64620dc-dd4a-447a-8491-d9e144ec8828",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -293,9 +329,11 @@
     "uuid": "ee8445cc-82a2-489f-9ff9-ec5d38a8dfd5",
     "set_uuid": "13a9d984-2e46-4319-a466-d59fce44fef3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -311,9 +349,11 @@
     "uuid": "b69abbba-a98c-40f2-8a9a-972710b73149",
     "set_uuid": "13a9d984-2e46-4319-a466-d59fce44fef3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -327,9 +367,11 @@
     "uuid": "3ca8a65d-5561-4d8e-a4f2-0b653b42991b",
     "set_uuid": "9f4b3199-56cf-4d3f-9185-969001da490c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
-    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+      "replacedBy": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    }
   },
   {
     "name": {
@@ -343,9 +385,11 @@
     "uuid": "ba11dc6e-fbd8-46bc-94fd-b4d02f654d2d",
     "set_uuid": "9f4b3199-56cf-4d3f-9185-969001da490c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
-    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+      "replacedBy": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    }
   },
   {
     "name": {
@@ -359,9 +403,11 @@
     "uuid": "96acbf76-082b-487c-8c47-f0fa173f54d2",
     "set_uuid": "1fc7990f-7ae1-4047-9d0d-e4170d41c631",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -375,9 +421,11 @@
     "uuid": "2a6fa386-4eba-44d5-b129-c832264fafd9",
     "set_uuid": "1fc7990f-7ae1-4047-9d0d-e4170d41c631",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -391,9 +439,11 @@
     "uuid": "8a3eadad-8b88-4885-b4ca-07360b45d3ba",
     "set_uuid": "6092119d-924e-4774-a79c-21886bce0b78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -407,9 +457,11 @@
     "uuid": "05d8a39d-a0d5-496c-810a-f1244c31b169",
     "set_uuid": "6092119d-924e-4774-a79c-21886bce0b78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -423,9 +475,11 @@
     "uuid": "bdc61836-fdcf-4ca0-a277-dd9cb314563a",
     "set_uuid": "ab6d93cd-177d-47b0-b521-f8e3e831b7b5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -439,9 +493,11 @@
     "uuid": "56a65744-b195-4faf-ab5c-69a8424593f9",
     "set_uuid": "ab6d93cd-177d-47b0-b521-f8e3e831b7b5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -456,9 +512,11 @@
     "uuid": "87008eae-491c-4f7d-a13b-83eae517c92f",
     "set_uuid": "85bd22b3-6be9-4b69-953a-7717b501ea0b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -473,9 +531,11 @@
     "uuid": "48383ab9-1e66-47f9-988b-6f59b7349241",
     "set_uuid": "85bd22b3-6be9-4b69-953a-7717b501ea0b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -491,9 +551,11 @@
     "uuid": "c26ba15a-cb44-44b2-8423-baf52b1b42db",
     "set_uuid": "ed09b2f0-da52-4317-8be2-89ce2508650e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -509,9 +571,11 @@
     "uuid": "c9aaff95-a17a-408b-bb55-1c9026314c8b",
     "set_uuid": "ed09b2f0-da52-4317-8be2-89ce2508650e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -527,9 +591,11 @@
     "uuid": "755f796f-bcb6-466c-b4f2-b10b0f819bba",
     "set_uuid": "2ed28849-15b1-4e23-9a81-e5a75be79bc9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead. Major refactor necessary",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead. Major refactor necessary",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -545,9 +611,11 @@
     "uuid": "f4d133f7-d444-4ddc-907f-9d75ff621a03",
     "set_uuid": "2ed28849-15b1-4e23-9a81-e5a75be79bc9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead. Major refactor necessary",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead. Major refactor necessary",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -563,9 +631,11 @@
     "uuid": "66fbf171-ff30-4376-9026-686ae3e2fc70",
     "set_uuid": "67a7388d-91db-4c0d-a32c-0eda0c6705ba",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -581,9 +651,11 @@
     "uuid": "80419f6a-d93a-4cc0-883a-833e4717e28f",
     "set_uuid": "67a7388d-91db-4c0d-a32c-0eda0c6705ba",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -599,9 +671,11 @@
     "uuid": "b7b23a23-abca-4e96-8c6f-d2b5b4c79d99",
     "set_uuid": "5dd933e8-c1db-43d1-b3ac-67f7df4ce6fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -617,9 +691,11 @@
     "uuid": "782d9dfd-413f-4031-8431-be9b638c69b6",
     "set_uuid": "5dd933e8-c1db-43d1-b3ac-67f7df4ce6fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -634,8 +710,10 @@
     "uuid": "709082c2-71b9-423a-9c93-3b53a9e18da3",
     "set_uuid": "3e16490f-8fca-4a5a-ad95-fb1882d367d9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -650,8 +728,10 @@
     "uuid": "9c651dee-7d77-414d-930b-7c6b78cfed1b",
     "set_uuid": "3e16490f-8fca-4a5a-ad95-fb1882d367d9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -663,7 +743,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "27b481a4-0ea9-4e1c-a283-4a799d18d642",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -679,9 +761,11 @@
     "uuid": "90fe1ad4-76a8-4b02-a036-af6d4397334e",
     "set_uuid": "13517d70-4770-469b-8574-fab16c6ebfc5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead. These gap vales don't match with what's in the Figma component. Recommending design update anyhow",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead. These gap vales don't match with what's in the Figma component. Recommending design update anyhow",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -697,9 +781,11 @@
     "uuid": "aafcb612-0828-48c7-af1c-39870aafd44a",
     "set_uuid": "13517d70-4770-469b-8574-fab16c6ebfc5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead. These gap vales don't match with what's in the Figma component. Recommending design update anyhow",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead. These gap vales don't match with what's in the Figma component. Recommending design update anyhow",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -715,9 +801,11 @@
     "uuid": "802cef85-0ad5-417b-953f-66a812e6637e",
     "set_uuid": "43049c7d-3f40-41f1-ae4e-d08ab2d6d6ad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Major refactor necessary",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead. Major refactor necessary",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -733,9 +821,11 @@
     "uuid": "fae0b204-0198-465a-aa98-c7b4224e4c48",
     "set_uuid": "43049c7d-3f40-41f1-ae4e-d08ab2d6d6ad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Major refactor necessary",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead. Major refactor necessary",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -751,9 +841,11 @@
     "uuid": "e28ca787-7457-4f40-9188-039347047c83",
     "set_uuid": "63508f68-42cd-46f3-a4f9-88ce0914d2d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead. Major refactor necessary",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead. Major refactor necessary",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -769,9 +861,11 @@
     "uuid": "f62edd6d-b833-4aea-8e03-ddd1dfccc464",
     "set_uuid": "63508f68-42cd-46f3-a4f9-88ce0914d2d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead. Major refactor necessary",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead. Major refactor necessary",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -787,9 +881,11 @@
     "uuid": "e6cb7eb7-afa3-441f-9f22-5ca8eec66749",
     "set_uuid": "8c484a6a-0851-4f12-8a63-afc3a56d9b53",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead. Major refactor necessary",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead. Major refactor necessary",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -805,9 +901,11 @@
     "uuid": "f009b7a8-95ca-4b39-92c3-f7656cf2e429",
     "set_uuid": "8c484a6a-0851-4f12-8a63-afc3a56d9b53",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead. Major refactor necessary",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead. Major refactor necessary",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -820,9 +918,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
     "uuid": "75bc2d16-cf6b-48ef-a2e5-0516835af468",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead. Duplicate token use case. Major refactor necessary",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead. Duplicate token use case. Major refactor necessary",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -835,9 +935,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
     "uuid": "56633713-ae34-4a8a-8cfd-39508e4c4b0a",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead. Duplicate token use case. Major refactor necessary",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead. Duplicate token use case. Major refactor necessary",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -850,9 +952,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
     "uuid": "77894e1e-8b67-468d-a3d0-d9a7c87d1a52",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Duplicate token use case. Major refactor necessary",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead. Duplicate token use case. Major refactor necessary",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -865,9 +969,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
     "uuid": "b594a566-9649-497d-bf8f-289ec3f59689",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Duplicate token use case. Major refactor necessary",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead. Duplicate token use case. Major refactor necessary",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -879,7 +985,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "614e6448-c0a4-4ad1-b125-f362e3001a86",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -891,8 +999,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "a9641e89-2c2e-49c3-9662-f530ad23a688",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -903,9 +1013,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "318c5cda-be1b-416b-b1b7-b962e5f45c0c",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead.",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead.",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -917,8 +1029,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "9a2c9dee-7acf-4083-9c66-685454444f8c",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -956,9 +1070,11 @@
     "uuid": "229fa20e-6d13-40b0-b19f-5cf6386f81ac",
     "set_uuid": "e96c75c2-f69a-49b5-8309-6490c5b0768c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead",
-    "replaced_by": "696ab6c1-0c23-4868-8d6c-039d6d430d29"
+    "lifecycle": {
+      "deprecatedIn": "14.12.0",
+      "deprecatedComment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead",
+      "replacedBy": "696ab6c1-0c23-4868-8d6c-039d6d430d29"
+    }
   },
   {
     "name": {
@@ -972,9 +1088,11 @@
     "uuid": "bef73b91-db4f-4532-9f4d-f5a81ead625d",
     "set_uuid": "e96c75c2-f69a-49b5-8309-6490c5b0768c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead",
-    "replaced_by": "7bcbaaf1-f1d8-4755-acb2-5f6a45c3b9fe"
+    "lifecycle": {
+      "deprecatedIn": "14.12.0",
+      "deprecatedComment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead",
+      "replacedBy": "7bcbaaf1-f1d8-4755-acb2-5f6a45c3b9fe"
+    }
   },
   {
     "name": {
@@ -988,9 +1106,11 @@
     "uuid": "6e08e002-56bf-421e-b9f8-9d37b1e80e6e",
     "set_uuid": "ac9fa12f-4864-47c2-bd03-bc057a9bedfa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1004,9 +1124,11 @@
     "uuid": "5ebd5aab-49b3-49d1-be25-8aff15217eda",
     "set_uuid": "ac9fa12f-4864-47c2-bd03-bc057a9bedfa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1020,9 +1142,11 @@
     "uuid": "a73cc1b0-e31d-4d42-bb89-2e283fe9c59b",
     "set_uuid": "b8bef4c7-090d-409d-91ce-398ebf3db5ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1036,9 +1160,11 @@
     "uuid": "c09ca9bf-1b8b-4ff3-93b7-e9296472dc76",
     "set_uuid": "b8bef4c7-090d-409d-91ce-398ebf3db5ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1049,9 +1175,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
     "uuid": "484c9603-07f1-4ba6-b1bf-7cfaec5d1594",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1065,9 +1193,11 @@
     "uuid": "d6cc404c-af92-43be-88e3-407fdcb6e068",
     "set_uuid": "287c49e1-860a-4fd3-8024-0fecfbbbff26",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1081,9 +1211,11 @@
     "uuid": "cfc8d280-5ea0-47f2-bdcb-ae5e93627498",
     "set_uuid": "287c49e1-860a-4fd3-8024-0fecfbbbff26",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1099,9 +1231,11 @@
     "uuid": "1a8c45b2-caa4-47b9-b72a-782894168342",
     "set_uuid": "346cdddd-d063-42bf-960a-c38e5cdcf862",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -1117,9 +1251,11 @@
     "uuid": "d76aaca3-6e02-4f90-b254-debf8d10fc89",
     "set_uuid": "346cdddd-d063-42bf-960a-c38e5cdcf862",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -1135,9 +1271,11 @@
     "uuid": "b005554a-ac7f-45ff-86a1-d240d1270f40",
     "set_uuid": "dd578daf-93a2-48f0-9df2-e67095cf5d7a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1153,9 +1291,11 @@
     "uuid": "ebc6e896-6964-4337-b146-468e43d31db3",
     "set_uuid": "dd578daf-93a2-48f0-9df2-e67095cf5d7a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1171,9 +1311,11 @@
     "uuid": "728ad09d-0820-4c71-9974-57386f3d62d2",
     "set_uuid": "9a60996d-f55e-47b5-a966-a10e297e4bd7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1189,9 +1331,11 @@
     "uuid": "2d7e81ba-1390-4607-8ee2-5d322d3e0bae",
     "set_uuid": "9a60996d-f55e-47b5-a966-a10e297e4bd7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1202,7 +1346,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "346cdddd-d063-42bf-960a-c38e5cdcf862",
     "uuid": "9289aae4-ddaa-4a43-8f00-973dea8350f2",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -1213,7 +1359,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dd578daf-93a2-48f0-9df2-e67095cf5d7a",
     "uuid": "2021d787-ddaa-470a-a25d-8a57f67b7359",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -1224,7 +1372,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a60996d-f55e-47b5-a966-a10e297e4bd7",
     "uuid": "48db5aeb-6752-4267-89c7-48ed84692ec8",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -1235,7 +1385,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bbaac303-b17e-48d5-8cad-9342c51d5c80",
     "uuid": "4f6e49d2-9ab8-4548-aae4-eed45a4003b9",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.10.0"
+    }
   },
   {
     "name": {
@@ -1251,9 +1403,11 @@
     "uuid": "efd68835-b6de-479c-9c71-bccbe8e20c21",
     "set_uuid": "bbaac303-b17e-48d5-8cad-9342c51d5c80",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1269,9 +1423,11 @@
     "uuid": "0dea279c-62ca-4670-a693-03eaa7ccecb5",
     "set_uuid": "bbaac303-b17e-48d5-8cad-9342c51d5c80",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1285,9 +1441,11 @@
     "uuid": "5d8877e0-076c-4c9f-b2e9-cdde6942ea61",
     "set_uuid": "1804d0c4-e643-4c87-8c36-4868405d08b4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
-    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+      "replacedBy": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    }
   },
   {
     "name": {
@@ -1301,9 +1459,11 @@
     "uuid": "bd300d17-3599-4382-8a7d-1b78700d49e9",
     "set_uuid": "1804d0c4-e643-4c87-8c36-4868405d08b4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
-    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+      "replacedBy": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+    }
   },
   {
     "name": {
@@ -1317,9 +1477,11 @@
     "uuid": "8e042372-2504-46f2-8486-4d6174293ea2",
     "set_uuid": "b7fb12b8-5e6d-4d82-99e7-aa961b86c99b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -1333,9 +1495,11 @@
     "uuid": "e90553f0-d71e-44c2-b70a-89110fab7c6a",
     "set_uuid": "b7fb12b8-5e6d-4d82-99e7-aa961b86c99b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -1349,9 +1513,11 @@
     "uuid": "19c91104-bdf4-4969-8d92-c9cd47d39d13",
     "set_uuid": "93e90ef0-28d7-46c1-8e44-1077e64e8d0c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1365,9 +1531,11 @@
     "uuid": "63602a66-5f96-4e6a-8bf0-2ac03321a577",
     "set_uuid": "93e90ef0-28d7-46c1-8e44-1077e64e8d0c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1381,9 +1549,11 @@
     "uuid": "696ab6c1-0c23-4868-8d6c-039d6d430d29",
     "set_uuid": "264faa19-9174-4d2c-8fb2-16dc0a693abd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1397,9 +1567,11 @@
     "uuid": "7bcbaaf1-f1d8-4755-acb2-5f6a45c3b9fe",
     "set_uuid": "264faa19-9174-4d2c-8fb2-16dc0a693abd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1411,9 +1583,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "3116a00c-0ad3-4ae6-9fbb-f9b5624a2708",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1425,9 +1599,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f9da434a-7742-4d38-ad52-05dec8d09cfa",
     "uuid": "bc54e89f-6740-4004-891e-c515f8f79693",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token group-gap-extra-small instead.",
-    "replaced_by": "c3ada312-da94-4779-bbf0-0fde3beb8121"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token group-gap-extra-small instead.",
+      "replacedBy": "c3ada312-da94-4779-bbf0-0fde3beb8121"
+    }
   },
   {
     "name": {
@@ -1449,9 +1625,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "a9fc8786-060e-4663-9381-211621240b2f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-horizontal-compact instead.",
-    "replaced_by": "7f237198-3842-49bc-aa79-e723fbe6c78e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-horizontal-compact instead.",
+      "replacedBy": "7f237198-3842-49bc-aa79-e723fbe6c78e"
+    }
   },
   {
     "name": {
@@ -1472,9 +1650,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "72e276ce-d6ee-4bcf-9955-91c833b8b2cd",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-gap-horizontal instead.",
-    "replaced_by": "c0571c46-5946-4896-bcbf-270560de5385"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-gap-horizontal instead.",
+      "replacedBy": "c0571c46-5946-4896-bcbf-270560de5385"
+    }
   },
   {
     "name": {
@@ -1495,9 +1675,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "cfa41a43-8fb2-4c3b-a2df-f8658c87b31b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1509,9 +1691,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
     "uuid": "73f82d09-7927-461c-b7d7-ab0bc6b3e3f9",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1527,9 +1711,11 @@
     "uuid": "1c72a1bf-cfcc-4553-91c6-d7bbcf02cc5a",
     "set_uuid": "2ab2fb4b-eb8a-4ea7-9fe9-0d60ee52ac73",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-extra-large instead.",
-    "replaced_by": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-extra-large instead.",
+      "replacedBy": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544"
+    }
   },
   {
     "name": {
@@ -1545,9 +1731,11 @@
     "uuid": "b4b4710b-2073-4285-8342-31ae6712671b",
     "set_uuid": "2ab2fb4b-eb8a-4ea7-9fe9-0d60ee52ac73",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-extra-large instead.",
-    "replaced_by": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-extra-large instead.",
+      "replacedBy": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544"
+    }
   },
   {
     "name": {
@@ -1560,9 +1748,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
     "uuid": "b79597cc-5294-4555-ab78-f4200e480ac3",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-extra-small instead.",
-    "replaced_by": "b4d6b11b-240b-4daf-8c24-3661888730d1"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-extra-small instead.",
+      "replacedBy": "b4d6b11b-240b-4daf-8c24-3661888730d1"
+    }
   },
   {
     "name": {
@@ -1578,9 +1768,11 @@
     "uuid": "dc65074f-a923-4130-84e5-59fa5d5f4121",
     "set_uuid": "1f708860-2cfd-42c2-8ccb-f3bb954566ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-large instead.",
-    "replaced_by": "31fe1f21-a95a-4354-b6d1-e40dc66990fb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-large instead.",
+      "replacedBy": "31fe1f21-a95a-4354-b6d1-e40dc66990fb"
+    }
   },
   {
     "name": {
@@ -1596,9 +1788,11 @@
     "uuid": "86a36757-a2d1-4263-97dc-62cf4543b3f9",
     "set_uuid": "1f708860-2cfd-42c2-8ccb-f3bb954566ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-large instead.",
-    "replaced_by": "31fe1f21-a95a-4354-b6d1-e40dc66990fb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-large instead.",
+      "replacedBy": "31fe1f21-a95a-4354-b6d1-e40dc66990fb"
+    }
   },
   {
     "name": {
@@ -1614,9 +1808,11 @@
     "uuid": "5022d77a-9332-4bb8-bd9f-d353eed2caa3",
     "set_uuid": "0f14030d-1b31-4157-b834-f02df83b7a17",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-medium instead.",
-    "replaced_by": "32bdfee6-cc93-4d53-9d08-2591646d38e9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-medium instead.",
+      "replacedBy": "32bdfee6-cc93-4d53-9d08-2591646d38e9"
+    }
   },
   {
     "name": {
@@ -1632,9 +1828,11 @@
     "uuid": "255a24ab-f70d-4698-8d2e-569c37c6c798",
     "set_uuid": "0f14030d-1b31-4157-b834-f02df83b7a17",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-medium instead.",
-    "replaced_by": "32bdfee6-cc93-4d53-9d08-2591646d38e9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-medium instead.",
+      "replacedBy": "32bdfee6-cc93-4d53-9d08-2591646d38e9"
+    }
   },
   {
     "name": {
@@ -1647,9 +1845,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
     "uuid": "fa106863-0e09-44d4-9465-68cd3254ed2b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-affixed-small instead.",
-    "replaced_by": "7789a1e5-3bc8-494d-91c2-1309b4697da9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-affixed-small instead.",
+      "replacedBy": "7789a1e5-3bc8-494d-91c2-1309b4697da9"
+    }
   },
   {
     "name": {
@@ -1663,7 +1863,9 @@
     "uuid": "e2f088b2-1ec4-4fc4-aacd-3ded4f0a239e",
     "set_uuid": "8fd1aabf-b5e5-4f60-bed2-43c3bec97f7e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1677,7 +1879,9 @@
     "uuid": "4141f697-72cf-4948-acc7-7aa96035fbe8",
     "set_uuid": "8fd1aabf-b5e5-4f60-bed2-43c3bec97f7e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1691,7 +1895,9 @@
     "uuid": "6bc4db4c-ab1a-4c68-bc37-2053b289d982",
     "set_uuid": "ca31ed73-c382-48a5-a6ae-45cb7648ec2e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1705,7 +1911,9 @@
     "uuid": "708bfa69-42fb-41cf-b734-ef3736cafc02",
     "set_uuid": "ca31ed73-c382-48a5-a6ae-45cb7648ec2e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1719,7 +1927,9 @@
     "uuid": "6f6b3134-6fcc-457d-ae87-43814ccada0f",
     "set_uuid": "7153703c-7f93-437d-a3fd-19d3712cd008",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1733,7 +1943,9 @@
     "uuid": "6ac66626-4a7b-4880-ba39-6756b30e0872",
     "set_uuid": "7153703c-7f93-437d-a3fd-19d3712cd008",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1747,7 +1959,9 @@
     "uuid": "d754631a-979d-4dec-b42c-f539421d1c86",
     "set_uuid": "ebe32780-2683-4112-a31d-a96c83c84d1e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1761,7 +1975,9 @@
     "uuid": "d74d9dc5-9c20-4c87-bacc-d8898c805aa0",
     "set_uuid": "ebe32780-2683-4112-a31d-a96c83c84d1e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1775,7 +1991,9 @@
     "uuid": "1456b16e-09bc-4b63-b3c7-4ecf9a0c3754",
     "set_uuid": "19aeee29-ee00-483f-9caa-544149aaabae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1789,7 +2007,9 @@
     "uuid": "cfa5af27-add5-475d-90e4-2bd4fc14fcf1",
     "set_uuid": "19aeee29-ee00-483f-9caa-544149aaabae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -1804,9 +2024,11 @@
     "uuid": "e19fdd96-44a4-407b-b2b1-01001684fc84",
     "set_uuid": "848a9c0d-eba9-4258-83fd-80e114fac05a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1821,9 +2043,11 @@
     "uuid": "5f2b2bc1-ebb0-46dd-a563-58df6307996d",
     "set_uuid": "848a9c0d-eba9-4258-83fd-80e114fac05a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1858,12 +2082,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e19fdd96-44a4-407b-b2b1-01001684fc84",
     "uuid": "e2bd6435-6fbd-4030-9ff5-b034438b8d8a",
-    "deprecated": "unknown",
-    "deprecated_comment": "Introduced as an error. Use alert-banner-bottom-to-text instead",
-    "replaced_by": [
-      "e19fdd96-44a4-407b-b2b1-01001684fc84",
-      "5f2b2bc1-ebb0-46dd-a563-58df6307996d"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "12.3.0",
+      "deprecatedComment": "Introduced as an error. Use alert-banner-bottom-to-text instead",
+      "replacedBy": [
+        "e19fdd96-44a4-407b-b2b1-01001684fc84",
+        "5f2b2bc1-ebb0-46dd-a563-58df6307996d"
+      ]
+    }
   },
   {
     "name": {
@@ -1874,12 +2100,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1d289972-d5ba-41e8-8935-e8c83afb15cf",
     "uuid": "8fefedaf-6e95-4a14-a8ba-08381f57bfeb",
-    "deprecated": "unknown",
-    "deprecated_comment": "Introduced as an error. Use alert-banner-top-to-text instead",
-    "replaced_by": [
-      "1d289972-d5ba-41e8-8935-e8c83afb15cf",
-      "8db02117-b543-4b3e-b0ff-203e9a821708"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "12.3.0",
+      "deprecatedComment": "Introduced as an error. Use alert-banner-top-to-text instead",
+      "replacedBy": [
+        "1d289972-d5ba-41e8-8935-e8c83afb15cf",
+        "8db02117-b543-4b3e-b0ff-203e9a821708"
+      ]
+    }
   },
   {
     "name": {
@@ -1890,12 +2118,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fbe047c4-0346-4b81-bdf6-6565cede7a28",
     "uuid": "42b40d65-eed4-432e-8ede-74d89905d131",
-    "deprecated": "unknown",
-    "deprecated_comment": "Introduced as an error. Use alert-banner-top-to-workflow-icon instead",
-    "replaced_by": [
-      "fbe047c4-0346-4b81-bdf6-6565cede7a28",
-      "402c755b-322c-4ea0-856c-ca209bdaa8ec"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "12.3.0",
+      "deprecatedComment": "Introduced as an error. Use alert-banner-top-to-workflow-icon instead",
+      "replacedBy": [
+        "fbe047c4-0346-4b81-bdf6-6565cede7a28",
+        "402c755b-322c-4ea0-856c-ca209bdaa8ec"
+      ]
+    }
   },
   {
     "name": {
@@ -1910,9 +2140,11 @@
     "uuid": "fa14092c-ef3f-4b11-8bc8-968d22bed6e0",
     "set_uuid": "cee3c085-e5bb-405e-9065-49e43f9113db",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1927,9 +2159,11 @@
     "uuid": "7939208b-2f8c-4569-b7cb-1c1bcfc8705a",
     "set_uuid": "cee3c085-e5bb-405e-9065-49e43f9113db",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1944,9 +2178,11 @@
     "uuid": "1d289972-d5ba-41e8-8935-e8c83afb15cf",
     "set_uuid": "db0461aa-d466-4a49-8f6d-f3b65659abb5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1961,9 +2197,11 @@
     "uuid": "8db02117-b543-4b3e-b0ff-203e9a821708",
     "set_uuid": "db0461aa-d466-4a49-8f6d-f3b65659abb5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1978,9 +2216,11 @@
     "uuid": "fbe047c4-0346-4b81-bdf6-6565cede7a28",
     "set_uuid": "8ab5ed06-52be-4cbc-8922-35483e361488",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -1995,9 +2235,11 @@
     "uuid": "402c755b-322c-4ea0-856c-ca209bdaa8ec",
     "set_uuid": "8ab5ed06-52be-4cbc-8922-35483e361488",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -2058,12 +2300,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "eda300de-5f0a-42e9-9880-9244a45d4e7d",
     "uuid": "9dc42d1a-b87d-4a5d-a5a3-6afd4d5bd599",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replace with alert-dialog-description-font-size",
-    "replaced_by": [
-      "eda300de-5f0a-42e9-9880-9244a45d4e7d",
-      "e969f730-9eea-4a35-8981-2804d660c23e"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.26",
+      "deprecatedComment": "Replace with alert-dialog-description-font-size",
+      "replacedBy": [
+        "eda300de-5f0a-42e9-9880-9244a45d4e7d",
+        "e969f730-9eea-4a35-8981-2804d660c23e"
+      ]
+    }
   },
   {
     "name": {
@@ -2118,12 +2362,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "749fa425-de12-464d-a1e2-80eb135d3ea6",
     "uuid": "9b7ce1fc-ea8a-4d7b-a926-0accbd6b1197",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replace with alert-dialog-title-font-size",
-    "replaced_by": [
-      "749fa425-de12-464d-a1e2-80eb135d3ea6",
-      "c84328d2-578b-4a36-9065-6c6a9e1d311f"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.26",
+      "deprecatedComment": "Replace with alert-dialog-title-font-size",
+      "replacedBy": [
+        "749fa425-de12-464d-a1e2-80eb135d3ea6",
+        "c84328d2-578b-4a36-9065-6c6a9e1d311f"
+      ]
+    }
   },
   {
     "name": {
@@ -2137,7 +2383,9 @@
     "uuid": "c22e7427-617d-4f99-bee7-e3fffba07fc2",
     "set_uuid": "9aa4e6ea-50ee-4a44-b3a5-cab3f7aed7f2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2151,7 +2399,9 @@
     "uuid": "e9b3eb08-2004-4ad3-bb13-a00a6cb536aa",
     "set_uuid": "9aa4e6ea-50ee-4a44-b3a5-cab3f7aed7f2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2165,7 +2415,9 @@
     "uuid": "645d5384-e3a8-4d97-acf6-7cbce00e6537",
     "set_uuid": "334c967f-5b41-4fd4-bf75-bd9d405de0d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2179,7 +2431,9 @@
     "uuid": "c7df43e2-7354-4f53-b453-dc9bf9060e64",
     "set_uuid": "334c967f-5b41-4fd4-bf75-bd9d405de0d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2193,7 +2447,9 @@
     "uuid": "d0df9084-c6bf-42e5-b830-82906036e397",
     "set_uuid": "c2eb8a49-f7aa-49d9-9216-4b3292a9fda8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2207,7 +2463,9 @@
     "uuid": "f6116604-efbe-4c6f-b047-29247d632174",
     "set_uuid": "c2eb8a49-f7aa-49d9-9216-4b3292a9fda8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2221,7 +2479,9 @@
     "uuid": "4ced8527-31ad-4e48-9491-806ffc57442a",
     "set_uuid": "0c807977-8951-4dce-a580-ed4b11045d86",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2235,7 +2495,9 @@
     "uuid": "35f055a9-8a33-42b2-a316-7e2ef0a4b99d",
     "set_uuid": "0c807977-8951-4dce-a580-ed4b11045d86",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2249,7 +2511,9 @@
     "uuid": "31f09728-964b-4598-99a0-d17bf7256e40",
     "set_uuid": "e8ae5614-5793-46a3-9d5c-bf04b57ef870",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2263,7 +2527,9 @@
     "uuid": "dcf16e1a-49ea-4888-85b7-012462a60f40",
     "set_uuid": "e8ae5614-5793-46a3-9d5c-bf04b57ef870",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2277,7 +2543,9 @@
     "uuid": "5ffece39-b8fc-4a40-a051-0d6c8e253f8f",
     "set_uuid": "54adb815-8e74-498f-a4b9-f647de95d3b5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2291,7 +2559,9 @@
     "uuid": "2f5f49e5-9aba-4ea0-a8d9-0f0e4c086b89",
     "set_uuid": "54adb815-8e74-498f-a4b9-f647de95d3b5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2305,7 +2575,9 @@
     "uuid": "b39b3ce3-6a48-4025-96ef-659b0c9ae9e8",
     "set_uuid": "853a105e-8a45-4588-a173-4a5b8add9730",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2319,7 +2591,9 @@
     "uuid": "6ff35aff-8a9f-466c-bdd3-dda460ccaee5",
     "set_uuid": "853a105e-8a45-4588-a173-4a5b8add9730",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2333,7 +2607,9 @@
     "uuid": "d04b37cc-2c35-49af-9e92-9993264e405a",
     "set_uuid": "597db14a-a852-40ac-b4d3-80528dda07d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2347,7 +2623,9 @@
     "uuid": "f6f11ca3-b78b-4207-868f-f834c19e8d3d",
     "set_uuid": "597db14a-a852-40ac-b4d3-80528dda07d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2361,7 +2639,9 @@
     "uuid": "49892fb4-a9df-4882-a656-7f9ffb9558bc",
     "set_uuid": "692207dd-e636-4511-ba54-c24ddf3e4e46",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2375,7 +2655,9 @@
     "uuid": "3f1b200b-d341-41e4-ae7b-c981ccb492f7",
     "set_uuid": "692207dd-e636-4511-ba54-c24ddf3e4e46",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2389,7 +2671,9 @@
     "uuid": "93506e7b-f388-4cf8-bd73-e7d96da935d5",
     "set_uuid": "69685097-066a-4fec-8440-fb51804c06d1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2403,7 +2687,9 @@
     "uuid": "a1cdad1f-6537-4c35-a87b-45d8e161ee46",
     "set_uuid": "69685097-066a-4fec-8440-fb51804c06d1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2414,7 +2700,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "49ea57ee-7b12-4a8b-a9bb-a11cf2c9d72c",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -2949,9 +3237,11 @@
     "uuid": "273888c7-abc9-4af8-802a-e8ecf864f2fa",
     "set_uuid": "782eb521-1666-4b13-a89a-2fa1b5dc8148",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -2965,9 +3255,11 @@
     "uuid": "bacd5b38-1eed-49d6-9513-f363315f2a23",
     "set_uuid": "782eb521-1666-4b13-a89a-2fa1b5dc8148",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -2981,9 +3273,11 @@
     "uuid": "629d5ce9-487d-4ee9-be0d-5ff24c66d174",
     "set_uuid": "d3a296c0-137a-4e4b-bb59-507d88059733",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -2997,9 +3291,11 @@
     "uuid": "7815e63c-1d4f-4ee0-a656-a6053595ad59",
     "set_uuid": "d3a296c0-137a-4e4b-bb59-507d88059733",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -3013,9 +3309,11 @@
     "uuid": "e345324b-640f-4f45-88c6-4765ca97ea22",
     "set_uuid": "a04102eb-1876-4792-9172-9152c864e025",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -3029,9 +3327,11 @@
     "uuid": "04481b80-1c05-416a-95cf-c0c85147ce2e",
     "set_uuid": "a04102eb-1876-4792-9172-9152c864e025",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -3045,9 +3345,11 @@
     "uuid": "63c5deff-94da-4981-ba9a-fd46b4372830",
     "set_uuid": "1ec7c31f-7dd0-407c-975b-e90b63db5622",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -3061,9 +3363,11 @@
     "uuid": "5c733ac6-d7b9-44f0-8827-1d8232ca5332",
     "set_uuid": "1ec7c31f-7dd0-407c-975b-e90b63db5622",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -3077,9 +3381,11 @@
     "uuid": "4328bc86-01d4-4467-b99a-33099effe781",
     "set_uuid": "c6effdcb-1b30-4a23-979d-c2378311565c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -3093,9 +3399,11 @@
     "uuid": "b395e912-9061-44bd-ab77-840cde0f3e80",
     "set_uuid": "c6effdcb-1b30-4a23-979d-c2378311565c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -3109,9 +3417,11 @@
     "uuid": "8b6b74b4-e7c3-4f7c-a2b6-f410fcc17a83",
     "set_uuid": "13e5ce35-ff33-44e5-be4d-1365cba897d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-3x-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-3x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    }
   },
   {
     "name": {
@@ -3125,9 +3435,11 @@
     "uuid": "c980c4f4-f2c5-4963-873e-de275f3353d1",
     "set_uuid": "13e5ce35-ff33-44e5-be4d-1365cba897d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-3x-large instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-3x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    }
   },
   {
     "name": {
@@ -3141,9 +3453,11 @@
     "uuid": "4970f7de-506d-4e2c-9412-8ebd268c5da3",
     "set_uuid": "f7b596a6-5bf0-49f0-9897-4f368a8f4abf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -3157,9 +3471,11 @@
     "uuid": "889a7ebb-86b7-4615-87ee-e75aa4b48d60",
     "set_uuid": "f7b596a6-5bf0-49f0-9897-4f368a8f4abf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead. Implementations could negate value eg calc(-1 * token-name)",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead. Implementations could negate value eg calc(-1 * token-name)",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -3188,9 +3504,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "5fbb857b-5703-4e8e-bba4-86720ca261bd",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -3211,7 +3529,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "36742697-2320-4bc0-8a29-ad98e342349f",
     "uuid": "f0e6a20d-8c2d-4aa3-9060-b6ca66aa7943",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3224,7 +3544,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
     "uuid": "70a356be-c304-4bb4-a9df-97806931f089",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3240,9 +3562,11 @@
     "uuid": "5a78f5a4-ceee-4854-96d4-b61d76cc522b",
     "set_uuid": "d97a4b26-6b81-4f71-ac02-6e5914391fe7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -3258,9 +3582,11 @@
     "uuid": "a51a1142-e38e-4055-bd45-ad2bd0045880",
     "set_uuid": "d97a4b26-6b81-4f71-ac02-6e5914391fe7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -3272,8 +3598,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "99ef1a0d-5fe1-4b62-9609-8929e7a3bf9c",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -3283,7 +3611,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8f083cd-131e-4375-b948-3ef5c520cb42",
     "uuid": "2d39863c-6987-413c-90d8-07fcc506a0d4",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3294,7 +3624,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
     "uuid": "8393f599-37e8-484a-a1c6-0934ce15a507",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3333,7 +3665,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5749cb5-6950-4aef-80f0-8445451370a7",
     "uuid": "56dd2fd0-c7a3-4f2c-bda9-8e6ba6d99e6c",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3349,9 +3683,11 @@
     "uuid": "ba160ed7-e66b-4dd1-bef8-e91fe9b05d2c",
     "set_uuid": "c5749cb5-6950-4aef-80f0-8445451370a7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-3x-large instead.",
-    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-3x-large instead.",
+      "replacedBy": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    }
   },
   {
     "name": {
@@ -3367,9 +3703,11 @@
     "uuid": "a1c90c6d-851d-495f-99cc-bbeb0c6fdd4f",
     "set_uuid": "c5749cb5-6950-4aef-80f0-8445451370a7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-3x-large instead.",
-    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-3x-large instead.",
+      "replacedBy": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+    }
   },
   {
     "name": {
@@ -3381,12 +3719,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04141c6f-50ff-4301-a7b5-315bbd9cac18",
     "uuid": "a0542dab-98fb-45d8-b4a0-79cfd2cc4f1c",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-start-edge-to-text-large.",
-    "replaced_by": [
-      "04141c6f-50ff-4301-a7b5-315bbd9cac18",
-      "1d7bd78d-4469-4385-89e7-fcd574cc6368"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.37",
+      "deprecatedComment": "Use a sized token instead, e.g., breadcrumbs-start-edge-to-text-large.",
+      "replacedBy": [
+        "04141c6f-50ff-4301-a7b5-315bbd9cac18",
+        "1d7bd78d-4469-4385-89e7-fcd574cc6368"
+      ]
+    }
   },
   {
     "name": {
@@ -3402,9 +3742,11 @@
     "uuid": "04141c6f-50ff-4301-a7b5-315bbd9cac18",
     "set_uuid": "6833c05d-b5bd-49af-8dc7-8ef2ce52584a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead.",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -3420,9 +3762,11 @@
     "uuid": "1d7bd78d-4469-4385-89e7-fcd574cc6368",
     "set_uuid": "6833c05d-b5bd-49af-8dc7-8ef2ce52584a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead.",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -3438,9 +3782,11 @@
     "uuid": "941f9040-ddb7-419c-ac05-dfa24effa055",
     "set_uuid": "c5f8d9a0-0d8f-4f6c-be31-b120fb25e474",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -3456,9 +3802,11 @@
     "uuid": "e87a054b-dceb-4462-a8fc-733700cc0f79",
     "set_uuid": "c5f8d9a0-0d8f-4f6c-be31-b120fb25e474",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -3474,9 +3822,11 @@
     "uuid": "3dd655e7-f0d4-4fa4-a885-4a7aff9510fd",
     "set_uuid": "79d6a7a8-44e7-46fd-bf3c-b6999d04ba49",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -3492,9 +3842,11 @@
     "uuid": "60a75c05-a9cd-4ecf-89e5-0bca9e137e9f",
     "set_uuid": "79d6a7a8-44e7-46fd-bf3c-b6999d04ba49",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -3506,8 +3858,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "b1fba444-c281-4be4-bded-4852b551cfee",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -3523,9 +3877,11 @@
     "uuid": "3e19f21e-0c87-4eca-bc21-d4c13bc984ef",
     "set_uuid": "01ce78a6-df7d-47fc-a0fb-2d1484d56aa2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead.",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -3541,9 +3897,11 @@
     "uuid": "25d8256e-b05f-43e8-bbc3-5b60c24be29c",
     "set_uuid": "01ce78a6-df7d-47fc-a0fb-2d1484d56aa2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead.",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -3559,9 +3917,11 @@
     "uuid": "74d2cda7-385e-4145-8a3e-26065db5e302",
     "set_uuid": "73709a35-806f-4b34-a31c-ca856425ba0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -3577,9 +3937,11 @@
     "uuid": "bf2e3518-154e-4975-b9fb-acbf60b7e154",
     "set_uuid": "73709a35-806f-4b34-a31c-ca856425ba0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -3595,9 +3957,11 @@
     "uuid": "0d4dd9ba-5b01-432d-a7b2-d95947cfc43d",
     "set_uuid": "db6ce612-bbcd-4107-84c0-7175cb728d6c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -3613,9 +3977,11 @@
     "uuid": "fbf763fe-9e35-4cdc-a5ed-9f90e03d23bd",
     "set_uuid": "db6ce612-bbcd-4107-84c0-7175cb728d6c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -3630,9 +3996,11 @@
     "uuid": "3a89734d-4fcc-43cf-9b77-b2f6d3732391",
     "set_uuid": "6b497d21-d4a6-4690-badf-ec273ec5a692",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-medium instead. Difference is due to other values changing, but expected. Requires some refactor.",
-    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-medium instead. Difference is due to other values changing, but expected. Requires some refactor.",
+      "replacedBy": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    }
   },
   {
     "name": {
@@ -3647,9 +4015,11 @@
     "uuid": "b93aad22-aff0-46d5-b54e-17891f02124a",
     "set_uuid": "6b497d21-d4a6-4690-badf-ec273ec5a692",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-medium instead. Difference is due to other values changing, but expected. Requires some refactor.",
-    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-medium instead. Difference is due to other values changing, but expected. Requires some refactor.",
+      "replacedBy": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    }
   },
   {
     "name": {
@@ -3661,12 +4031,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2e8091e4-f60b-438c-bcbb-111eb243900d",
     "uuid": "15e56281-5fc1-4b59-b815-fc333231e364",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-large.",
-    "replaced_by": [
-      "2e8091e4-f60b-438c-bcbb-111eb243900d",
-      "2e12202a-8099-4a4d-b06d-703deaf20862"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.37",
+      "deprecatedComment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-large.",
+      "replacedBy": [
+        "2e8091e4-f60b-438c-bcbb-111eb243900d",
+        "2e12202a-8099-4a4d-b06d-703deaf20862"
+      ]
+    }
   },
   {
     "name": {
@@ -3679,12 +4051,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fdbf3b4b-7d6e-4464-8514-17c1b4790db6",
     "uuid": "a63e8df1-124f-4f3e-9e1b-ba422b8d8257",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-medium.",
-    "replaced_by": [
-      "fdbf3b4b-7d6e-4464-8514-17c1b4790db6",
-      "fcbd2bcb-7f53-4219-9d6b-89c01fd50da7"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.37",
+      "deprecatedComment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-medium.",
+      "replacedBy": [
+        "fdbf3b4b-7d6e-4464-8514-17c1b4790db6",
+        "fcbd2bcb-7f53-4219-9d6b-89c01fd50da7"
+      ]
+    }
   },
   {
     "name": {
@@ -3700,7 +4074,9 @@
     "uuid": "6b310160-ab2e-40fd-9216-21ddcb36b575",
     "set_uuid": "3acadfab-ddd5-4eac-85de-b6c573dae071",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3716,7 +4092,9 @@
     "uuid": "eb3b2566-6fc1-4a2c-a8cf-e40af3d34715",
     "set_uuid": "3acadfab-ddd5-4eac-85de-b6c573dae071",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3732,9 +4110,11 @@
     "uuid": "2e8091e4-f60b-438c-bcbb-111eb243900d",
     "set_uuid": "f5a2b688-0ddd-4423-a958-6ef4bad42809",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Require unified UI icon set.",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Require unified UI icon set.",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -3750,9 +4130,11 @@
     "uuid": "2e12202a-8099-4a4d-b06d-703deaf20862",
     "set_uuid": "f5a2b688-0ddd-4423-a958-6ef4bad42809",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Require unified UI icon set.",
-    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-2x-large instead. Require unified UI icon set.",
+      "replacedBy": "51761a5c-200d-467d-a575-3722f825edb9"
+    }
   },
   {
     "name": {
@@ -3768,9 +4150,11 @@
     "uuid": "fdbf3b4b-7d6e-4464-8514-17c1b4790db6",
     "set_uuid": "e7f97e3d-129e-4971-bc78-5f184710d716",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -3786,9 +4170,11 @@
     "uuid": "fcbd2bcb-7f53-4219-9d6b-89c01fd50da7",
     "set_uuid": "e7f97e3d-129e-4971-bc78-5f184710d716",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -3804,9 +4190,11 @@
     "uuid": "96d7dff4-4b3d-433a-8f83-8f55a1514812",
     "set_uuid": "5b042e52-ddce-4e17-84c0-faf86049a945",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -3822,9 +4210,11 @@
     "uuid": "4b7eab87-e6a8-40f6-a071-5aff25493f2f",
     "set_uuid": "5b042e52-ddce-4e17-84c0-faf86049a945",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -3836,7 +4226,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306b871f-cbfa-49a2-a74b-dd120bbff503",
     "uuid": "d084038e-bc31-43be-99ee-13cf727eaf9d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3849,7 +4241,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
     "uuid": "b19547e2-bd8f-435d-b726-4f2ce6a83984",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3865,9 +4259,11 @@
     "uuid": "138070fe-1f06-48b4-ac49-f8ff117c5f42",
     "set_uuid": "23002fd3-7ea9-48a6-9364-fc25fb49e3d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -3883,9 +4279,11 @@
     "uuid": "ea82fc23-82e7-4116-a8bb-186a253675ad",
     "set_uuid": "23002fd3-7ea9-48a6-9364-fc25fb49e3d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -3897,8 +4295,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "751734bd-1c58-4222-bbd8-8b2349f2fbd2",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -3911,7 +4311,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "751734bd-1c58-4222-bbd8-8b2349f2fbd2",
     "uuid": "e0aba287-799f-4621-97cb-563352002a20",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3926,9 +4328,11 @@
     "uuid": "2285d870-68ec-469f-a034-2fdeb31e33f0",
     "set_uuid": "f6a7f9c9-8722-4df3-9c6f-7093cc91a646",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead.",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead.",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -3943,9 +4347,11 @@
     "uuid": "154bce30-bfe2-445b-bbdd-69efce5565ae",
     "set_uuid": "f6a7f9c9-8722-4df3-9c6f-7093cc91a646",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead.",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead.",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -3957,8 +4363,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "963bd7ed-cfc9-4a93-a8a6-a2340ec6479f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -3970,7 +4378,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "963bd7ed-cfc9-4a93-a8a6-a2340ec6479f",
     "uuid": "1fe2a3df-3179-4c4a-8d1f-de41297b6d74",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -4051,9 +4461,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "248d1f30-c0d3-49bb-a5b7-0860cc75ee85",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -4064,9 +4476,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "a9f253aa-631e-447a-8335-15b4491a8e9d",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-large instead.",
-    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-large instead.",
+      "replacedBy": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    }
   },
   {
     "name": {
@@ -4077,9 +4491,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "562738ca-ed16-4855-8855-3914b9109408",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-2x-small instead.",
-    "replaced_by": "f0d9117a-5606-4e49-a81f-f89938b34ca4"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-2x-small instead.",
+      "replacedBy": "f0d9117a-5606-4e49-a81f-f89938b34ca4"
+    }
   },
   {
     "name": {
@@ -4090,9 +4506,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
     "uuid": "0b551228-5a6a-403d-bb92-9800835cb3be",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -4103,9 +4521,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
     "uuid": "f3566ff3-2430-4fdd-a48c-e8c0d3c34adc",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead.",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead.",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -4116,9 +4536,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "521df9e4-9c61-4a73-9157-d235a4d04090",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead.",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead.",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -4129,9 +4551,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
     "uuid": "7acf60d0-7870-403e-94b9-18e84eff861b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -4142,9 +4566,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "9ecb4a76-013a-4952-9646-a5660005b31e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead.",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead.",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -4155,9 +4581,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "8856270e-65b5-4f81-87c0-5332ffd7459f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-large instead.",
-    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-large instead.",
+      "replacedBy": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    }
   },
   {
     "name": {
@@ -4168,9 +4596,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
     "uuid": "04ef066b-4733-4d20-9538-7eefd71e7a1e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -4181,9 +4611,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
     "uuid": "569f8d0a-75f3-4743-aa51-9ec6479cdf21",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead.",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead.",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -4194,9 +4626,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
     "uuid": "c4ee268c-aca6-488f-90db-d3e51a0c5c89",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-2x-large instead.",
-    "replaced_by": "3801295f-e52b-412a-baf4-0b8e20449333"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-2x-large instead.",
+      "replacedBy": "3801295f-e52b-412a-baf4-0b8e20449333"
+    }
   },
   {
     "name": {
@@ -4207,9 +4641,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
     "uuid": "91289dd0-0a27-49ef-96c9-3508edecfa44",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead.",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead.",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -4220,9 +4656,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
     "uuid": "73da978a-bede-439e-97cd-afeb32e87780",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -4233,9 +4671,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "98ef0816-ad83-43ec-b976-1169a7ce8540",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-large instead.",
-    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-large instead.",
+      "replacedBy": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    }
   },
   {
     "name": {
@@ -4246,9 +4686,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
     "uuid": "8ec39e04-de4f-48cf-9c8b-7bb7f76730a0",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -4260,9 +4702,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "e874d2cd-6ad6-4d1c-8103-789945f10294",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-medium instead. May require refactor",
-    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-medium instead. May require refactor",
+      "replacedBy": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    }
   },
   {
     "name": {
@@ -4275,9 +4719,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
     "uuid": "fd732759-52ab-45b7-9949-9d9352091efe",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead.",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead.",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -4290,9 +4736,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
     "uuid": "45af5962-8d41-476d-a92d-befa408b47b7",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -4305,9 +4753,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "104c7b60-387b-4550-b0eb-573915d28f42",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-large instead.",
-    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-large instead.",
+      "replacedBy": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+    }
   },
   {
     "name": {
@@ -4417,9 +4867,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3a11949c-f1ac-490b-8416-f4883402d105",
     "uuid": "55db9f3d-621d-4d23-b3d0-c0f2b0f3f9b0",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use card-minimum-width-default instead.",
-    "replaced_by": "3a11949c-f1ac-490b-8416-f4883402d105"
+    "lifecycle": {
+      "deprecatedIn": "13.11.0",
+      "deprecatedComment": "This token has been deprecated, use card-minimum-width-default instead.",
+      "replacedBy": "3a11949c-f1ac-490b-8416-f4883402d105"
+    }
   },
   {
     "name": {
@@ -4678,9 +5130,11 @@
     "uuid": "3c4217bb-91f2-4347-9f65-a0528992f600",
     "set_uuid": "068911fa-495d-43d0-a1bd-c35de883bc47",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires other design enhancements to this component",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires other design enhancements to this component",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4696,9 +5150,11 @@
     "uuid": "b3be5ac8-2415-4490-8b4a-c08661ec84d1",
     "set_uuid": "068911fa-495d-43d0-a1bd-c35de883bc47",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires other design enhancements to this component",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires other design enhancements to this component",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4714,9 +5170,11 @@
     "uuid": "93edae08-5320-4e7e-a006-a9af1d3665ad",
     "set_uuid": "af3f2878-5437-4b37-a399-508a3bf038fa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires other design enhancements to this component",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires other design enhancements to this component",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4732,9 +5190,11 @@
     "uuid": "d040d2f4-9bb4-4d27-adac-40fef079d958",
     "set_uuid": "af3f2878-5437-4b37-a399-508a3bf038fa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires other design enhancements to this component",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires other design enhancements to this component",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4750,9 +5210,11 @@
     "uuid": "dcde5d2d-60f8-4d56-bfb1-bba44a087515",
     "set_uuid": "6ed456cf-9c7d-40d1-99b9-0bd4e0e8dc22",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires other design enhancements to this component",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires other design enhancements to this component",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4768,9 +5230,11 @@
     "uuid": "e3751526-2db9-421c-85f9-d60071aac49b",
     "set_uuid": "6ed456cf-9c7d-40d1-99b9-0bd4e0e8dc22",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires other design enhancements to this component",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires other design enhancements to this component",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4786,9 +5250,11 @@
     "uuid": "20518175-5bc7-4659-8007-e74339c39433",
     "set_uuid": "417a665d-fbe5-4756-ba30-0e8b79c0bee0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires other design enhancements to this component",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires other design enhancements to this component",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4804,9 +5270,11 @@
     "uuid": "f254146e-f469-44b1-b0c9-1ac72e88f9e3",
     "set_uuid": "417a665d-fbe5-4756-ba30-0e8b79c0bee0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires other design enhancements to this component",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires other design enhancements to this component",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4820,7 +5288,9 @@
     "uuid": "9227a279-09f4-457a-b5b3-894f0d6a00df",
     "set_uuid": "7dca1bf5-71bc-406d-8df8-98c9e3c443d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4834,7 +5304,9 @@
     "uuid": "23247915-3cc0-4fdf-b21a-85b97019a219",
     "set_uuid": "7dca1bf5-71bc-406d-8df8-98c9e3c443d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4848,7 +5320,9 @@
     "uuid": "342a360b-d58c-4d7a-9a9d-893600b90785",
     "set_uuid": "51745ca2-1ea0-4648-8b90-26021d8cb24c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4862,7 +5336,9 @@
     "uuid": "d4e3f5ff-91d6-499e-b79e-b1d85c0c597b",
     "set_uuid": "51745ca2-1ea0-4648-8b90-26021d8cb24c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4876,7 +5352,9 @@
     "uuid": "b5eff9b7-6987-47a1-a673-c47b7e806370",
     "set_uuid": "ccb1a2b3-4661-4bda-9ccc-aa737e6c3ae1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4890,7 +5368,9 @@
     "uuid": "d9b251b2-aa8a-46dc-9a2a-0eb46afea241",
     "set_uuid": "ccb1a2b3-4661-4bda-9ccc-aa737e6c3ae1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4904,7 +5384,9 @@
     "uuid": "1a043355-03e6-4322-a462-7d628c23fd06",
     "set_uuid": "43c66b3c-ee3d-42dc-94b3-b4e8f24d9a0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4918,7 +5400,9 @@
     "uuid": "c044459e-12a3-4cdd-9f22-db1d14f34164",
     "set_uuid": "43c66b3c-ee3d-42dc-94b3-b4e8f24d9a0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4932,7 +5416,9 @@
     "uuid": "6335cb3a-6ceb-40e7-b241-ff9b36f1277c",
     "set_uuid": "4a56fa39-3250-45ee-a13e-885aa51e05d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4946,7 +5432,9 @@
     "uuid": "ee52f114-1ab6-430b-bd54-62a82bf3600e",
     "set_uuid": "4a56fa39-3250-45ee-a13e-885aa51e05d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4960,7 +5448,9 @@
     "uuid": "0bf97a2b-5fe6-46ca-8175-8457e8e37d36",
     "set_uuid": "e58cc203-6a8d-46a6-a8c6-eeaefbd4a50e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4974,7 +5464,9 @@
     "uuid": "29f107aa-b8a8-4a09-bf55-9c903c1005ed",
     "set_uuid": "e58cc203-6a8d-46a6-a8c6-eeaefbd4a50e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -4988,7 +5480,9 @@
     "uuid": "4bacaeea-2d60-46d2-8c98-288b45a79aaf",
     "set_uuid": "af33c41e-0824-45bf-a6de-f960deacef46",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5002,7 +5496,9 @@
     "uuid": "b52f4e53-06c2-4746-8063-e2bd99361174",
     "set_uuid": "af33c41e-0824-45bf-a6de-f960deacef46",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5016,7 +5512,9 @@
     "uuid": "0545a68c-f273-4348-84cd-9cd365bdb474",
     "set_uuid": "66be8a28-4c91-4418-9589-f9a3114f361b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5030,7 +5528,9 @@
     "uuid": "99224b4e-751a-49ec-8db4-41c8cc4c7bf5",
     "set_uuid": "66be8a28-4c91-4418-9589-f9a3114f361b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5044,7 +5544,9 @@
     "uuid": "fdd4f0b4-3284-4734-b158-ecd5da36d586",
     "set_uuid": "dea35658-0356-4578-b3b0-f538449ee8f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5058,7 +5560,9 @@
     "uuid": "c4d6bea8-61b0-45a4-81e0-1e5dd7429463",
     "set_uuid": "dea35658-0356-4578-b3b0-f538449ee8f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5072,7 +5576,9 @@
     "uuid": "2df0f6e0-5821-4f70-9aa9-1cc61f860b53",
     "set_uuid": "6a8b4db6-5057-4aac-a548-88b365f8a491",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5086,7 +5592,9 @@
     "uuid": "08bbd8dd-bb02-43b9-8e25-7709aee5ff52",
     "set_uuid": "6a8b4db6-5057-4aac-a548-88b365f8a491",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5100,7 +5608,9 @@
     "uuid": "087dcfa2-5bfd-47a4-a67c-dca50e086e7a",
     "set_uuid": "dc5f5463-25e5-4dd6-a019-422dff279d7a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5114,7 +5624,9 @@
     "uuid": "e6fdcac2-9916-45e2-a479-e87d17ece1f9",
     "set_uuid": "dc5f5463-25e5-4dd6-a019-422dff279d7a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5128,7 +5640,9 @@
     "uuid": "7fc3ab50-4856-442b-85f7-7f0e5ab3304a",
     "set_uuid": "f683fc1b-4d90-4165-8f00-59a7be264f3b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5142,7 +5656,9 @@
     "uuid": "ee913eaa-bdaf-44c0-a139-17c5d94b1d4a",
     "set_uuid": "f683fc1b-4d90-4165-8f00-59a7be264f3b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5156,7 +5672,9 @@
     "uuid": "785a9152-a69b-4164-a8e2-cc201c1f8063",
     "set_uuid": "ddd17061-8664-4dd4-8b21-45354cd37467",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5170,7 +5688,9 @@
     "uuid": "6d8ce7eb-a2a2-496c-9ce7-847f4da5fc0c",
     "set_uuid": "ddd17061-8664-4dd4-8b21-45354cd37467",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5184,7 +5704,9 @@
     "uuid": "2891d3c7-1178-4901-9be9-75efada4a9e7",
     "set_uuid": "41f34810-35b7-4179-b997-d01fabf70599",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5198,7 +5720,9 @@
     "uuid": "95400787-7abb-4cad-830b-8a4042831860",
     "set_uuid": "41f34810-35b7-4179-b997-d01fabf70599",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5212,7 +5736,9 @@
     "uuid": "c1de2d7d-ef83-4a3f-9407-2f512127244f",
     "set_uuid": "95d55e28-01ee-40df-8a67-a30ccea2d809",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5226,7 +5752,9 @@
     "uuid": "350b77ab-6440-49c1-9b1c-a31c5c4f2f5f",
     "set_uuid": "95d55e28-01ee-40df-8a67-a30ccea2d809",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5240,7 +5768,9 @@
     "uuid": "43ef1792-b182-419d-966c-a8a2d77dbe03",
     "set_uuid": "1ccb5e05-1156-46a9-b2b3-14cc5d815aa5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5254,7 +5784,9 @@
     "uuid": "74dbb8c0-2e65-413d-8b52-7215993b5696",
     "set_uuid": "1ccb5e05-1156-46a9-b2b3-14cc5d815aa5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -5265,9 +5797,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "adb8eace-decc-4bef-93e9-ff2cb27e9ce6",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead.",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead.",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -5302,9 +5836,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "b25c696f-c6c3-45af-bdc9-fe3a046067f3",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -5374,12 +5910,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4b88a0d5-2d07-4e63-afa6-cdd611f0a8c1",
     "uuid": "eba9f466-deda-48d5-a120-14419d5a670f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replace with coach-mark-body-font-size",
-    "replaced_by": [
-      "4b88a0d5-2d07-4e63-afa6-cdd611f0a8c1",
-      "73959c3d-afc2-4f6e-bd34-0399bf3b5b73"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.27",
+      "deprecatedComment": "Replace with coach-mark-body-font-size",
+      "replacedBy": [
+        "4b88a0d5-2d07-4e63-afa6-cdd611f0a8c1",
+        "73959c3d-afc2-4f6e-bd34-0399bf3b5b73"
+      ]
+    }
   },
   {
     "name": {
@@ -5394,9 +5932,11 @@
     "uuid": "d5a3e2c7-f717-4436-91a3-3ab34aebd48e",
     "set_uuid": "aba07ab5-e655-4a1c-9704-7850bafefae8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -5411,9 +5951,11 @@
     "uuid": "11fb0ab2-d6a0-4da8-9c83-c1f6b918406a",
     "set_uuid": "aba07ab5-e655-4a1c-9704-7850bafefae8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -5556,12 +6098,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "06ae2458-8490-4741-8a02-97f60cc01592",
     "uuid": "df8bc8ae-b6fa-4414-93b7-c89d8097fe11",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replace with coach-mark-pagination-body-font-size",
-    "replaced_by": [
-      "06ae2458-8490-4741-8a02-97f60cc01592",
-      "4f8c99a5-0942-41b0-ac41-923ea9ca2bf2"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.27",
+      "deprecatedComment": "Replace with coach-mark-pagination-body-font-size",
+      "replacedBy": [
+        "06ae2458-8490-4741-8a02-97f60cc01592",
+        "4f8c99a5-0942-41b0-ac41-923ea9ca2bf2"
+      ]
+    }
   },
   {
     "name": {
@@ -5576,9 +6120,11 @@
     "uuid": "d2ff2d4f-058e-412b-9e16-1725d6d29e25",
     "set_uuid": "b99f2904-e6e6-4ad2-b8d7-02d7ca334932",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead. Refactor may be required",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead. Refactor may be required",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -5593,9 +6139,11 @@
     "uuid": "cd48e6b7-a4d8-4a22-8d65-531d770a9898",
     "set_uuid": "b99f2904-e6e6-4ad2-b8d7-02d7ca334932",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead. Refactor may be required",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead. Refactor may be required",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -5632,12 +6180,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5b132698-4ee2-40e4-83c0-9ad80f36f5fd",
     "uuid": "331604db-3f28-472e-810d-9010ed2c8e33",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replace with coach-mark-title-font-size",
-    "replaced_by": [
-      "5b132698-4ee2-40e4-83c0-9ad80f36f5fd",
-      "45855bc5-3b86-49a9-b443-7be9aa763c4e"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.27",
+      "deprecatedComment": "Replace with coach-mark-title-font-size",
+      "replacedBy": [
+        "5b132698-4ee2-40e4-83c0-9ad80f36f5fd",
+        "45855bc5-3b86-49a9-b443-7be9aa763c4e"
+      ]
+    }
   },
   {
     "name": {
@@ -6263,7 +6813,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 2,
     "uuid": "4798728b-9a97-4ce1-b703-0182b1513e8b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -6275,8 +6827,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6289,9 +6843,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "4a4ee415-1f25-4d36-928c-5ece0ce4abcc",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
-    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.25",
+      "deprecatedComment": "Replaced with combo-box-visual-to-field-button",
+      "replacedBy": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    }
   },
   {
     "name": {
@@ -6304,9 +6860,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "356c4912-69c7-4a95-956b-c1aa78cb02cb",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
-    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.25",
+      "deprecatedComment": "Replaced with combo-box-visual-to-field-button",
+      "replacedBy": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    }
   },
   {
     "name": {
@@ -6319,9 +6877,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "c5a4baf2-effe-4d9a-92f3-b4ead5440d36",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
-    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.25",
+      "deprecatedComment": "Replaced with combo-box-visual-to-field-button",
+      "replacedBy": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    }
   },
   {
     "name": {
@@ -6332,9 +6892,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "292cbbe1-1ba4-4369-9768-2051c07e6406",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
-    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.25",
+      "deprecatedComment": "Replaced with combo-box-visual-to-field-button",
+      "replacedBy": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    }
   },
   {
     "name": {
@@ -6347,9 +6909,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "5d054a3e-e4bb-4ca3-b84a-51b3d7fa2cb8",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
-    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.25",
+      "deprecatedComment": "Replaced with combo-box-visual-to-field-button",
+      "replacedBy": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+    }
   },
   {
     "name": {
@@ -6386,7 +6950,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
     "uuid": "e458fa68-ab9c-4441-a7d5-a02f42df1cae",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -6432,7 +6998,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
     "uuid": "5358fd6c-d9a0-4caa-a85e-af82ed82efaf",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -6446,7 +7014,9 @@
     "uuid": "c9fac273-0c5c-46cd-b774-ad566a540511",
     "set_uuid": "e8659c2e-f4b7-4732-b23c-16af4a1d79c9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6460,7 +7030,9 @@
     "uuid": "11f924ca-5542-4864-b153-77363a32d690",
     "set_uuid": "e8659c2e-f4b7-4732-b23c-16af4a1d79c9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6474,7 +7046,9 @@
     "uuid": "5b416331-7910-4d64-9b5f-43fd1832d3a6",
     "set_uuid": "587977b6-8adf-4b54-b940-6354b0e830fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6488,7 +7062,9 @@
     "uuid": "11f65b04-c50d-45bb-86bd-34520aa7db61",
     "set_uuid": "587977b6-8adf-4b54-b940-6354b0e830fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6502,7 +7078,9 @@
     "uuid": "f0a65c80-55e8-4ad3-b68c-8429c2fefcf5",
     "set_uuid": "8a4ae475-b40f-49dd-bbcc-bd6bc135b0f7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6516,7 +7094,9 @@
     "uuid": "37867ac1-4101-4553-98e1-c8a94fdd2d66",
     "set_uuid": "8a4ae475-b40f-49dd-bbcc-bd6bc135b0f7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6530,7 +7110,9 @@
     "uuid": "b7e0939f-45ef-4250-8138-2bee9dcb2be4",
     "set_uuid": "b490e81d-f2f0-4857-b2f4-cbea8edb8383",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6544,7 +7126,9 @@
     "uuid": "2fed48b7-dd3d-4c3c-9d5c-3046934f5cfd",
     "set_uuid": "b490e81d-f2f0-4857-b2f4-cbea8edb8383",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6558,7 +7142,9 @@
     "uuid": "1228762d-8c89-4e04-a097-5001d805877d",
     "set_uuid": "7029c6a0-dce5-4149-a8fd-c3d28c05d065",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6572,7 +7158,9 @@
     "uuid": "a865d5f8-4798-4721-ab76-3b51067d6439",
     "set_uuid": "7029c6a0-dce5-4149-a8fd-c3d28c05d065",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6586,7 +7174,9 @@
     "uuid": "825c1a0a-e6a3-41dc-81bb-0fb9b74c0ca2",
     "set_uuid": "96e922f2-8178-4961-99e5-f86e08b947b2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6600,7 +7190,9 @@
     "uuid": "e12ac1ec-08f8-4d8b-8c4b-29b74cafe1a1",
     "set_uuid": "96e922f2-8178-4961-99e5-f86e08b947b2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6614,7 +7206,9 @@
     "uuid": "8e597833-1025-4de4-b34a-2f34201487c3",
     "set_uuid": "bd1ab7ff-ab35-401f-8f6e-69d986a457c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6628,7 +7222,9 @@
     "uuid": "622d259d-b52b-409a-bf58-04705d8423f9",
     "set_uuid": "bd1ab7ff-ab35-401f-8f6e-69d986a457c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6642,7 +7238,9 @@
     "uuid": "67464126-edf0-49db-a07c-8641d4a24cae",
     "set_uuid": "01c16d60-dd80-4a7b-a55f-24d68a6e88c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6656,7 +7254,9 @@
     "uuid": "9dc14737-973d-4f6e-8336-2e119c1f1af7",
     "set_uuid": "01c16d60-dd80-4a7b-a55f-24d68a6e88c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6670,7 +7270,9 @@
     "uuid": "220d2f95-067f-4169-bab7-1b4e202bd1a1",
     "set_uuid": "fafd0a22-6824-43fc-b348-a4cf287ad4a2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6684,7 +7286,9 @@
     "uuid": "98ebf128-02f1-4d4b-a686-af8713a0f24b",
     "set_uuid": "fafd0a22-6824-43fc-b348-a4cf287ad4a2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6698,7 +7302,9 @@
     "uuid": "84f3da59-4c41-4e4e-925c-5fda4222361d",
     "set_uuid": "4d434220-41ef-4ab3-8adc-dabb5e0d799c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6712,7 +7318,9 @@
     "uuid": "ad59353e-3ed1-4e76-af87-020cebfa2664",
     "set_uuid": "4d434220-41ef-4ab3-8adc-dabb5e0d799c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6726,7 +7334,9 @@
     "uuid": "17540c3a-2f85-4771-a4f8-834c70872abb",
     "set_uuid": "85ca8298-e55c-4a58-813a-50419d06a0c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6740,7 +7350,9 @@
     "uuid": "d2c45711-be18-4c85-8b23-f4d4f3d0b492",
     "set_uuid": "85ca8298-e55c-4a58-813a-50419d06a0c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6754,7 +7366,9 @@
     "uuid": "59e5a3f7-c1d0-4b76-bb7e-2bcddddb83da",
     "set_uuid": "2298f2ce-e1b5-4a77-b1e5-180ed32b9711",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6768,7 +7382,9 @@
     "uuid": "ea331ff6-aa92-4cb4-936a-554a2404152d",
     "set_uuid": "2298f2ce-e1b5-4a77-b1e5-180ed32b9711",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6782,7 +7398,9 @@
     "uuid": "08358bbf-3f8d-48fe-bb48-5dadead4170f",
     "set_uuid": "59582588-d429-4949-9dfc-d2be3eb1963b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6796,7 +7414,9 @@
     "uuid": "8d2ad303-095d-4f0c-b0c5-c1ec75b96819",
     "set_uuid": "59582588-d429-4949-9dfc-d2be3eb1963b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6810,7 +7430,9 @@
     "uuid": "34316272-7bcd-4b44-af20-07c0e1cb8690",
     "set_uuid": "002e91f0-f8d7-4c82-983d-9fdeb54c8a27",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6824,7 +7446,9 @@
     "uuid": "2e81ce48-452d-401f-a44d-10ca427f031e",
     "set_uuid": "002e91f0-f8d7-4c82-983d-9fdeb54c8a27",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6838,7 +7462,9 @@
     "uuid": "bfd0ad6e-6656-46d6-aa9f-0940b2c2902a",
     "set_uuid": "b44a2927-7b2e-494c-9f79-ba7ea5eaabd2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6852,7 +7478,9 @@
     "uuid": "1b6d0e50-3ba2-43c9-8b8c-c220364f4434",
     "set_uuid": "b44a2927-7b2e-494c-9f79-ba7ea5eaabd2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -6873,9 +7501,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "4725710f-67b2-4000-b4e8-e67a68cd75f5",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Date and time fields use 20px whereas text field appears to use padding value",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Date and time fields use 20px whereas text field appears to use padding value",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -6896,8 +7526,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "c6c92147-8ee5-408b-9590-adede6abc935",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6909,8 +7541,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "da7f0c10-fa1b-4700-8acf-01feebdeed7f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6996,7 +7630,9 @@
     "uuid": "85273338-00a6-407d-b5f9-803a732b84fa",
     "set_uuid": "a0334fc6-e127-43e0-be41-7ecb5ef52b22",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7010,7 +7646,9 @@
     "uuid": "f60c626f-f217-46eb-b2ed-5c56c3f87aa4",
     "set_uuid": "a0334fc6-e127-43e0-be41-7ecb5ef52b22",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7024,7 +7662,9 @@
     "uuid": "4342319b-d8c4-485b-9b2f-5bd4c702979c",
     "set_uuid": "79a9ff24-76dd-4d94-aac8-c226e64b88ba",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7038,7 +7678,9 @@
     "uuid": "b8370ec4-5e70-4a53-a98e-a733c86ce065",
     "set_uuid": "79a9ff24-76dd-4d94-aac8-c226e64b88ba",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7052,7 +7694,9 @@
     "uuid": "91eb8665-5728-468c-a533-1aadf70aeef1",
     "set_uuid": "42b99d05-5642-4663-8789-c30b9a7439d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7066,7 +7710,9 @@
     "uuid": "93052ad2-8ada-40d8-a046-16e5a91ae826",
     "set_uuid": "42b99d05-5642-4663-8789-c30b9a7439d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7080,7 +7726,9 @@
     "uuid": "c4ae0720-ee2c-41b8-a8ad-a30528a8a967",
     "set_uuid": "c1efdd8f-29ec-4c77-b750-ca011bd8de1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7094,7 +7742,9 @@
     "uuid": "e2615055-159e-4b87-b7ce-1537f25fcdd4",
     "set_uuid": "c1efdd8f-29ec-4c77-b750-ca011bd8de1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7115,9 +7765,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "644593be-82da-4ae4-ae57-fabebd4513ca",
     "uuid": "bb3fee51-24cc-4643-9f22-fa1592ab2457",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use drop-zone-body-font-size instead",
-    "replaced_by": "644593be-82da-4ae4-ae57-fabebd4513ca"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.35",
+      "deprecatedComment": "Use drop-zone-body-font-size instead",
+      "replacedBy": "644593be-82da-4ae4-ae57-fabebd4513ca"
+    }
   },
   {
     "name": {
@@ -7128,9 +7780,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "47c15433-53d3-425b-8b87-ea234701f781",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token drop-target-dash-gap instead.",
-    "replaced_by": "5582026a-22e6-4e0e-9a21-2a7a43b026a6"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token drop-target-dash-gap instead.",
+      "replacedBy": "5582026a-22e6-4e0e-9a21-2a7a43b026a6"
+    }
   },
   {
     "name": {
@@ -7141,9 +7795,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "a596af57-256f-4445-b91f-36e47bfb2d95",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token drop-target-dash-length instead.",
-    "replaced_by": "24cd8175-3dc5-46ae-b1af-01632787fcd8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token drop-target-dash-length instead.",
+      "replacedBy": "24cd8175-3dc5-46ae-b1af-01632787fcd8"
+    }
   },
   {
     "name": {
@@ -7166,9 +7822,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75",
     "uuid": "013387e8-8925-4bb4-a8ee-94420141fde9",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use drop-zone-cjk-title-font-size instead",
-    "replaced_by": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.35",
+      "deprecatedComment": "Use drop-zone-cjk-title-font-size instead",
+      "replacedBy": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75"
+    }
   },
   {
     "name": {
@@ -7179,7 +7837,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
     "uuid": "b8d0db71-9a25-46fc-b77a-037fcf86be8e",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.5.0"
+    }
   },
   {
     "name": {
@@ -7200,9 +7860,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "07564dd0-3628-42e1-8a29-253448a8c75f",
     "uuid": "edc68bfe-7ad3-4a12-81fa-ded8fb6fc2e3",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use drop-zone-title-font-size instead",
-    "replaced_by": "07564dd0-3628-42e1-8a29-253448a8c75f"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.35",
+      "deprecatedComment": "Use drop-zone-title-font-size instead",
+      "replacedBy": "07564dd0-3628-42e1-8a29-253448a8c75f"
+    }
   },
   {
     "name": {
@@ -7345,9 +8007,11 @@
     "uuid": "4140e899-8a28-4627-a91a-e6526da1bdf5",
     "set_uuid": "b5fb9c25-00db-4bcc-9910-9fa9c0a8e704",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -7361,9 +8025,11 @@
     "uuid": "17ba788d-da38-455d-9322-16e4f05ea923",
     "set_uuid": "b5fb9c25-00db-4bcc-9910-9fa9c0a8e704",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -7377,9 +8043,11 @@
     "uuid": "997c475e-6ae5-469f-9c8e-9fedafa2b556",
     "set_uuid": "e96cc084-8713-459c-8912-7cf238446020",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -7393,9 +8061,11 @@
     "uuid": "87149afe-899b-4fb6-bd7c-d2becf8117fc",
     "set_uuid": "e96cc084-8713-459c-8912-7cf238446020",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -7409,9 +8079,11 @@
     "uuid": "7be280dc-43dc-48c3-bf0c-b53f95e76516",
     "set_uuid": "95cbc996-ee6b-4f20-88ce-ccca3753ac14",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -7425,9 +8097,11 @@
     "uuid": "2fbc4add-e6b4-4dfa-9a7d-0de628b2f63c",
     "set_uuid": "95cbc996-ee6b-4f20-88ce-ccca3753ac14",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -7441,9 +8115,11 @@
     "uuid": "4796831f-4d3e-472c-bad8-699d4eb443ea",
     "set_uuid": "03e228c7-41b9-4f57-b7d9-4b31b881fa35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -7457,9 +8133,11 @@
     "uuid": "4271498d-747c-423d-87cc-761b8a181f7c",
     "set_uuid": "03e228c7-41b9-4f57-b7d9-4b31b881fa35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -7470,8 +8148,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "4738ec46-a43c-48f9-aeca-87863275dc4d",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -7485,7 +8165,9 @@
     "uuid": "d6c750dc-3117-4c1a-96bf-b94d530e912d",
     "set_uuid": "af6de4b2-6fee-48fe-9222-c62caa55f212",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7499,7 +8181,9 @@
     "uuid": "e1298748-d7cc-4bff-93bc-745b777fcf9e",
     "set_uuid": "af6de4b2-6fee-48fe-9222-c62caa55f212",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7513,7 +8197,9 @@
     "uuid": "be80f1b1-4c08-479f-a39e-28b6a64714f2",
     "set_uuid": "79363184-cff7-42ae-8087-c68213bfaa8a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7527,7 +8213,9 @@
     "uuid": "c29cfb87-34e7-4397-bfd8-23378ecbb011",
     "set_uuid": "79363184-cff7-42ae-8087-c68213bfaa8a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7541,7 +8229,9 @@
     "uuid": "dc00948e-3c0f-4c6b-8e3e-a7fbf396e059",
     "set_uuid": "445b1198-2df9-4c34-ae7e-790b846071e0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7555,7 +8245,9 @@
     "uuid": "074489d2-66b0-4198-94fe-9818279bbf0f",
     "set_uuid": "445b1198-2df9-4c34-ae7e-790b846071e0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7569,7 +8261,9 @@
     "uuid": "1218beeb-1d74-4e1a-b495-38d5f07afb55",
     "set_uuid": "e4372c7c-3f59-4b2d-8862-61453adcd800",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7583,7 +8277,9 @@
     "uuid": "2d3e67ce-de6d-4e41-bcf8-06b09c0bcce7",
     "set_uuid": "e4372c7c-3f59-4b2d-8862-61453adcd800",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -7594,8 +8290,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "5c14d528-fe17-4b0b-a123-edbdb93fd173",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -7606,8 +8304,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "f7dd90d8-91e6-4090-a5a9-6b30087860a4",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -7618,8 +8318,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "b5243f56-7985-4686-b41f-9b9b9a18b047",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -7630,8 +8332,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "ab718f97-15c3-4b8b-aee7-b50b09ec0a33",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -7645,9 +8349,11 @@
     "uuid": "e53ea4a5-bde5-4695-9ab8-50c2ce704019",
     "set_uuid": "2bfd21da-c4db-4837-9404-e02405717b25",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -7661,9 +8367,11 @@
     "uuid": "5227bf07-140a-49c6-88f9-cc454d8a90c1",
     "set_uuid": "2bfd21da-c4db-4837-9404-e02405717b25",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -7677,9 +8385,11 @@
     "uuid": "60caa810-5335-4c9f-95a7-0e60d49f43fc",
     "set_uuid": "a06e0c59-60ef-41f4-b471-797687ee76cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -7693,9 +8403,11 @@
     "uuid": "e410a804-2655-4bbc-9b66-53a5facc92ac",
     "set_uuid": "a06e0c59-60ef-41f4-b471-797687ee76cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -7709,9 +8421,11 @@
     "uuid": "eb2b857d-9482-42fb-82f9-bbe7899a22b9",
     "set_uuid": "5435348b-4bb7-43b2-910f-31d2ca5873f9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -7725,9 +8439,11 @@
     "uuid": "6f65ad1a-4a65-4b83-af44-5bd893f3b40e",
     "set_uuid": "5435348b-4bb7-43b2-910f-31d2ca5873f9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -7741,9 +8457,11 @@
     "uuid": "7122627b-1906-424d-9cbf-261546ff3774",
     "set_uuid": "2eda2c97-806e-40fd-8a72-f6542bd4e988",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -7757,9 +8475,11 @@
     "uuid": "ec0c072f-50fb-4934-99fc-a2576062e7b4",
     "set_uuid": "2eda2c97-806e-40fd-8a72-f6542bd4e988",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -7792,7 +8512,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
     "uuid": "e6f95e88-636d-4d3a-8966-8c811dc697d6",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7803,8 +8525,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "f99eb317-ebe5-43e7-8066-982fe7a9a8aa",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -7817,12 +8541,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "72d6ae5c-e133-4e7f-bc96-3e4c28d586fd",
     "uuid": "bec914a9-5905-40ac-bd61-a727016c1228",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with component-top-to-workflow-icon-300",
-    "replaced_by": [
-      "72d6ae5c-e133-4e7f-bc96-3e4c28d586fd",
-      "bac14298-68f0-4fb6-a152-c95ab19fd27f"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0",
+      "deprecatedComment": "Replaced with component-top-to-workflow-icon-300",
+      "replacedBy": [
+        "72d6ae5c-e133-4e7f-bc96-3e4c28d586fd",
+        "bac14298-68f0-4fb6-a152-c95ab19fd27f"
+      ]
+    }
   },
   {
     "name": {
@@ -7835,12 +8561,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ef82b92a-2cbd-4b70-920c-4b999b018e07",
     "uuid": "54cae12b-5f21-47b4-a964-6033bd025975",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with component-top-to-workflow-icon-200",
-    "replaced_by": [
-      "ef82b92a-2cbd-4b70-920c-4b999b018e07",
-      "259c0cf5-d321-4a6b-a3ae-b8c58fc1c9d6"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0",
+      "deprecatedComment": "Replaced with component-top-to-workflow-icon-200",
+      "replacedBy": [
+        "ef82b92a-2cbd-4b70-920c-4b999b018e07",
+        "259c0cf5-d321-4a6b-a3ae-b8c58fc1c9d6"
+      ]
+    }
   },
   {
     "name": {
@@ -7853,12 +8581,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c3a280b0-bc84-4a7c-8048-c689f8deef86",
     "uuid": "d159b313-4def-493a-adcf-398e2d1fce9f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with component-top-to-workflow-icon-100",
-    "replaced_by": [
-      "c3a280b0-bc84-4a7c-8048-c689f8deef86",
-      "a3d3f9e9-a784-445a-a052-22f84b832512"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0",
+      "deprecatedComment": "Replaced with component-top-to-workflow-icon-100",
+      "replacedBy": [
+        "c3a280b0-bc84-4a7c-8048-c689f8deef86",
+        "a3d3f9e9-a784-445a-a052-22f84b832512"
+      ]
+    }
   },
   {
     "name": {
@@ -7871,12 +8601,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
     "uuid": "91cb19ef-63fc-4d98-a61e-a5f55951f656",
-    "deprecated": "unknown",
-    "deprecated_comment": "Replaced with component-top-to-workflow-icon-75",
-    "replaced_by": [
-      "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
-      "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0",
+      "deprecatedComment": "Replaced with component-top-to-workflow-icon-75",
+      "replacedBy": [
+        "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
+        "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3"
+      ]
+    }
   },
   {
     "name": {
@@ -7887,12 +8619,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
     "uuid": "4140710f-ae31-4ae3-b8b6-2d3eb6a1ae78",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use illustrated-message-medium-body-font-size instead",
-    "replaced_by": [
-      "ca0d9e22-35a8-4ae5-99ee-29cce3ffa0bd",
-      "32b359dc-b489-4476-afbd-1c04e6b0ff0e"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.35",
+      "deprecatedComment": "Use illustrated-message-medium-body-font-size instead",
+      "replacedBy": [
+        "ca0d9e22-35a8-4ae5-99ee-29cce3ffa0bd",
+        "32b359dc-b489-4476-afbd-1c04e6b0ff0e"
+      ]
+    }
   },
   {
     "name": {
@@ -7903,12 +8637,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "44509721-b85a-4c57-8850-d52322e0afef",
     "uuid": "e77279df-bc62-441a-8a30-5faa41d0df10",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use illustrated-message-medium-cjk-title-font-size instead",
-    "replaced_by": [
-      "ee763c7d-b98f-4f2e-9fc4-764cfa2ac53f",
-      "1cb0c913-f4ec-478c-b92d-4c9d78875362"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.35",
+      "deprecatedComment": "Use illustrated-message-medium-cjk-title-font-size instead",
+      "replacedBy": [
+        "ee763c7d-b98f-4f2e-9fc4-764cfa2ac53f",
+        "1cb0c913-f4ec-478c-b92d-4c9d78875362"
+      ]
+    }
   },
   {
     "name": {
@@ -8018,7 +8754,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95c055b0-f688-4405-8426-1b2302e32ebd",
     "uuid": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -8191,12 +8929,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
     "uuid": "365ec548-431b-4e1e-9f9d-7b04d337f001",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use illustrated-message-medium-title-font-size instead",
-    "replaced_by": [
-      "8e2d1a48-937c-4493-9624-5ca8383f74bd",
-      "65961091-abdb-4155-9887-4aebe857c4fd"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.35",
+      "deprecatedComment": "Use illustrated-message-medium-title-font-size instead",
+      "replacedBy": [
+        "8e2d1a48-937c-4493-9624-5ca8383f74bd",
+        "65961091-abdb-4155-9887-4aebe857c4fd"
+      ]
+    }
   },
   {
     "name": {
@@ -8217,9 +8957,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
     "uuid": "d563157b-f0d7-407d-aaaf-ae1790c75503",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Requires refactor; prior value is this token + accessory-gap-[size]",
-    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-extra-large instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+      "replacedBy": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    }
   },
   {
     "name": {
@@ -8230,9 +8972,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
     "uuid": "6a6e5478-b549-4a39-a7f5-5d3c417464ce",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Requires refactor; prior value is this token + accessory-gap-[size]",
-    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-large instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+      "replacedBy": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    }
   },
   {
     "name": {
@@ -8243,9 +8987,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
     "uuid": "ccb60cfc-86fe-4959-b4a8-1a45835132c8",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Requires refactor; prior value is this token + accessory-gap-[size]",
-    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-medium instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+      "replacedBy": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    }
   },
   {
     "name": {
@@ -8256,9 +9002,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
     "uuid": "8b6a0ab1-4dba-4da2-9c67-3befca0f110e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Requires refactor; prior value is this token + accessory-gap-[size]",
-    "replaced_by": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-small instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+      "replacedBy": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+    }
   },
   {
     "name": {
@@ -8270,7 +9018,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "5bffe992-2982-49e8-aa3a-e4e93c884f43",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -8286,9 +9036,11 @@
     "uuid": "4b212f73-7a28-4d95-b06b-6d3f0d7e5cf9",
     "set_uuid": "bb2781a4-0b80-4d3d-9d40-9755833ef217",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead.",
-    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-extra-large instead.",
+      "replacedBy": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    }
   },
   {
     "name": {
@@ -8304,9 +9056,11 @@
     "uuid": "61cf3878-48bd-4785-ad71-ec35c4f99656",
     "set_uuid": "bb2781a4-0b80-4d3d-9d40-9755833ef217",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead.",
-    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-extra-large instead.",
+      "replacedBy": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    }
   },
   {
     "name": {
@@ -8319,9 +9073,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "44e97486-53ce-4bb0-a778-0f9262dfe27e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-large instead.",
-    "replaced_by": "609e172d-40af-4329-b9d7-32c9158b40bb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-large instead.",
+      "replacedBy": "609e172d-40af-4329-b9d7-32c9158b40bb"
+    }
   },
   {
     "name": {
@@ -8334,9 +9090,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "86f41898-b794-4f7e-ae41-9eb84c2c7a5b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-medium instead.",
-    "replaced_by": "627d972a-4164-4ec6-8c64-0ee97c23fc43"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-medium instead.",
+      "replacedBy": "627d972a-4164-4ec6-8c64-0ee97c23fc43"
+    }
   },
   {
     "name": {
@@ -8352,9 +9110,11 @@
     "uuid": "0171b422-021a-4f25-bbe3-7d6ca6459166",
     "set_uuid": "9a3568cf-7ca2-4393-a087-c865ad803e70",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-small instead.",
-    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-small instead.",
+      "replacedBy": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    }
   },
   {
     "name": {
@@ -8370,9 +9130,11 @@
     "uuid": "a2143caf-07e6-4d45-977c-3d79d69c335e",
     "set_uuid": "9a3568cf-7ca2-4393-a087-c865ad803e70",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-small instead.",
-    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-small instead.",
+      "replacedBy": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    }
   },
   {
     "name": {
@@ -8396,9 +9158,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "391e1e67-1677-4f60-a09a-3b49bacd01f5",
     "uuid": "c47499c1-b89f-49a7-bbb5-17e83e4b306e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    }
   },
   {
     "name": {
@@ -8409,9 +9173,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "acc9c48a-f461-48ff-9f69-0224c4feabc6",
     "uuid": "710ebe58-f0d8-4d6b-8974-0be1f2f48dc4",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    }
   },
   {
     "name": {
@@ -8422,9 +9188,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a87d68bb-4249-43cd-947d-bd061baba0ef",
     "uuid": "3dd5babb-5026-4f28-89ae-bfe687673f31",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    }
   },
   {
     "name": {
@@ -8435,9 +9203,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9890df35-2d45-4767-9cbe-ee745d09d990",
     "uuid": "6c1330a4-1c89-45a7-b2b1-8cbcaf20b9ab",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+    }
   },
   {
     "name": {
@@ -8448,9 +9218,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
     "uuid": "391e1e67-1677-4f60-a09a-3b49bacd01f5",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    }
   },
   {
     "name": {
@@ -8461,9 +9233,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
     "uuid": "acc9c48a-f461-48ff-9f69-0224c4feabc6",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    }
   },
   {
     "name": {
@@ -8474,9 +9248,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
     "uuid": "a87d68bb-4249-43cd-947d-bd061baba0ef",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    }
   },
   {
     "name": {
@@ -8487,9 +9263,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
     "uuid": "9890df35-2d45-4767-9cbe-ee745d09d990",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
-    "replaced_by": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
+      "replacedBy": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+    }
   },
   {
     "name": {
@@ -8500,8 +9278,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "56b54ece-0ff3-4957-9c1c-9e7fb992653c",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -8564,8 +9344,10 @@
     "uuid": "b49756fe-40d5-439a-ba07-4e5eb07e7cc5",
     "set_uuid": "b051b8d7-11cd-44e4-9a80-743d551722ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Single pixel value for a specific component: not a token"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Single pixel value for a specific component: not a token"
+    }
   },
   {
     "name": {
@@ -8580,8 +9362,10 @@
     "uuid": "1263a125-9e9d-4eb4-8b71-024899dcf623",
     "set_uuid": "b051b8d7-11cd-44e4-9a80-743d551722ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Single pixel value for a specific component: not a token"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Single pixel value for a specific component: not a token"
+    }
   },
   {
     "name": {
@@ -8700,9 +9484,11 @@
     "uuid": "8e57f77c-2921-44b8-a602-85300639f916",
     "set_uuid": "e405ccc1-4c8d-4d2e-8bb0-7013733e82c4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
-    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
+      "replacedBy": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    }
   },
   {
     "name": {
@@ -8717,9 +9503,11 @@
     "uuid": "fbc42d9d-2f00-42ae-92e9-727cac69404e",
     "set_uuid": "e405ccc1-4c8d-4d2e-8bb0-7013733e82c4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
-    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
+      "replacedBy": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+    }
   },
   {
     "name": {
@@ -8731,9 +9519,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
     "uuid": "cb3e458d-7dcd-484d-9028-220d08c9f129",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-large instead. Refactoring required",
-    "replaced_by": "609e172d-40af-4329-b9d7-32c9158b40bb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-large instead. Refactoring required",
+      "replacedBy": "609e172d-40af-4329-b9d7-32c9158b40bb"
+    }
   },
   {
     "name": {
@@ -8745,9 +9535,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
     "uuid": "fe42bdd0-de02-4814-b498-038b26a3c0e7",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-medium instead. Refactoring required",
-    "replaced_by": "627d972a-4164-4ec6-8c64-0ee97c23fc43"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-medium instead. Refactoring required",
+      "replacedBy": "627d972a-4164-4ec6-8c64-0ee97c23fc43"
+    }
   },
   {
     "name": {
@@ -8762,9 +9554,11 @@
     "uuid": "ec801932-08dc-4697-8725-5bc9d3ee230d",
     "set_uuid": "bceb3359-ccf7-4f05-9cf5-1fba6b7b9efb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-small instead. Refactoring required",
-    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-small instead. Refactoring required",
+      "replacedBy": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    }
   },
   {
     "name": {
@@ -8779,9 +9573,11 @@
     "uuid": "90669b85-c7e8-4b68-b96d-61a51a2451b3",
     "set_uuid": "bceb3359-ccf7-4f05-9cf5-1fba6b7b9efb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-gap-small instead. Refactoring required",
-    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-gap-small instead. Refactoring required",
+      "replacedBy": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+    }
   },
   {
     "name": {
@@ -8804,7 +9600,9 @@
     "uuid": "cc8ad91e-22f2-4f59-ae8c-99d2c1433d6e",
     "set_uuid": "0722a411-c7c0-4906-8e41-e043b4c245d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8818,7 +9616,9 @@
     "uuid": "083c11fe-1e10-46f5-9e71-3fcc2567fe2d",
     "set_uuid": "0722a411-c7c0-4906-8e41-e043b4c245d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8832,7 +9632,9 @@
     "uuid": "f78418a4-5b55-418b-9c90-7f388d5bb275",
     "set_uuid": "de0d84cb-14d8-40b3-bae2-8826d4ee03f7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8846,7 +9648,9 @@
     "uuid": "0062482b-0339-4632-9b40-89b5f1a440cf",
     "set_uuid": "de0d84cb-14d8-40b3-bae2-8826d4ee03f7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8860,7 +9664,9 @@
     "uuid": "66e386cd-e3b5-424b-b89b-27fe9aaf5ad1",
     "set_uuid": "bc5fab17-8503-442c-a560-fa7a1f8d99c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8874,7 +9680,9 @@
     "uuid": "a063db0d-81cf-45e0-988e-2224307560ba",
     "set_uuid": "bc5fab17-8503-442c-a560-fa7a1f8d99c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8888,7 +9696,9 @@
     "uuid": "54227cbe-b962-46de-b40a-d1ea759425a7",
     "set_uuid": "43458e95-45f9-4d0b-8383-6da7a6080a58",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8902,7 +9712,9 @@
     "uuid": "1bcd281a-38b0-4e83-8667-536351dd14ec",
     "set_uuid": "43458e95-45f9-4d0b-8383-6da7a6080a58",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8916,7 +9728,9 @@
     "uuid": "1e41d09e-684e-4f87-ae85-4bc95f958c0e",
     "set_uuid": "981b8bc8-1914-4406-890f-748efaa1c27c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8930,7 +9744,9 @@
     "uuid": "cb87186b-47aa-4baa-a47d-91b5e9f7965e",
     "set_uuid": "981b8bc8-1914-4406-890f-748efaa1c27c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -8945,9 +9761,11 @@
     "uuid": "6dc382ce-8e48-4bd9-8078-1272da767b13",
     "set_uuid": "4d5193b8-c43e-4bc6-ab23-8d0132ee738e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -8962,9 +9780,11 @@
     "uuid": "16552174-994e-41c3-9439-32b9876c399d",
     "set_uuid": "4d5193b8-c43e-4bc6-ab23-8d0132ee738e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -9062,8 +9882,10 @@
     "uuid": "2480bdaf-ac18-4f67-9a0b-f92200fb31d7",
     "set_uuid": "5cfd407f-6acc-4796-b337-e48e46a15ff4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9077,8 +9899,10 @@
     "uuid": "3385c12f-199b-4e9d-b2e2-ef6e2658d180",
     "set_uuid": "5cfd407f-6acc-4796-b337-e48e46a15ff4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9092,8 +9916,10 @@
     "uuid": "bc6a7e9d-b84c-4bf3-9a63-a08047deb41c",
     "set_uuid": "de0aca49-d688-4b7b-85d1-7b1d74ed1098",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9107,8 +9933,10 @@
     "uuid": "90385dcc-ea45-466f-ba4d-a1b13f6a079c",
     "set_uuid": "de0aca49-d688-4b7b-85d1-7b1d74ed1098",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9122,8 +9950,10 @@
     "uuid": "ac4c8abe-abca-4c6f-82e7-ed7fae0c761d",
     "set_uuid": "68195e44-015b-4611-9557-81fd60ff5965",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9137,8 +9967,10 @@
     "uuid": "5faa4858-5590-40d4-bd12-b4c839908c4c",
     "set_uuid": "68195e44-015b-4611-9557-81fd60ff5965",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9152,8 +9984,10 @@
     "uuid": "033fb47f-30d8-4ff2-9825-a3318ca2118b",
     "set_uuid": "9e079b05-cb44-4901-945f-35f78b3c5fb5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9167,8 +10001,10 @@
     "uuid": "de2ef572-54a2-46c2-ad1d-60468fbe6090",
     "set_uuid": "9e079b05-cb44-4901-945f-35f78b3c5fb5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+    }
   },
   {
     "name": {
@@ -9180,7 +10016,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "608fd592-fff8-435e-88e2-846bd34cc235",
     "uuid": "628cf42f-eb40-49b0-b110-3340421d4502",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -9192,9 +10030,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "5543ede1-4e55-44f5-920f-288ee96e06ca",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-extra-large instead.",
-    "replaced_by": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-extra-large instead.",
+      "replacedBy": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb"
+    }
   },
   {
     "name": {
@@ -9206,9 +10046,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "4ce8b4db-72f8-411b-baad-8b66c0496182",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-large instead.",
-    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-large instead.",
+      "replacedBy": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    }
   },
   {
     "name": {
@@ -9220,9 +10062,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
     "uuid": "608fd592-fff8-435e-88e2-846bd34cc235",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-medium instead.",
-    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-medium instead.",
+      "replacedBy": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    }
   },
   {
     "name": {
@@ -9234,9 +10078,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
     "uuid": "66d57402-d7db-45df-8872-fd362014bcbe",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-small instead.",
-    "replaced_by": "d61248dc-0a2d-469d-a81f-0417e0bb5de2"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-small instead.",
+      "replacedBy": "d61248dc-0a2d-469d-a81f-0417e0bb5de2"
+    }
   },
   {
     "name": {
@@ -9263,9 +10109,11 @@
     "uuid": "63919dd9-0dfa-4e6f-ab89-8a24fc91061b",
     "set_uuid": "c700c8fe-18e4-49b5-9887-dc65217207f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -9281,9 +10129,11 @@
     "uuid": "77e97b70-ef7e-4228-8d91-0ff9d9d2b063",
     "set_uuid": "c700c8fe-18e4-49b5-9887-dc65217207f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -9299,9 +10149,11 @@
     "uuid": "bceffb12-72a3-40eb-98a5-3d5fb4d3b627",
     "set_uuid": "a42d6196-dd09-4731-98fb-6eecf7551f15",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -9317,9 +10169,11 @@
     "uuid": "bda3ee60-8f9a-41b2-a8a2-894aed3b3bed",
     "set_uuid": "a42d6196-dd09-4731-98fb-6eecf7551f15",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -9335,9 +10189,11 @@
     "uuid": "0ed8f599-b4c1-4ac5-b2b0-60db06a98a88",
     "set_uuid": "e89563f5-9481-4f60-9af8-d2836ccc4a8d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -9353,9 +10209,11 @@
     "uuid": "e0468683-b2d2-4839-9ad8-46963d7402fc",
     "set_uuid": "e89563f5-9481-4f60-9af8-d2836ccc4a8d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -9371,9 +10229,11 @@
     "uuid": "8e4b2873-fb57-42d6-8b7b-91fd270c048e",
     "set_uuid": "108ba016-2e21-4f7b-94a7-3f61c987620b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -9389,9 +10249,11 @@
     "uuid": "eb9cf950-cba2-4fb8-a115-8a4c0ddb00d0",
     "set_uuid": "108ba016-2e21-4f7b-94a7-3f61c987620b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -9405,9 +10267,11 @@
     "uuid": "7be78bf9-a761-45a4-b764-b88e6209440b",
     "set_uuid": "70bbe380-0356-4d91-98ea-93f40c66638d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -9421,9 +10285,11 @@
     "uuid": "3ff6cb7a-20cb-4b25-a367-7e4497d0f237",
     "set_uuid": "70bbe380-0356-4d91-98ea-93f40c66638d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -9437,9 +10303,11 @@
     "uuid": "ccfed193-e366-4b13-806c-0cc18e2a87b4",
     "set_uuid": "a3d53327-385a-44c0-a2ee-266cef172810",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -9453,9 +10321,11 @@
     "uuid": "f84569c5-bb63-4eb1-8193-1130e88e7e5b",
     "set_uuid": "a3d53327-385a-44c0-a2ee-266cef172810",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -9469,9 +10339,11 @@
     "uuid": "8fb8ad12-9bb9-417f-8d0d-7323455cfb7a",
     "set_uuid": "acef8bbf-016d-44cc-ab9e-59e5b982d38e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -9485,9 +10357,11 @@
     "uuid": "61e906e3-6daa-4841-b4f0-54939157a50b",
     "set_uuid": "acef8bbf-016d-44cc-ab9e-59e5b982d38e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -9501,9 +10375,11 @@
     "uuid": "fbe45d1b-f4b9-40d1-965f-38abe057dc69",
     "set_uuid": "a2e09127-bc4b-4f6f-bff3-b6c1524733e5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -9517,9 +10393,11 @@
     "uuid": "943a0b43-6c91-40a3-a680-318a934bf6ef",
     "set_uuid": "a2e09127-bc4b-4f6f-bff3-b6c1524733e5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -9534,9 +10412,11 @@
     "uuid": "06a6c13b-2d58-4102-b169-073eed5599e6",
     "set_uuid": "ea52bf43-3e3b-4559-aec3-4f0a02734a95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -9551,9 +10431,11 @@
     "uuid": "dfeef197-57b9-41a1-b759-3c782a64f2f3",
     "set_uuid": "ea52bf43-3e3b-4559-aec3-4f0a02734a95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -9568,9 +10450,11 @@
     "uuid": "0d468b92-74df-4044-8af3-c867eebbf370",
     "set_uuid": "1df536f1-c853-4955-9533-8c9371fc05cc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -9585,9 +10469,11 @@
     "uuid": "64b2f613-35b2-46a8-be7d-c39c314840b9",
     "set_uuid": "1df536f1-c853-4955-9533-8c9371fc05cc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -9602,9 +10488,11 @@
     "uuid": "f71c4487-3c1e-4204-b631-b0658a6b5e12",
     "set_uuid": "57fe1e26-77a9-4d8a-ab54-a6f16dc9c5fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -9619,9 +10507,11 @@
     "uuid": "62815f67-4e23-43f9-93d2-f29d1688cddf",
     "set_uuid": "57fe1e26-77a9-4d8a-ab54-a6f16dc9c5fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -9636,9 +10526,11 @@
     "uuid": "456d5283-eb93-4b8d-b796-7f181ebcec04",
     "set_uuid": "f81ebf2a-300e-4bc8-89e0-baec8fc07ee4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -9653,9 +10545,11 @@
     "uuid": "af422766-3185-47d6-adba-31b1e97b92d9",
     "set_uuid": "f81ebf2a-300e-4bc8-89e0-baec8fc07ee4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -9668,9 +10562,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "c9e46b75-f1d8-4b19-a258-b8b0a0e66484",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-extra-large instead.",
-    "replaced_by": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-extra-large instead.",
+      "replacedBy": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb"
+    }
   },
   {
     "name": {
@@ -9683,9 +10579,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "2899d6e1-acad-453b-ad65-1e6a6e380363",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-large instead.",
-    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-large instead.",
+      "replacedBy": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    }
   },
   {
     "name": {
@@ -9698,9 +10596,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
     "uuid": "4211feff-12af-4288-b86d-4c66a5a55b8f",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-medium instead.",
-    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-medium instead.",
+      "replacedBy": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    }
   },
   {
     "name": {
@@ -9713,9 +10613,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
     "uuid": "ac039575-7c1f-4733-a310-b39cebf83b82",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-small instead.",
-    "replaced_by": "d61248dc-0a2d-469d-a81f-0417e0bb5de2"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-small instead.",
+      "replacedBy": "d61248dc-0a2d-469d-a81f-0417e0bb5de2"
+    }
   },
   {
     "name": {
@@ -9726,12 +10628,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ceeda4da-026b-496c-8abd-7081aceae262",
     "uuid": "2633d29d-8a14-48e8-977c-bdb9a53b3bd5",
-    "deprecated": "unknown",
-    "deprecated_comment": "Token renamed, use `meter-width`",
-    "replaced_by": [
-      "ceeda4da-026b-496c-8abd-7081aceae262",
-      "dc5f4966-4ddd-4e9a-a748-370d8eaae568"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "12.18.0",
+      "deprecatedComment": "Token renamed, use `meter-width`",
+      "replacedBy": [
+        "ceeda4da-026b-496c-8abd-7081aceae262",
+        "dc5f4966-4ddd-4e9a-a748-370d8eaae568"
+      ]
+    }
   },
   {
     "name": {
@@ -9902,9 +10806,11 @@
     "uuid": "54f47bf6-78cc-409a-a83e-15f36404d548",
     "set_uuid": "ebfdcbb4-c3e3-4c68-859e-09b1e01c4005",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead.",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead.",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -9920,9 +10826,11 @@
     "uuid": "777f9750-cfea-4eb3-ae08-a18c2fbde315",
     "set_uuid": "ebfdcbb4-c3e3-4c68-859e-09b1e01c4005",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead.",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead.",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -9938,9 +10846,11 @@
     "uuid": "e041ee57-b8be-4c7e-a13d-ec2e2be05504",
     "set_uuid": "ed452e2a-eded-4035-87fe-d1c120a4de8e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead.",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -9956,9 +10866,11 @@
     "uuid": "136a2c42-1868-4343-903d-9e7fbf345d45",
     "set_uuid": "ed452e2a-eded-4035-87fe-d1c120a4de8e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead.",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -9974,9 +10886,11 @@
     "uuid": "2d2b2029-37ff-4563-a404-1347492ca7db",
     "set_uuid": "fefd5395-dee0-49a6-b5f8-0e2ef2282828",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -9992,9 +10906,11 @@
     "uuid": "83dd3160-a826-4fa2-b643-a6f11533ba45",
     "set_uuid": "fefd5395-dee0-49a6-b5f8-0e2ef2282828",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -10010,9 +10926,11 @@
     "uuid": "1b494a23-b312-43e2-8148-0d86777c38d4",
     "set_uuid": "f750781f-5fb2-4578-bf33-95c85bbf469a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -10028,9 +10946,11 @@
     "uuid": "1e55a991-6d8f-4fc1-9dc7-91f86be50e3f",
     "set_uuid": "f750781f-5fb2-4578-bf33-95c85bbf469a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -10164,9 +11084,11 @@
     "uuid": "9ddf2e73-ad74-46d7-a79d-fe961b06dbbd",
     "set_uuid": "d847973c-89b2-4454-9dd8-44fb671e9408",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use opacity-checkerboard-square-size-medium instead.",
-    "replaced_by": "ead3f34f-55b1-4012-a4af-0f7fbf226020"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.21",
+      "deprecatedComment": "This token has been deprecated, use opacity-checkerboard-square-size-medium instead.",
+      "replacedBy": "ead3f34f-55b1-4012-a4af-0f7fbf226020"
+    }
   },
   {
     "name": {
@@ -10180,9 +11102,11 @@
     "uuid": "879360e9-a7b0-47e0-bc4a-931a12877014",
     "set_uuid": "d847973c-89b2-4454-9dd8-44fb671e9408",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use opacity-checkerboard-square-size-medium instead.",
-    "replaced_by": "cc6fdec6-c03a-4691-805f-b60d199bb60d"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.21",
+      "deprecatedComment": "This token has been deprecated, use opacity-checkerboard-square-size-medium instead.",
+      "replacedBy": "cc6fdec6-c03a-4691-805f-b60d199bb60d"
+    }
   },
   {
     "name": {
@@ -10262,8 +11186,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "03da68d8-cd87-4e29-9aaf-ab467594ec2b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -10274,9 +11200,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03da68d8-cd87-4e29-9aaf-ab467594ec2b",
     "uuid": "c8bd227d-c72b-4f6a-9d93-0b595821dee0",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use `picker-end-edge-to-disclosure-icon-quiet` instead",
-    "replaced_by": "03da68d8-cd87-4e29-9aaf-ab467594ec2b"
+    "lifecycle": {
+      "deprecatedIn": "12.11.0",
+      "deprecatedComment": "Use `picker-end-edge-to-disclosure-icon-quiet` instead",
+      "replacedBy": "03da68d8-cd87-4e29-9aaf-ab467594ec2b"
+    }
   },
   {
     "name": {
@@ -10301,9 +11229,11 @@
     "uuid": "de09427a-eef3-4360-a912-0b0d5602d4a4",
     "set_uuid": "e23401b3-8651-4e03-8be3-380e09670ccc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -10319,9 +11249,11 @@
     "uuid": "0ac097c8-020e-4a7b-b692-59dfdf07e3f8",
     "set_uuid": "e23401b3-8651-4e03-8be3-380e09670ccc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -10337,9 +11269,11 @@
     "uuid": "2f22005b-305b-4629-bc03-10d81e36ce78",
     "set_uuid": "ea7d1bf8-6182-441c-8ffd-046980a2e7b1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -10355,9 +11289,11 @@
     "uuid": "47f5a27f-4039-4668-bb21-aafb9dcb82fb",
     "set_uuid": "ea7d1bf8-6182-441c-8ffd-046980a2e7b1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -10373,9 +11309,11 @@
     "uuid": "f83b0313-ba78-4c98-be6e-702b58956589",
     "set_uuid": "bb6e5e38-eb54-464a-a94a-00be04263d2a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -10391,9 +11329,11 @@
     "uuid": "c620ab2b-256d-409a-a80c-7d7c2295efc8",
     "set_uuid": "bb6e5e38-eb54-464a-a94a-00be04263d2a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -10409,9 +11349,11 @@
     "uuid": "4bcebd07-28a8-401d-9072-3b2ac22e8b63",
     "set_uuid": "6b3db559-9077-45a2-9e7c-993833799c0a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -10427,9 +11369,11 @@
     "uuid": "269725c9-3462-4132-8487-95dd61814448",
     "set_uuid": "6b3db559-9077-45a2-9e7c-993833799c0a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -10441,9 +11385,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "2a3bd47e-fde5-41d3-a585-f970bdefaf07",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-padding instead.",
-    "replaced_by": "c872da51-317e-44cf-aef8-2f5f9fb77ae8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-padding instead.",
+      "replacedBy": "c872da51-317e-44cf-aef8-2f5f9fb77ae8"
+    }
   },
   {
     "name": {
@@ -10475,9 +11421,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2a3bd47e-fde5-41d3-a585-f970bdefaf07",
     "uuid": "f97488e8-b1c1-442e-b98c-0ae6cff0b774",
-    "deprecated": "unknown",
-    "deprecated_comment": "Introduced as an error. Use popover-edge-to-content-area instead",
-    "replaced_by": "2a3bd47e-fde5-41d3-a585-f970bdefaf07"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.34",
+      "deprecatedComment": "Introduced as an error. Use popover-edge-to-content-area instead",
+      "replacedBy": "2a3bd47e-fde5-41d3-a585-f970bdefaf07"
+    }
   },
   {
     "name": {
@@ -10895,9 +11843,11 @@
     "uuid": "f4620f0a-43ba-4650-8640-9425ed1a1260",
     "set_uuid": "77bbc887-ee2d-4a6c-8a1b-6a6b9cd6a2fd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -10913,9 +11863,11 @@
     "uuid": "c478710f-1747-455b-998a-6fa837762905",
     "set_uuid": "77bbc887-ee2d-4a6c-8a1b-6a6b9cd6a2fd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -10931,9 +11883,11 @@
     "uuid": "309c9559-1763-4345-8090-aaa12f570889",
     "set_uuid": "b99d260c-1bc7-4e0e-96be-bdfe4592829d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -10949,9 +11903,11 @@
     "uuid": "41d0dde7-de34-4e99-96d0-4f727ed71673",
     "set_uuid": "b99d260c-1bc7-4e0e-96be-bdfe4592829d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -10967,9 +11923,11 @@
     "uuid": "dcc0155a-6bd1-4148-acaf-e255a7f4d22a",
     "set_uuid": "a7ff453c-7241-406a-a682-c7d841c66134",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -10985,9 +11943,11 @@
     "uuid": "2f805530-cefe-420a-89e6-a6a81c0faea0",
     "set_uuid": "a7ff453c-7241-406a-a682-c7d841c66134",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11003,9 +11963,11 @@
     "uuid": "b775d7e9-d182-4818-9ae0-b3765a0ecbf7",
     "set_uuid": "1f228973-43d9-46f2-a3c6-9d4074d49bb3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -11021,9 +11983,11 @@
     "uuid": "02438c4c-161d-45eb-935d-b083ab830876",
     "set_uuid": "1f228973-43d9-46f2-a3c6-9d4074d49bb3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -11036,9 +12000,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "897117a7-4e29-4fc2-85b4-1b2aa882ff7b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11051,9 +12017,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "360ab235-93bf-482c-9ff1-387d69f018e1",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -11066,9 +12034,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "888c8501-b709-4b72-9d19-504e3b0befb4",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11081,9 +12051,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "a2ad2062-a115-4abb-859b-f9d307b44744",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -11118,7 +12090,9 @@
     "uuid": "b132d948-bec9-4a29-b281-e77801ce5a7c",
     "set_uuid": "56769fc6-5bf3-418e-a424-e3a079e2428b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -11133,7 +12107,9 @@
     "uuid": "8e13ea1d-8000-485e-8700-5522cc71b95c",
     "set_uuid": "56769fc6-5bf3-418e-a424-e3a079e2428b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -11147,7 +12123,9 @@
     "uuid": "f0958cee-9688-43db-9542-1aef164f9dfe",
     "set_uuid": "2716ef49-9896-4451-a7c2-e0dce18ead18",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -11161,7 +12139,9 @@
     "uuid": "dce9ff1e-06d1-49a5-817f-5319f4ab15e2",
     "set_uuid": "2716ef49-9896-4451-a7c2-e0dce18ead18",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -11174,9 +12154,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "6b99f788-336d-4159-819e-29050f8b571a",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11189,9 +12171,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "8cf415d3-57f2-41c6-a175-40c75b58a79e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -11261,8 +12245,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "9e790995-7d43-4ce2-8ac0-a1c79c607575",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -11284,9 +12270,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "70a20970-ebd9-48a7-8324-44d352f79978",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-small instead.",
-    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-small instead.",
+      "replacedBy": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+    }
   },
   {
     "name": {
@@ -11300,9 +12288,11 @@
     "uuid": "a99ea589-33e4-4196-8c49-77a0d0d522ed",
     "set_uuid": "26032430-2ed5-430c-aff0-63655b5b82fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-2x-large instead.",
-    "replaced_by": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-2x-large instead.",
+      "replacedBy": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412"
+    }
   },
   {
     "name": {
@@ -11316,9 +12306,11 @@
     "uuid": "9c78208b-bb4f-4cda-82f0-a38f68d33172",
     "set_uuid": "26032430-2ed5-430c-aff0-63655b5b82fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-2x-large instead.",
-    "replaced_by": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-2x-large instead.",
+      "replacedBy": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412"
+    }
   },
   {
     "name": {
@@ -11332,9 +12324,11 @@
     "uuid": "b98f3e7a-d30a-49f7-80fd-d793554eaf6d",
     "set_uuid": "e8e1494d-f8da-42f8-a4d7-cb0e4e967982",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-small instead.",
-    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-small instead.",
+      "replacedBy": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    }
   },
   {
     "name": {
@@ -11348,9 +12342,11 @@
     "uuid": "6c8580ac-c2c4-4d62-8a9d-b0498dd0b69b",
     "set_uuid": "e8e1494d-f8da-42f8-a4d7-cb0e4e967982",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-small instead.",
-    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-small instead.",
+      "replacedBy": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    }
   },
   {
     "name": {
@@ -11364,9 +12360,11 @@
     "uuid": "94b742aa-bec9-43bc-81ad-a913191481d1",
     "set_uuid": "2eec83d8-6239-46b6-9324-2b008aff7133",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-large instead.",
-    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-large instead.",
+      "replacedBy": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    }
   },
   {
     "name": {
@@ -11380,9 +12378,11 @@
     "uuid": "255479ac-24f5-4128-bba0-258ec68026af",
     "set_uuid": "2eec83d8-6239-46b6-9324-2b008aff7133",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-large instead.",
-    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-large instead.",
+      "replacedBy": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+    }
   },
   {
     "name": {
@@ -11448,9 +12448,11 @@
     "uuid": "9ab0ef93-1293-48e9-911c-2ea32f15b44b",
     "set_uuid": "e24d7c1a-4fbd-44ac-9660-ff617d011a1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -11464,9 +12466,11 @@
     "uuid": "009afde4-ea54-4025-aaa0-7df7e5e50229",
     "set_uuid": "e24d7c1a-4fbd-44ac-9660-ff617d011a1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -11480,9 +12484,11 @@
     "uuid": "736900ff-ea3c-4c5b-85b6-080524cb78fc",
     "set_uuid": "560ccf4a-7060-4c66-9d12-03ac082c93c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -11496,9 +12502,11 @@
     "uuid": "75f16efb-6905-4091-bd87-bd08494a92bf",
     "set_uuid": "560ccf4a-7060-4c66-9d12-03ac082c93c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-medium instead.",
-    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-medium instead.",
+      "replacedBy": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+    }
   },
   {
     "name": {
@@ -11539,9 +12547,11 @@
     "uuid": "237b6422-31fd-4729-98f1-451b7bd27a4d",
     "set_uuid": "3a8c21e6-ba80-4ab6-b8e9-d34ac424ced6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead. Should actually be 12 when checkbox component's vertical padding removed as it should be in this scenario",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead. Should actually be 12 when checkbox component's vertical padding removed as it should be in this scenario",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -11556,9 +12566,11 @@
     "uuid": "011f2ccf-b2fb-4da8-94c4-29fc0a5b9a71",
     "set_uuid": "3a8c21e6-ba80-4ab6-b8e9-d34ac424ced6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-small instead. Should actually be 12 when checkbox component's vertical padding removed as it should be in this scenario",
-    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-small instead. Should actually be 12 when checkbox component's vertical padding removed as it should be in this scenario",
+      "replacedBy": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+    }
   },
   {
     "name": {
@@ -11572,9 +12584,11 @@
     "uuid": "ef9b9dd4-5e45-4c1a-8874-f097fd892352",
     "set_uuid": "db90cd08-a4fe-46d0-9282-16f6fdfdbd5f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -11588,9 +12602,11 @@
     "uuid": "e807df92-1c13-4394-ace9-cb998ada9395",
     "set_uuid": "db90cd08-a4fe-46d0-9282-16f6fdfdbd5f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
-    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-extra-large instead.",
+      "replacedBy": "2e855806-0f65-4df0-9d8f-74428daa358d"
+    }
   },
   {
     "name": {
@@ -11630,9 +12646,11 @@
     "uuid": "f6a52618-bf5d-4a9d-ac95-e5a6d002851d",
     "set_uuid": "30ed63ea-dc66-40b6-8d63-8ef2ec7e5b48",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-small instead.",
-    "replaced_by": "9c79efdc-ab56-4f2e-b44d-5641d2480964"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-small instead.",
+      "replacedBy": "9c79efdc-ab56-4f2e-b44d-5641d2480964"
+    }
   },
   {
     "name": {
@@ -11646,9 +12664,11 @@
     "uuid": "8a805540-3b26-4b50-8a0d-0c7beb13885e",
     "set_uuid": "30ed63ea-dc66-40b6-8d63-8ef2ec7e5b48",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-small instead.",
-    "replaced_by": "9c79efdc-ab56-4f2e-b44d-5641d2480964"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-small instead.",
+      "replacedBy": "9c79efdc-ab56-4f2e-b44d-5641d2480964"
+    }
   },
   {
     "name": {
@@ -11663,9 +12683,11 @@
     "uuid": "8751d85d-a325-4e4e-a7b2-0a3ca94b6b6e",
     "set_uuid": "4647e408-e2c8-417b-94dc-1fe44ef91fe2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11680,9 +12702,11 @@
     "uuid": "e3f49e5e-f9ec-485c-846e-7a8fda08caea",
     "set_uuid": "4647e408-e2c8-417b-94dc-1fe44ef91fe2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11697,9 +12721,11 @@
     "uuid": "fe5071ea-bcff-4a7b-ade8-16850426ac30",
     "set_uuid": "8d6fedf3-e99a-410a-90b4-468c4d7ad275",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -11714,9 +12740,11 @@
     "uuid": "ce76b010-6554-4cfd-993f-9963aa15830e",
     "set_uuid": "8d6fedf3-e99a-410a-90b4-468c4d7ad275",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -11731,9 +12759,11 @@
     "uuid": "cb89bc11-246a-4824-afa3-68076c56f3d9",
     "set_uuid": "b87a907f-3c16-4f57-9a23-3e38aa8287ae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -11748,9 +12778,11 @@
     "uuid": "a1ae3448-227c-4277-9bab-f0147eff02e9",
     "set_uuid": "b87a907f-3c16-4f57-9a23-3e38aa8287ae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -11765,9 +12797,11 @@
     "uuid": "423b5520-bb29-4179-9145-67305ca75b75",
     "set_uuid": "ea95e13b-1da3-4720-b01b-1e121b6acb59",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11782,9 +12816,11 @@
     "uuid": "ad959938-ad69-4137-91e4-fcf2465b223a",
     "set_uuid": "ea95e13b-1da3-4720-b01b-1e121b6acb59",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -11836,9 +12872,11 @@
     "uuid": "436f98c0-ec74-40ab-9a26-a8fe8d139329",
     "set_uuid": "5bd0f57a-50af-40b4-89f8-43a9678ffa52",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead. If using base padding horizontal, this would be 7",
-    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-uniform-medium instead. If using base padding horizontal, this would be 7",
+      "replacedBy": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    }
   },
   {
     "name": {
@@ -11853,9 +12891,11 @@
     "uuid": "37ba411c-9067-46b0-b757-8348f4cf9aab",
     "set_uuid": "5bd0f57a-50af-40b4-89f8-43a9678ffa52",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead. If using base padding horizontal, this would be 7",
-    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-uniform-medium instead. If using base padding horizontal, this would be 7",
+      "replacedBy": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    }
   },
   {
     "name": {
@@ -11870,9 +12910,11 @@
     "uuid": "c5de72a2-931a-429d-ba85-5aaf2e30fbc4",
     "set_uuid": "3aeb1d76-ba81-4f10-b5fe-fc3c8e40145c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
-    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-large instead.",
+      "replacedBy": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    }
   },
   {
     "name": {
@@ -11887,9 +12929,11 @@
     "uuid": "0f3821f1-6f0e-4325-bfa7-e572768fd468",
     "set_uuid": "3aeb1d76-ba81-4f10-b5fe-fc3c8e40145c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
-    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-large instead.",
+      "replacedBy": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    }
   },
   {
     "name": {
@@ -11904,9 +12948,11 @@
     "uuid": "47e687e4-c458-4e0b-bd02-7698cc14983b",
     "set_uuid": "43e16db0-e78e-4a13-8b64-92d46ede1a9e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -11921,9 +12967,11 @@
     "uuid": "be37c65c-88c5-48cd-9554-8240909db98d",
     "set_uuid": "43e16db0-e78e-4a13-8b64-92d46ede1a9e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -11936,7 +12984,9 @@
     "uuid": "68210b40-f87e-4059-88c1-e66d1c8cbd38",
     "set_uuid": "771e5a13-6af2-46f9-b850-25e81e2e2c4a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.16.0"
+    }
   },
   {
     "name": {
@@ -11949,7 +12999,9 @@
     "uuid": "bcb163a0-0156-4e2e-abfe-b2ac0158f348",
     "set_uuid": "771e5a13-6af2-46f9-b850-25e81e2e2c4a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.16.0"
+    }
   },
   {
     "name": {
@@ -11987,9 +13039,11 @@
     "uuid": "e44d5d55-8fc5-4231-ab37-0c06edd06d2c",
     "set_uuid": "708b50f4-cbb7-4af3-99bc-f2a006422ee2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12003,9 +13057,11 @@
     "uuid": "87377ada-4ebf-4a45-b651-35ee1f94e73b",
     "set_uuid": "708b50f4-cbb7-4af3-99bc-f2a006422ee2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12019,9 +13075,11 @@
     "uuid": "2e5df819-ac9e-4b09-bdf6-8b1fe751c8fb",
     "set_uuid": "aedf6dad-a2d8-4c1b-aa3e-51060d22835f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead.",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead.",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12035,9 +13093,11 @@
     "uuid": "e77cde34-8f77-4fd1-a1f7-aa6738130902",
     "set_uuid": "aedf6dad-a2d8-4c1b-aa3e-51060d22835f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead.",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead.",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12051,9 +13111,11 @@
     "uuid": "c1a8c779-aacf-4b14-8b15-9734deafcc41",
     "set_uuid": "0e0bc57b-9deb-4e27-aba6-db5dc7bcbb65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-second-level-edge-to-indicator. Refactor may be needed",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-second-level-edge-to-indicator. Refactor may be needed",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12067,9 +13129,11 @@
     "uuid": "b76c6a5c-23c1-4cf1-8bbb-baca46b3b497",
     "set_uuid": "0e0bc57b-9deb-4e27-aba6-db5dc7bcbb65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-second-level-edge-to-indicator. Refactor may be needed",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-second-level-edge-to-indicator. Refactor may be needed",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12083,9 +13147,11 @@
     "uuid": "7ba0524c-cfef-47fd-b3df-2c71e5618d20",
     "set_uuid": "e09f8f4b-9384-49ad-88e9-f8b3fc966b1e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12099,9 +13165,11 @@
     "uuid": "17ae8b85-c5d2-47c0-810a-c99c91735d3e",
     "set_uuid": "e09f8f4b-9384-49ad-88e9-f8b3fc966b1e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12115,9 +13183,11 @@
     "uuid": "aaf6af3d-4d94-4559-880e-c6201a4f72a7",
     "set_uuid": "5a69662d-fd28-43ac-b3c9-99ae2aad79d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12131,9 +13201,11 @@
     "uuid": "650a896e-c67d-427b-950c-88cfc1099406",
     "set_uuid": "5a69662d-fd28-43ac-b3c9-99ae2aad79d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12147,9 +13219,11 @@
     "uuid": "adfe198d-a39b-47a1-bfa4-77dd0d139803",
     "set_uuid": "36b92445-279d-4553-b000-730127f09f3d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead.",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead.",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12163,9 +13237,11 @@
     "uuid": "06140452-b779-4527-ae3a-5f0623a6b97c",
     "set_uuid": "36b92445-279d-4553-b000-730127f09f3d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead.",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead.",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12179,9 +13255,11 @@
     "uuid": "0c3ad7a1-6e2d-4e34-874e-45a654884650",
     "set_uuid": "e990d96a-cf34-4e09-bf51-4f8179b18df7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-third-level-edge-to-indicator. Refactor may be needed",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-third-level-edge-to-indicator. Refactor may be needed",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12195,9 +13273,11 @@
     "uuid": "2216f8c3-43e1-47ef-aaad-20b0c9bf0f17",
     "set_uuid": "e990d96a-cf34-4e09-bf51-4f8179b18df7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-third-level-edge-to-indicator. Refactor may be needed",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-third-level-edge-to-indicator. Refactor may be needed",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12211,9 +13291,11 @@
     "uuid": "7103cb49-859e-4376-8422-0e2a94b5d2d9",
     "set_uuid": "50359a00-5714-4f4f-accc-b9debc6de08f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12227,9 +13309,11 @@
     "uuid": "811bd0a1-ed6a-4238-a194-c7709a1691ed",
     "set_uuid": "50359a00-5714-4f4f-accc-b9debc6de08f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
-    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-large instead. Refactor may be needed",
+      "replacedBy": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+    }
   },
   {
     "name": {
@@ -12244,9 +13328,11 @@
     "uuid": "37969411-2beb-4038-bdee-d2a84398ef19",
     "set_uuid": "4d352b4a-afeb-4435-a485-0bda4ecd6d1c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Refactor may be needed",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead. Refactor may be needed",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -12261,9 +13347,11 @@
     "uuid": "f52fe067-f989-4f43-a762-1ea453fa0dde",
     "set_uuid": "4d352b4a-afeb-4435-a485-0bda4ecd6d1c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Refactor may be needed",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead. Refactor may be needed",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -12301,9 +13389,11 @@
     "uuid": "d254c910-2939-48ce-8547-08cfb346a0db",
     "set_uuid": "54cd1b31-fdef-4b15-a236-eb18e8468a65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead.",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "13.16.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead.",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12317,9 +13407,11 @@
     "uuid": "7d4cd9bd-bfaf-4ad7-9c3b-19f7913f0825",
     "set_uuid": "54cd1b31-fdef-4b15-a236-eb18e8468a65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead.",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "13.16.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead.",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12333,9 +13425,11 @@
     "uuid": "f1d90f18-e114-477f-88ca-548c5ddbc287",
     "set_uuid": "ea2417cb-8f92-44ef-9f0c-00046c43fc69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead.",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "13.16.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead.",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12349,9 +13443,11 @@
     "uuid": "f82ab001-808a-4528-bf4a-be27645a28fc",
     "set_uuid": "ea2417cb-8f92-44ef-9f0c-00046c43fc69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead.",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "13.16.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead.",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -12389,7 +13485,9 @@
     "uuid": "155b6273-1661-4ef5-85c0-a1688ce1ee72",
     "set_uuid": "160794db-05e4-4305-a353-326e62f23f9c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12405,7 +13503,9 @@
     "uuid": "e04d9975-4a54-416b-b5fa-87f3ae930204",
     "set_uuid": "160794db-05e4-4305-a353-326e62f23f9c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12421,7 +13521,9 @@
     "uuid": "be9aed61-c7a1-4dce-80a7-07c9ecef1fd9",
     "set_uuid": "cffd4d17-8e02-43d6-bd96-570af44e198f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12437,7 +13539,9 @@
     "uuid": "3915ff73-11dd-4389-8d81-2f540ab060f4",
     "set_uuid": "cffd4d17-8e02-43d6-bd96-570af44e198f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12453,7 +13557,9 @@
     "uuid": "238ebdc2-e51c-459d-8cc7-abfeafed6451",
     "set_uuid": "ce8bf0ee-4fa1-4bdc-9b1d-cb9201e7b842",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12469,7 +13575,9 @@
     "uuid": "5030babb-0017-4784-84ad-d3aaacf6fa05",
     "set_uuid": "ce8bf0ee-4fa1-4bdc-9b1d-cb9201e7b842",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12485,7 +13593,9 @@
     "uuid": "bf2e4550-f97e-4bd2-91e8-b0ddb5a8abe2",
     "set_uuid": "2c1d7793-70e8-4178-9504-a169c2266d7a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12501,7 +13611,9 @@
     "uuid": "3b96ab4f-6628-4ebd-aba8-2837fce04709",
     "set_uuid": "2c1d7793-70e8-4178-9504-a169c2266d7a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12516,7 +13628,9 @@
     "uuid": "fd74d5a5-b966-4d26-abca-58c7a21f8136",
     "set_uuid": "c5945975-ac1d-4475-9b95-b69a2dd08082",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12531,7 +13645,9 @@
     "uuid": "c5d47ebf-c83f-43c3-b2f2-f4d51c40960b",
     "set_uuid": "c5945975-ac1d-4475-9b95-b69a2dd08082",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12546,7 +13662,9 @@
     "uuid": "320abda8-9fe8-4f78-87d6-3f1be921e880",
     "set_uuid": "63f8f04e-7512-4b56-9ac1-9bc8a1240202",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12561,7 +13679,9 @@
     "uuid": "0926d8f3-bdd6-4dde-89d0-6d5d7ab9f094",
     "set_uuid": "63f8f04e-7512-4b56-9ac1-9bc8a1240202",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12576,7 +13696,9 @@
     "uuid": "dd3b649d-12f8-427b-95a6-a4964d92d3b0",
     "set_uuid": "b4676e41-d9a7-4cf1-bc24-acb21e96f365",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12591,7 +13713,9 @@
     "uuid": "7306fc00-67fd-4ccd-aec3-7a14e092da5e",
     "set_uuid": "b4676e41-d9a7-4cf1-bc24-acb21e96f365",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12606,7 +13730,9 @@
     "uuid": "cf748652-099a-4022-ae68-0e5dcb8eff9b",
     "set_uuid": "b567a911-c356-4ed3-8d1f-b8698285a8cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12621,7 +13747,9 @@
     "uuid": "19adc707-4fc6-40f0-a972-340d6c935908",
     "set_uuid": "b567a911-c356-4ed3-8d1f-b8698285a8cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -12635,8 +13763,10 @@
     "uuid": "e82d0719-2d65-438f-a9a6-f61c80a80376",
     "set_uuid": "c94e3a1b-71a8-410c-bf8b-38709189103c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12650,8 +13780,10 @@
     "uuid": "23f0c597-a889-4653-8870-df86101fe544",
     "set_uuid": "c94e3a1b-71a8-410c-bf8b-38709189103c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12665,8 +13797,10 @@
     "uuid": "c849ce3c-0e3a-4882-a061-021eed8d55d8",
     "set_uuid": "e34d5351-83c3-43b6-b45c-5cef8853b5f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12680,8 +13814,10 @@
     "uuid": "657325f5-74e4-4d39-8ba4-f480c141da79",
     "set_uuid": "e34d5351-83c3-43b6-b45c-5cef8853b5f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12695,8 +13831,10 @@
     "uuid": "4cdfa762-9580-4fff-a396-1538666ef8d7",
     "set_uuid": "5c9f93bf-bbe2-4e24-af87-52dee0e0949b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12710,8 +13848,10 @@
     "uuid": "a5326ae9-27b6-450c-b88f-d4b89a06502a",
     "set_uuid": "5c9f93bf-bbe2-4e24-af87-52dee0e0949b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12725,8 +13865,10 @@
     "uuid": "882a70c2-afd4-483a-adf5-5437dd34fcba",
     "set_uuid": "33f78486-04db-4a01-ae1f-29e35cdf83f0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12740,8 +13882,10 @@
     "uuid": "5816b3c6-937c-47b8-9bdd-ebc69224831b",
     "set_uuid": "33f78486-04db-4a01-ae1f-29e35cdf83f0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12757,8 +13901,10 @@
     "uuid": "309b149c-306a-49ee-b14c-a0eb4826e3b1",
     "set_uuid": "0e2532f3-c4d2-4001-9c10-9dc706b66273",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12774,8 +13920,10 @@
     "uuid": "9be47810-7a07-4885-a86d-647f5f36d7e5",
     "set_uuid": "0e2532f3-c4d2-4001-9c10-9dc706b66273",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12791,8 +13939,10 @@
     "uuid": "a4be5828-2176-42e7-97de-1f80e7dc08bb",
     "set_uuid": "9201b712-8203-4653-8f0c-07e489587d35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12808,8 +13958,10 @@
     "uuid": "f4fc7ec7-cc02-4ff4-bd9a-f05f9bd59c1d",
     "set_uuid": "9201b712-8203-4653-8f0c-07e489587d35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12825,8 +13977,10 @@
     "uuid": "b257bf97-d632-4488-a954-57b16bcf18b9",
     "set_uuid": "65cf8114-d8a3-4e9b-8a58-082df40c72fb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12842,8 +13996,10 @@
     "uuid": "20a8d579-038e-4432-b271-8e44b83a9aa1",
     "set_uuid": "65cf8114-d8a3-4e9b-8a58-082df40c72fb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -12857,9 +14013,11 @@
     "uuid": "4dc8268e-42c5-4c3c-a17a-fe0f7227facc",
     "set_uuid": "674b365b-e77b-4c00-ae1a-620725a3d534",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
-    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-large instead.",
+      "replacedBy": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    }
   },
   {
     "name": {
@@ -12873,9 +14031,11 @@
     "uuid": "19036695-7f27-4c08-babc-45226b7bf920",
     "set_uuid": "674b365b-e77b-4c00-ae1a-620725a3d534",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
-    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-large instead.",
+      "replacedBy": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    }
   },
   {
     "name": {
@@ -12889,9 +14049,11 @@
     "uuid": "dff9511c-7b97-4cfb-abff-953be7228e28",
     "set_uuid": "28d7f1c0-ab0c-40c7-9c50-072187407e14",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-large instead.",
-    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-large instead.",
+      "replacedBy": "236385bb-9e50-484c-912d-a71fe33924f4"
+    }
   },
   {
     "name": {
@@ -12905,9 +14067,11 @@
     "uuid": "095779c9-64fc-4a51-8a0a-f8b452fb3650",
     "set_uuid": "28d7f1c0-ab0c-40c7-9c50-072187407e14",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-large instead.",
-    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-large instead.",
+      "replacedBy": "236385bb-9e50-484c-912d-a71fe33924f4"
+    }
   },
   {
     "name": {
@@ -12921,9 +14085,11 @@
     "uuid": "8d294c76-353f-42f0-8aa9-8c489a90ac14",
     "set_uuid": "4496beb8-be60-4c70-a809-de7b1c9df947",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-medium instead.",
-    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-medium instead.",
+      "replacedBy": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    }
   },
   {
     "name": {
@@ -12937,9 +14103,11 @@
     "uuid": "5d470123-0f06-4319-b299-b8f5d80c7c94",
     "set_uuid": "4496beb8-be60-4c70-a809-de7b1c9df947",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-medium instead.",
-    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-medium instead.",
+      "replacedBy": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    }
   },
   {
     "name": {
@@ -12953,9 +14121,11 @@
     "uuid": "2d3a0c09-3f66-42da-8276-a7dabc6c4cd3",
     "set_uuid": "9335b6f7-5faa-4f7d-8fc0-3584cc1a1051",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-small instead.",
-    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-small instead.",
+      "replacedBy": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    }
   },
   {
     "name": {
@@ -12969,9 +14139,11 @@
     "uuid": "31e670e4-2400-4705-a0e8-cef9cbca9869",
     "set_uuid": "9335b6f7-5faa-4f7d-8fc0-3584cc1a1051",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-small instead.",
-    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-small instead.",
+      "replacedBy": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    }
   },
   {
     "name": {
@@ -12987,8 +14159,10 @@
     "uuid": "cbf9c42b-c14e-440d-97ad-3c937c464446",
     "set_uuid": "d46ed9c3-7ac2-461c-b924-bc7eca3ef7a6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -13004,8 +14178,10 @@
     "uuid": "d20768dd-dbf4-48a9-8cc8-3370fa6ef810",
     "set_uuid": "d46ed9c3-7ac2-461c-b924-bc7eca3ef7a6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Refactor required; remove padding from label, no negative margins"
+    }
   },
   {
     "name": {
@@ -13021,9 +14197,11 @@
     "uuid": "6c592cd0-9d00-478c-a001-b7d4f3e851f9",
     "set_uuid": "8da44bc9-d615-4788-996e-92b72cbd26d9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
-    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-large instead.",
+      "replacedBy": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    }
   },
   {
     "name": {
@@ -13039,9 +14217,11 @@
     "uuid": "41601fb4-8571-4e7d-91b1-ea7b69ca8a1d",
     "set_uuid": "8da44bc9-d615-4788-996e-92b72cbd26d9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
-    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-extra-large instead.",
+      "replacedBy": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+    }
   },
   {
     "name": {
@@ -13057,9 +14237,11 @@
     "uuid": "281d3ab8-c760-4240-a349-2b9986eeecfe",
     "set_uuid": "795d22d2-9adb-4a61-8fc8-42102008c0f2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-large instead.",
-    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-large instead.",
+      "replacedBy": "236385bb-9e50-484c-912d-a71fe33924f4"
+    }
   },
   {
     "name": {
@@ -13075,9 +14257,11 @@
     "uuid": "d20985d9-2d46-4744-84a7-21baad0eb8cb",
     "set_uuid": "795d22d2-9adb-4a61-8fc8-42102008c0f2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-large instead.",
-    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-large instead.",
+      "replacedBy": "236385bb-9e50-484c-912d-a71fe33924f4"
+    }
   },
   {
     "name": {
@@ -13093,9 +14277,11 @@
     "uuid": "600b162b-5a37-4c01-9fa2-05df934433cc",
     "set_uuid": "6a333980-ed8f-4a71-9802-92a005dfea15",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-medium instead.",
-    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-medium instead.",
+      "replacedBy": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    }
   },
   {
     "name": {
@@ -13111,9 +14297,11 @@
     "uuid": "a99118fc-9837-4460-b4ae-9c7ffaa20ce0",
     "set_uuid": "6a333980-ed8f-4a71-9802-92a005dfea15",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-medium instead.",
-    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-medium instead.",
+      "replacedBy": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+    }
   },
   {
     "name": {
@@ -13129,9 +14317,11 @@
     "uuid": "52edd5bd-f859-487b-bc89-db09fa523025",
     "set_uuid": "de83abc9-702d-4d6c-a56b-96195d887f26",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-small instead.",
-    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-small instead.",
+      "replacedBy": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    }
   },
   {
     "name": {
@@ -13147,9 +14337,11 @@
     "uuid": "526c8840-b08c-401b-8242-32c1cb574b58",
     "set_uuid": "de83abc9-702d-4d6c-a56b-96195d887f26",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-small instead.",
-    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-small instead.",
+      "replacedBy": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+    }
   },
   {
     "name": {
@@ -13163,7 +14355,9 @@
     "uuid": "47d025e2-0b26-4ebc-9b46-3cd1e470b9bc",
     "set_uuid": "00777225-cee5-4b46-97be-5432eda938c9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13177,7 +14371,9 @@
     "uuid": "feac9f02-b52a-4694-a5d4-4b1930ab4f07",
     "set_uuid": "00777225-cee5-4b46-97be-5432eda938c9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13191,7 +14387,9 @@
     "uuid": "525e7d74-2bc0-48ac-85ca-b07335819a31",
     "set_uuid": "7f87b6dc-6864-4086-a3cf-8372ee0659c4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13205,7 +14403,9 @@
     "uuid": "3bf8805b-b4f7-4d0d-af85-d227d6380539",
     "set_uuid": "7f87b6dc-6864-4086-a3cf-8372ee0659c4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13219,7 +14419,9 @@
     "uuid": "63c65cd6-a2c2-4430-a1e9-cf82ae0a3f25",
     "set_uuid": "8fc235a6-e19a-4463-b097-074f861ce80f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13233,7 +14435,9 @@
     "uuid": "25959ff8-6c2f-4612-8d69-b95bfe485ce4",
     "set_uuid": "8fc235a6-e19a-4463-b097-074f861ce80f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13247,7 +14451,9 @@
     "uuid": "c9b7d8d9-c5ba-4d97-a03b-a214104ede23",
     "set_uuid": "44b4d529-53dd-4013-880e-fd0264644d12",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13261,7 +14467,9 @@
     "uuid": "683fb538-290c-423f-990b-d7134e485f51",
     "set_uuid": "44b4d529-53dd-4013-880e-fd0264644d12",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13302,7 +14510,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
     "uuid": "1a257268-32e9-4c5c-8477-32a724ff1d42",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13517,7 +14727,9 @@
     "uuid": "10ccce0d-5a2c-414e-8055-0be76709c180",
     "set_uuid": "0d284138-77bb-4395-b9b0-bc332634034b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13532,7 +14744,9 @@
     "uuid": "413dc697-1f14-47c8-a7f2-e52254513e6e",
     "set_uuid": "0d284138-77bb-4395-b9b0-bc332634034b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13547,7 +14761,9 @@
     "uuid": "3df3c866-faf0-43db-8c18-f442e7f94822",
     "set_uuid": "701777c1-c3b6-4b1b-87ed-be5575beb236",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13562,7 +14778,9 @@
     "uuid": "2a3fb9b0-d701-4e86-8180-9d81f68e91d5",
     "set_uuid": "701777c1-c3b6-4b1b-87ed-be5575beb236",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13577,7 +14795,9 @@
     "uuid": "a8a02181-c797-461d-a666-a63f7535a096",
     "set_uuid": "b464a520-7d24-4a98-9078-d3ea25b744c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13592,7 +14812,9 @@
     "uuid": "278fc618-f6c1-4d30-bf85-075654079003",
     "set_uuid": "b464a520-7d24-4a98-9078-d3ea25b744c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13607,7 +14829,9 @@
     "uuid": "1384d419-bfad-44d7-847c-a0f2c195fb93",
     "set_uuid": "5dce7d54-6cc0-4c90-8442-a70fc021d217",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13622,7 +14846,9 @@
     "uuid": "7feb3d57-59fb-4095-966e-e8ca0e91442f",
     "set_uuid": "5dce7d54-6cc0-4c90-8442-a70fc021d217",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13685,7 +14911,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "50a71b8b-30fb-40c0-b81e-5ce0dcc8c96b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -13700,9 +14928,11 @@
     "uuid": "3b41366d-2c29-4477-95fa-528c762b8a3b",
     "set_uuid": "566ca7d9-87b6-4e9d-be7c-3740c32d5994",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead.",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -13717,9 +14947,11 @@
     "uuid": "cd7df3af-975e-4d8a-addd-92a920173fd6",
     "set_uuid": "566ca7d9-87b6-4e9d-be7c-3740c32d5994",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead.",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -13734,9 +14966,11 @@
     "uuid": "80800e9d-8b0d-4d1b-adfc-f85faee2bc2f",
     "set_uuid": "35875843-c69e-4c4b-86d7-d4f44e66a9e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead.",
-    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-uniform-medium instead.",
+      "replacedBy": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    }
   },
   {
     "name": {
@@ -13751,9 +14985,11 @@
     "uuid": "ed1689ea-2661-419b-ad18-7877712b0dfa",
     "set_uuid": "35875843-c69e-4c4b-86d7-d4f44e66a9e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead.",
-    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-uniform-medium instead.",
+      "replacedBy": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+    }
   },
   {
     "name": {
@@ -13768,9 +15004,11 @@
     "uuid": "cb302d23-5dd8-4ca6-b104-3fc5f03f633b",
     "set_uuid": "12f099d5-f8cf-4251-94a0-0398e6d463a2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -13785,9 +15023,11 @@
     "uuid": "ef8dc413-ef24-456c-aa91-6a80d107f6c6",
     "set_uuid": "12f099d5-f8cf-4251-94a0-0398e6d463a2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -13802,9 +15042,11 @@
     "uuid": "5405f82f-6022-468c-a150-b74210ef52cb",
     "set_uuid": "1bbe4ff0-1a91-44e3-b992-16c41ad6ef0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -13819,9 +15061,11 @@
     "uuid": "7e743edb-d49b-4750-88b3-e35b6e534a3b",
     "set_uuid": "1bbe4ff0-1a91-44e3-b992-16c41ad6ef0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -13861,8 +15105,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "c030a978-cf5b-4ad0-a3c7-dde81f1bf136",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -13990,9 +15236,11 @@
     "uuid": "abc302a3-c0b5-4f93-a141-39988ca3720b",
     "set_uuid": "745f62b2-d562-4a5a-9a6f-ba01312b29d9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -14007,9 +15255,11 @@
     "uuid": "799fbc36-ea79-44d2-8e8b-dc3aade544a0",
     "set_uuid": "745f62b2-d562-4a5a-9a6f-ba01312b29d9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -14024,9 +15274,11 @@
     "uuid": "e65d0e08-9c29-43f6-b7a2-281865a82b70",
     "set_uuid": "ad4d04dd-77f1-494b-9825-4d0092c54806",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -14041,9 +15293,11 @@
     "uuid": "aaee547c-df72-420e-8d39-3028e79feac1",
     "set_uuid": "ad4d04dd-77f1-494b-9825-4d0092c54806",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -14147,9 +15401,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
     "uuid": "6364d657-804c-4753-832d-09bfdf5ad36a",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14162,9 +15418,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
     "uuid": "f2c9847f-2c3f-4e2e-94ed-59b6cc58f34a",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14177,9 +15435,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
     "uuid": "b9c04337-a6f5-42db-9bf9-a761c0d9f876",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14220,9 +15480,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
     "uuid": "66f385cd-b60b-42dd-bfdc-aba2db6e35a2",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14235,9 +15497,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
     "uuid": "968a056e-4397-4a71-91f1-a0f1ebb6f751",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14250,9 +15514,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
     "uuid": "96572147-20a9-4089-9904-0a0efa42a5af",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14385,9 +15651,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
     "uuid": "752a84f5-cbb7-4d18-85ca-fc913a061bb5",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -14399,9 +15667,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
     "uuid": "d3e53f14-b91e-4d10-8508-17360ae5620e",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -14413,9 +15683,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
     "uuid": "ee780be7-b32c-4da8-a6bc-fc0897799537",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -14427,9 +15699,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
     "uuid": "ea98b9b0-20b5-4f19-aa4f-375559b1362a",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -14445,9 +15719,11 @@
     "uuid": "899c7b7c-7405-4e29-8d42-edf41ca2943f",
     "set_uuid": "2173f265-63f5-442a-8795-693e214db315",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires Dot to be placed in frame of height workflow-icon-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires Dot to be placed in frame of height workflow-icon-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -14463,9 +15739,11 @@
     "uuid": "b351cade-6d69-449e-908a-518793fef5b9",
     "set_uuid": "2173f265-63f5-442a-8795-693e214db315",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires Dot to be placed in frame of height workflow-icon-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires Dot to be placed in frame of height workflow-icon-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -14481,9 +15759,11 @@
     "uuid": "ead22722-10f9-4cfe-a387-65f5d86ca520",
     "set_uuid": "7d47591a-b1a0-4bc9-b024-3cf78e4cf603",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires Dot to be placed in frame of height workflow-icon-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires Dot to be placed in frame of height workflow-icon-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14499,9 +15779,11 @@
     "uuid": "8d9d872f-7c55-4a94-a80d-c1f2c8834f5d",
     "set_uuid": "7d47591a-b1a0-4bc9-b024-3cf78e4cf603",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires Dot to be placed in frame of height workflow-icon-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires Dot to be placed in frame of height workflow-icon-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -14517,9 +15799,11 @@
     "uuid": "e2aa334e-ebb7-4e5f-a735-4f6a43b2d6cf",
     "set_uuid": "cf3e3e4a-3290-4188-8a43-76331c2d0700",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires Dot to be placed in frame of height workflow-icon-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires Dot to be placed in frame of height workflow-icon-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -14535,9 +15819,11 @@
     "uuid": "321a462b-8811-4264-ac1f-4608df8f8c53",
     "set_uuid": "cf3e3e4a-3290-4188-8a43-76331c2d0700",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires Dot to be placed in frame of height workflow-icon-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires Dot to be placed in frame of height workflow-icon-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -14553,9 +15839,11 @@
     "uuid": "ddece3b1-7f85-4c08-b783-5bde8e31f480",
     "set_uuid": "299c2a75-f3d9-4c65-8628-608acbcbdb34",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires Dot to be placed in frame of height workflow-icon-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires Dot to be placed in frame of height workflow-icon-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -14571,9 +15859,11 @@
     "uuid": "a4f43adc-1db1-4e2f-a5d1-3ec06c62c9ff",
     "set_uuid": "299c2a75-f3d9-4c65-8628-608acbcbdb34",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires Dot to be placed in frame of height workflow-icon-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires Dot to be placed in frame of height workflow-icon-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -14585,8 +15875,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
     "uuid": "a52c893c-8c03-43a5-88ed-3cd230365b84",
-    "deprecated": "unknown",
-    "deprecated_comment": "Even noted in design spec; only needed until VF swap"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Even noted in design spec; only needed until VF swap"
+    }
   },
   {
     "name": {
@@ -14815,9 +16107,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "b80ef303-eae7-498f-b172-73a098be0f0b",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-gap-2x-small instead. NOTE: All other swatch gaps need to use these semantics too",
-    "replaced_by": "b83df7f2-8811-4bad-b012-213e430e2aaf"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-gap-2x-small instead. NOTE: All other swatch gaps need to use these semantics too",
+      "replacedBy": "b83df7f2-8811-4bad-b012-213e430e2aaf"
+    }
   },
   {
     "name": {
@@ -15460,9 +16754,11 @@
     "uuid": "fbc21571-970f-4bb2-8280-f6262446896b",
     "set_uuid": "de9a4e67-0d4e-4444-968d-f6d42d93f866",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires switch control to be placed in frame of height workflow-icon-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires switch control to be placed in frame of height workflow-icon-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -15478,9 +16774,11 @@
     "uuid": "7e95ad9a-ca10-4f06-9c19-8dd2270cfdad",
     "set_uuid": "de9a4e67-0d4e-4444-968d-f6d42d93f866",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires switch control to be placed in frame of height workflow-icon-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires switch control to be placed in frame of height workflow-icon-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -15496,9 +16794,11 @@
     "uuid": "f2c965e6-89fb-4b9d-843d-cfde31b7703d",
     "set_uuid": "9a52d174-d050-45ee-af46-858738bd8981",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires switch control to be placed in frame of height workflow-icon-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires switch control to be placed in frame of height workflow-icon-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -15514,9 +16814,11 @@
     "uuid": "035e786b-17f2-488e-a049-84b257a3312f",
     "set_uuid": "9a52d174-d050-45ee-af46-858738bd8981",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires switch control to be placed in frame of height workflow-icon-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires switch control to be placed in frame of height workflow-icon-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -15532,9 +16834,11 @@
     "uuid": "0135b823-5097-43bb-9911-9f731146af3b",
     "set_uuid": "af618934-f995-4bb4-8014-de8f4663adc3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires switch control to be placed in frame of height workflow-icon-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires switch control to be placed in frame of height workflow-icon-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -15550,9 +16854,11 @@
     "uuid": "68276028-41d8-49e1-b0d4-f70cd27ab149",
     "set_uuid": "af618934-f995-4bb4-8014-de8f4663adc3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires switch control to be placed in frame of height workflow-icon-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires switch control to be placed in frame of height workflow-icon-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -15568,9 +16874,11 @@
     "uuid": "8a907825-236c-4548-91c4-2123e095726c",
     "set_uuid": "3434ca1a-5c60-4e2b-83fd-f911b293140b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires switch control to be placed in frame of height workflow-icon-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires switch control to be placed in frame of height workflow-icon-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -15586,9 +16894,11 @@
     "uuid": "f379c453-da21-41f6-92d1-9b6bdb95fd86",
     "set_uuid": "3434ca1a-5c60-4e2b-83fd-f911b293140b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires switch control to be placed in frame of height workflow-icon-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires switch control to be placed in frame of height workflow-icon-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -15603,9 +16913,11 @@
     "uuid": "7e3a0369-fcc2-45d7-87ab-9053588713ef",
     "set_uuid": "adc6e66b-3fc9-4fd7-84ec-ef4494c62774",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -15620,9 +16932,11 @@
     "uuid": "3641ac9c-5610-4996-a55d-c2a94b2ff9ea",
     "set_uuid": "adc6e66b-3fc9-4fd7-84ec-ef4494c62774",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -15637,9 +16951,11 @@
     "uuid": "8e701e0e-4d7c-4d38-ba6b-1fd2ef5978dc",
     "set_uuid": "c3498128-c005-4ee4-915e-eb287caa1041",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -15654,9 +16970,11 @@
     "uuid": "091144b7-c63b-4827-840d-741cec01432a",
     "set_uuid": "c3498128-c005-4ee4-915e-eb287caa1041",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -15671,9 +16989,11 @@
     "uuid": "b44bbd5a-ef03-4e83-a9f5-88c896969d4d",
     "set_uuid": "d4758ee5-0e66-4812-90f3-618775a200e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -15688,9 +17008,11 @@
     "uuid": "e69dee42-92da-4ca9-9eb8-97a7860adaba",
     "set_uuid": "d4758ee5-0e66-4812-90f3-618775a200e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -15705,9 +17027,11 @@
     "uuid": "d87a2ee3-6f7c-4f5e-8191-d35624fc10f1",
     "set_uuid": "4a7ca31f-9087-4865-9a19-669fec8b1e6d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -15722,9 +17046,11 @@
     "uuid": "f453e51e-3d58-430e-8f17-8b95718dbf34",
     "set_uuid": "4a7ca31f-9087-4865-9a19-669fec8b1e6d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -15739,9 +17065,11 @@
     "uuid": "5840c3b8-3488-417b-8b33-f3fc667ffd7a",
     "set_uuid": "60b185b4-b257-47e6-9340-7e1a074a40ea",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15756,9 +17084,11 @@
     "uuid": "c63380d4-cc26-4299-b227-af2faedfdc74",
     "set_uuid": "60b185b4-b257-47e6-9340-7e1a074a40ea",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15773,9 +17103,11 @@
     "uuid": "61dd06ac-501e-4725-9d54-cc7a3d9f6586",
     "set_uuid": "662d4ef9-344e-450f-bd48-0298f111d88a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15790,9 +17122,11 @@
     "uuid": "31d1b6b6-721f-4474-ba86-795367399e49",
     "set_uuid": "662d4ef9-344e-450f-bd48-0298f111d88a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15807,9 +17141,11 @@
     "uuid": "f507e1bd-f08e-42b1-aee6-ea38f9f8a387",
     "set_uuid": "1cb59572-fa95-4bc4-b3b1-bad21a5bc28d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15824,9 +17160,11 @@
     "uuid": "691db84a-5336-4e45-bf73-ee617057e718",
     "set_uuid": "1cb59572-fa95-4bc4-b3b1-bad21a5bc28d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15841,9 +17179,11 @@
     "uuid": "2d0f71e2-66fc-4f28-bd4b-be41df0948ed",
     "set_uuid": "cfdfec23-be3a-4327-9067-60ecf3e9bed6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15858,9 +17198,11 @@
     "uuid": "e0791360-b505-492b-bf71-dfa393abecfa",
     "set_uuid": "cfdfec23-be3a-4327-9067-60ecf3e9bed6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -15927,9 +17269,11 @@
     "uuid": "1f12f9aa-19bd-4f77-93db-d737c0538677",
     "set_uuid": "efaf1230-6cee-4541-89de-e4ae0879cbdc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -15944,9 +17288,11 @@
     "uuid": "6c0aad05-5224-4ade-913a-3dc5ebceeb62",
     "set_uuid": "efaf1230-6cee-4541-89de-e4ae0879cbdc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -15961,9 +17307,11 @@
     "uuid": "6fd78b93-1356-4eb0-9f70-bed00c3eb2aa",
     "set_uuid": "c3865c45-3de0-4ab2-bb81-720c5bff2b41",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -15978,9 +17326,11 @@
     "uuid": "6c4d8c39-9f75-4c75-94e2-274a69a8f556",
     "set_uuid": "c3865c45-3de0-4ab2-bb81-720c5bff2b41",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -15995,9 +17345,11 @@
     "uuid": "cbbaa048-129d-439f-8aae-59153e28216b",
     "set_uuid": "b84c88e4-e5f2-489b-9564-185e3bd4beda",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -16012,9 +17364,11 @@
     "uuid": "09ee234f-a596-47ba-89df-ab9ebc07ded8",
     "set_uuid": "b84c88e4-e5f2-489b-9564-185e3bd4beda",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -16029,9 +17383,11 @@
     "uuid": "d23bdd67-d7d0-42df-9575-61502d3692ab",
     "set_uuid": "352d0f7d-f92e-4ac0-8170-9583107459bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -16046,9 +17402,11 @@
     "uuid": "5fbc924e-e79e-46c6-8544-c92d7f33bc26",
     "set_uuid": "352d0f7d-f92e-4ac0-8170-9583107459bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -16111,9 +17469,11 @@
     "uuid": "a480fffb-0a23-4893-87ce-730eb925a7cc",
     "set_uuid": "b3d0f59e-2e13-4e51-9252-a91a1556de92",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -16128,9 +17488,11 @@
     "uuid": "4e0b2015-06c8-41ab-9e2b-3a332a7625ff",
     "set_uuid": "b3d0f59e-2e13-4e51-9252-a91a1556de92",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -16145,9 +17507,11 @@
     "uuid": "c3f8f94b-d456-4aeb-8340-bd5643efe8fc",
     "set_uuid": "d4258a99-f47a-495c-9f24-b63f19c55c71",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -16162,9 +17526,11 @@
     "uuid": "2c85fa9a-e854-46f6-bc6b-547692d08290",
     "set_uuid": "d4258a99-f47a-495c-9f24-b63f19c55c71",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -16179,9 +17545,11 @@
     "uuid": "4d105a45-7403-47f2-ba50-419d822ff879",
     "set_uuid": "b3abe910-99fc-4f8b-83af-057fd478c2ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -16196,9 +17564,11 @@
     "uuid": "229477d5-e21a-4f4b-a24d-580f0c60eec5",
     "set_uuid": "b3abe910-99fc-4f8b-83af-057fd478c2ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -16210,8 +17580,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "f869f703-a850-4c6c-b518-ec8a1b355046",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -16226,9 +17598,11 @@
     "uuid": "712e62ce-b869-4097-aee1-82e3b7505e14",
     "set_uuid": "52087c63-410d-455b-8e3b-51ab1bd831c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -16243,9 +17617,11 @@
     "uuid": "8d413f56-6634-49c8-8d6a-53d0f57f1bbc",
     "set_uuid": "52087c63-410d-455b-8e3b-51ab1bd831c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -16260,9 +17636,11 @@
     "uuid": "c92ec468-0fac-4e12-b1f8-f22d09cb6c1e",
     "set_uuid": "f1708d11-7b46-45fd-8d39-5c31a65b7e0c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-extra-large instead.",
-    "replaced_by": "0c958750-2c96-453b-9464-f041ac126749"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-extra-large instead.",
+      "replacedBy": "0c958750-2c96-453b-9464-f041ac126749"
+    }
   },
   {
     "name": {
@@ -16277,9 +17655,11 @@
     "uuid": "482ed7f6-ba60-4110-85c8-daf5bf352406",
     "set_uuid": "f1708d11-7b46-45fd-8d39-5c31a65b7e0c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-extra-large instead.",
-    "replaced_by": "0c958750-2c96-453b-9464-f041ac126749"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-extra-large instead.",
+      "replacedBy": "0c958750-2c96-453b-9464-f041ac126749"
+    }
   },
   {
     "name": {
@@ -16294,9 +17674,11 @@
     "uuid": "1f9460a7-2ec0-4353-875c-ee5a6143d00b",
     "set_uuid": "3b8da429-2985-480a-b85b-319f0c458bd1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-large instead.",
-    "replaced_by": "8932b4cf-300f-4377-bbda-7fc02011cd37"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-large instead.",
+      "replacedBy": "8932b4cf-300f-4377-bbda-7fc02011cd37"
+    }
   },
   {
     "name": {
@@ -16311,9 +17693,11 @@
     "uuid": "71bdfd06-4672-464f-b787-9a62137b1763",
     "set_uuid": "3b8da429-2985-480a-b85b-319f0c458bd1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-large instead.",
-    "replaced_by": "8932b4cf-300f-4377-bbda-7fc02011cd37"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-large instead.",
+      "replacedBy": "8932b4cf-300f-4377-bbda-7fc02011cd37"
+    }
   },
   {
     "name": {
@@ -16328,9 +17712,11 @@
     "uuid": "31bea7d1-c8c2-4901-9f18-7a5c936d243f",
     "set_uuid": "ebae14c7-73ca-4f71-9caa-82fde4816b90",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
-    "replaced_by": "7a5f3049-0c20-4ff8-84ea-d161e58546fb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
+      "replacedBy": "7a5f3049-0c20-4ff8-84ea-d161e58546fb"
+    }
   },
   {
     "name": {
@@ -16345,9 +17731,11 @@
     "uuid": "885a7cc3-8873-4cb7-99e7-b17f42fb48f1",
     "set_uuid": "ebae14c7-73ca-4f71-9caa-82fde4816b90",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
-    "replaced_by": "7a5f3049-0c20-4ff8-84ea-d161e58546fb"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
+      "replacedBy": "7a5f3049-0c20-4ff8-84ea-d161e58546fb"
+    }
   },
   {
     "name": {
@@ -16362,9 +17750,11 @@
     "uuid": "79695d07-21cb-4772-b3f7-b2eb56e7ad20",
     "set_uuid": "038f3637-a968-4ccb-bf7e-6dde89677a8b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-small instead.",
-    "replaced_by": "a41aaa58-77af-476e-9050-4f4864c8c3f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-small instead.",
+      "replacedBy": "a41aaa58-77af-476e-9050-4f4864c8c3f9"
+    }
   },
   {
     "name": {
@@ -16379,9 +17769,11 @@
     "uuid": "8b5e1596-f13a-4786-b0c7-f01615423922",
     "set_uuid": "038f3637-a968-4ccb-bf7e-6dde89677a8b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token tab-gap-horizontal-small instead.",
-    "replaced_by": "a41aaa58-77af-476e-9050-4f4864c8c3f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token tab-gap-horizontal-small instead.",
+      "replacedBy": "a41aaa58-77af-476e-9050-4f4864c8c3f9"
+    }
   },
   {
     "name": {
@@ -16396,9 +17788,11 @@
     "uuid": "d74ea722-c146-4ad2-ab20-41c332ae1190",
     "set_uuid": "5ce7dfa6-aa85-4be6-bd22-10ae28c79f71",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16413,9 +17807,11 @@
     "uuid": "ea902ec1-25d5-47c3-896a-a95d9ca5bd62",
     "set_uuid": "5ce7dfa6-aa85-4be6-bd22-10ae28c79f71",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16430,9 +17826,11 @@
     "uuid": "9846992c-e27b-4760-8808-7c44cca2cc65",
     "set_uuid": "b0613cb8-b17d-4c5c-bab9-02153144c284",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16447,9 +17845,11 @@
     "uuid": "c193b2ee-a584-41dc-9ef8-3aebb38fb832",
     "set_uuid": "b0613cb8-b17d-4c5c-bab9-02153144c284",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16464,9 +17864,11 @@
     "uuid": "7cd196c1-18b1-4dae-abf7-7ef1b531e0af",
     "set_uuid": "1579ace5-820f-4b4b-81ed-3b1b8dfc3ae8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16481,9 +17883,11 @@
     "uuid": "6b6c960f-adcf-48b0-8310-ba12b47f4d9a",
     "set_uuid": "1579ace5-820f-4b4b-81ed-3b1b8dfc3ae8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16498,9 +17902,11 @@
     "uuid": "da8211ee-8944-447f-a6df-6a16580e1893",
     "set_uuid": "877ed7ee-8207-4eb3-8412-de9089cd8eae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16515,9 +17921,11 @@
     "uuid": "d51a6c05-67d0-425f-becf-86e783ab3305",
     "set_uuid": "877ed7ee-8207-4eb3-8412-de9089cd8eae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead.",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead.",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -16532,9 +17940,11 @@
     "uuid": "2bdd22cd-93fe-4cf4-a025-e690ecafb50b",
     "set_uuid": "e5a80358-315d-47b0-ad24-c74d9ad8ac98",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -16549,9 +17959,11 @@
     "uuid": "9694ebdc-cc88-4584-89f5-10a2c8de686f",
     "set_uuid": "e5a80358-315d-47b0-ad24-c74d9ad8ac98",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -16566,9 +17978,11 @@
     "uuid": "93af7bac-830c-4460-abe2-0b2d8f786786",
     "set_uuid": "4506ad0b-71e6-4627-b8e8-d6ff00b14e58",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -16583,9 +17997,11 @@
     "uuid": "fd20b444-38ac-4438-a9ef-32474222e45f",
     "set_uuid": "4506ad0b-71e6-4627-b8e8-d6ff00b14e58",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -16600,9 +18016,11 @@
     "uuid": "2481e3a1-302b-46b8-98c2-e9461dd47d0c",
     "set_uuid": "b88d643b-05db-464a-8b71-cd6b682e17e8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -16617,9 +18035,11 @@
     "uuid": "128757b0-d690-4886-95d5-e9df36182a0f",
     "set_uuid": "b88d643b-05db-464a-8b71-cd6b682e17e8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -16634,9 +18054,11 @@
     "uuid": "bbcf3eda-4add-4d0d-b5ae-c2e7078e85ed",
     "set_uuid": "1f2a4336-4d5b-4b39-a163-0a78a39c848c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -16651,9 +18073,11 @@
     "uuid": "d37488c4-d489-45bd-9086-8157c5204ae4",
     "set_uuid": "1f2a4336-4d5b-4b39-a163-0a78a39c848c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -16668,9 +18092,11 @@
     "uuid": "f1b6b932-748d-4b26-9c03-2bd9d0a40ac6",
     "set_uuid": "9a697594-5717-49da-a138-f3c03306082a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -16685,9 +18111,11 @@
     "uuid": "174cc6c8-9c0a-44c0-b6c7-ea6d337c819b",
     "set_uuid": "9a697594-5717-49da-a138-f3c03306082a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -16702,9 +18130,11 @@
     "uuid": "8b9275f5-3e63-459c-97fc-bc03691aa772",
     "set_uuid": "1ad119cf-c6ec-458f-b6d6-16c8432b9c28",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -16719,9 +18149,11 @@
     "uuid": "7e3db5ca-cd32-464b-9a23-9d03e83faa9c",
     "set_uuid": "1ad119cf-c6ec-458f-b6d6-16c8432b9c28",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -16736,9 +18168,11 @@
     "uuid": "e75e4e96-6d1b-4a86-9059-5c1f6f6ab269",
     "set_uuid": "b66ff2e3-edd1-4e73-9446-85f596b6252e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -16753,9 +18187,11 @@
     "uuid": "a8c455e9-60e5-4838-bc9c-eaf7b39a4bf7",
     "set_uuid": "b66ff2e3-edd1-4e73-9446-85f596b6252e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -16770,9 +18206,11 @@
     "uuid": "a9a6d785-f06d-4505-89ea-552d47ebe49d",
     "set_uuid": "1a709fec-7699-4373-83ba-8e8cb6963c5b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -16787,9 +18225,11 @@
     "uuid": "3e155b8c-6cea-4b59-817c-cf71a63e00c7",
     "set_uuid": "1a709fec-7699-4373-83ba-8e8cb6963c5b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -16804,9 +18244,11 @@
     "uuid": "dd4769f3-5c7e-491f-9d01-c80af0b561fb",
     "set_uuid": "863df6bc-a4c3-46f7-80c4-43b3437b37a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -16821,9 +18263,11 @@
     "uuid": "f310e5d7-7435-41a0-b44d-ececff4844f2",
     "set_uuid": "863df6bc-a4c3-46f7-80c4-43b3437b37a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -16838,9 +18282,11 @@
     "uuid": "fab951e5-1a78-4fb4-8c19-677f5f231189",
     "set_uuid": "d7b9e286-1b4e-47ef-a0fa-549f26e89848",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -16855,9 +18301,11 @@
     "uuid": "fad964d8-0020-4583-97ab-7d6565d01bdc",
     "set_uuid": "d7b9e286-1b4e-47ef-a0fa-549f26e89848",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -16872,9 +18320,11 @@
     "uuid": "7788c25c-0ce2-4170-8c5f-2fb1d98d953a",
     "set_uuid": "ae256abb-27d9-4771-9617-e24c722279ab",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -16889,9 +18339,11 @@
     "uuid": "4fb0520b-8c74-4fb7-b279-a3586a06a57e",
     "set_uuid": "ae256abb-27d9-4771-9617-e24c722279ab",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -16906,9 +18358,11 @@
     "uuid": "96c22cdc-aecb-4747-aea9-f140af5ee048",
     "set_uuid": "04cfef16-7bba-4d8f-9270-6334a2473cff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -16923,9 +18377,11 @@
     "uuid": "b79002d2-bcff-4e8d-a406-e512c7e7d0e3",
     "set_uuid": "04cfef16-7bba-4d8f-9270-6334a2473cff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -16940,9 +18396,11 @@
     "uuid": "2c869793-c10b-40ef-9545-45a8a6b4cbb5",
     "set_uuid": "f94bad20-f7c9-4998-822c-b8d20158c4bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -16957,9 +18415,11 @@
     "uuid": "5afa2636-7d4c-4d83-b9fc-3c5a52ee4646",
     "set_uuid": "f94bad20-f7c9-4998-822c-b8d20158c4bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -16974,9 +18434,11 @@
     "uuid": "65e1f735-5f46-4bb3-9c7b-d5f5abab91a1",
     "set_uuid": "8f813787-f636-49e9-94bf-464b291df600",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -16991,9 +18453,11 @@
     "uuid": "4dd99579-949b-4bf9-b022-e8f0c95eae33",
     "set_uuid": "8f813787-f636-49e9-94bf-464b291df600",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -17008,9 +18472,11 @@
     "uuid": "aec60dda-9e5a-40c8-8e45-5e1662eab6e3",
     "set_uuid": "5c4ae90f-f4b7-4f50-9e86-b8711c101c9e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -17025,9 +18491,11 @@
     "uuid": "820baccf-af24-42a3-9729-99408bc9322f",
     "set_uuid": "5c4ae90f-f4b7-4f50-9e86-b8711c101c9e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -17042,9 +18510,11 @@
     "uuid": "7bd7427d-06a8-4194-a9f4-300fd1a4f547",
     "set_uuid": "906995a7-4f9b-4b37-a90f-7f7712aa6f70",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -17059,9 +18529,11 @@
     "uuid": "923fd09d-8d08-4465-961f-63ac12014206",
     "set_uuid": "906995a7-4f9b-4b37-a90f-7f7712aa6f70",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
-    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+      "replacedBy": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+    }
   },
   {
     "name": {
@@ -17088,9 +18560,11 @@
     "uuid": "400553db-907c-43a5-8545-92ba212e12b8",
     "set_uuid": "da9aa4e5-0430-412e-b735-20cc09d5a740",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Erroneous measurement. It includes the padding of a text cell. Needs to be removed or changed",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Erroneous measurement. It includes the padding of a text cell. Needs to be removed or changed",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17105,9 +18579,11 @@
     "uuid": "cb7c89c0-9f31-43c4-8427-2e048f549ff7",
     "set_uuid": "da9aa4e5-0430-412e-b735-20cc09d5a740",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Erroneous measurement. It includes the padding of a text cell. Needs to be removed or changed",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Erroneous measurement. It includes the padding of a text cell. Needs to be removed or changed",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17123,9 +18599,11 @@
     "uuid": "0f76ceee-1d19-4c69-9393-09b02e1eede5",
     "set_uuid": "2e4077b4-2c60-49c6-8b7d-80bb745a01dc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -17141,9 +18619,11 @@
     "uuid": "c8bd103d-d952-4649-a7a0-09ae5242ea17",
     "set_uuid": "2e4077b4-2c60-49c6-8b7d-80bb745a01dc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -17159,9 +18639,11 @@
     "uuid": "fc30c9a8-b098-4edf-b3f4-c666c019b3f4",
     "set_uuid": "b0857d42-73a5-4c93-a831-686a1033cb83",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -17177,9 +18659,11 @@
     "uuid": "e465ee66-392f-469f-a46c-6c98df03b046",
     "set_uuid": "b0857d42-73a5-4c93-a831-686a1033cb83",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -17195,9 +18679,11 @@
     "uuid": "7357ba3f-c707-4475-b616-4752776c06d1",
     "set_uuid": "9214054f-3dae-493e-a45d-b2202caae539",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -17213,9 +18699,11 @@
     "uuid": "631d14a5-1d2e-4e4a-90e8-146e8a397530",
     "set_uuid": "9214054f-3dae-493e-a45d-b2202caae539",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -17231,9 +18719,11 @@
     "uuid": "9388deb6-6a77-49bc-aeb5-9084352c2574",
     "set_uuid": "889c37a4-4036-4048-a0cf-aaab8df8ef75",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -17249,9 +18739,11 @@
     "uuid": "9cf85eae-ec15-4bb0-ba48-00ec946306a5",
     "set_uuid": "889c37a4-4036-4048-a0cf-aaab8df8ef75",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -17267,9 +18759,11 @@
     "uuid": "05d4bb65-357a-4561-ab33-ea6de390a304",
     "set_uuid": "999236d7-31b0-47ab-9b70-62cca87ff4a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -17285,9 +18779,11 @@
     "uuid": "265247a7-bbc3-42b8-910d-946e8d04aee2",
     "set_uuid": "999236d7-31b0-47ab-9b70-62cca87ff4a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -17303,9 +18799,11 @@
     "uuid": "40b7bc07-3252-492a-9ee1-37aceeca3674",
     "set_uuid": "cfd7aa7d-ba00-4989-947b-505d17b6c339",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -17321,9 +18819,11 @@
     "uuid": "a02666d8-4ae2-42d2-b48e-419d5070e7ca",
     "set_uuid": "cfd7aa7d-ba00-4989-947b-505d17b6c339",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -17339,9 +18839,11 @@
     "uuid": "0ec68b5a-4251-4727-a689-b10722ce1a43",
     "set_uuid": "fcdfa773-b92a-4e33-a98a-13e97dd8a7d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -17357,9 +18859,11 @@
     "uuid": "ff3c5329-ccec-4b94-b200-29a377b34380",
     "set_uuid": "fcdfa773-b92a-4e33-a98a-13e97dd8a7d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -17375,9 +18879,11 @@
     "uuid": "de67ada3-eeed-45a2-8d03-91a5b09156ec",
     "set_uuid": "3b59fa13-cd23-460f-94e2-4e91e1d2b791",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -17393,9 +18899,11 @@
     "uuid": "fdc8b7ae-2356-4d49-ba54-0ea471be2986",
     "set_uuid": "3b59fa13-cd23-460f-94e2-4e91e1d2b791",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -17407,9 +18915,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
     "uuid": "5e46672f-eab0-4ec3-bd14-68ffa4404ec1",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead.",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead.",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17425,9 +18935,11 @@
     "uuid": "8adf3d5f-1024-4eb8-8515-f3b6fd7cc22c",
     "set_uuid": "38f190f0-bf31-498c-925e-143c0c5b1af5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -17443,9 +18955,11 @@
     "uuid": "42a78148-e111-4124-a7a6-d9baa2ca963f",
     "set_uuid": "38f190f0-bf31-498c-925e-143c0c5b1af5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -17461,9 +18975,11 @@
     "uuid": "5011ae3c-2e72-4891-926e-8de8847e0a47",
     "set_uuid": "56e2a957-2163-494f-83c0-c5bb904ffb1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -17479,9 +18995,11 @@
     "uuid": "f6648787-3cf1-4af8-aa4f-15669ea1626d",
     "set_uuid": "56e2a957-2163-494f-83c0-c5bb904ffb1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -17497,9 +19015,11 @@
     "uuid": "578765e6-b2ec-4bfe-ae28-f24cbee15898",
     "set_uuid": "833adc4a-4868-429c-adff-13f2dc21a2ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -17515,9 +19035,11 @@
     "uuid": "2e168a2b-46aa-453f-9ca1-746485216c84",
     "set_uuid": "833adc4a-4868-429c-adff-13f2dc21a2ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -17533,9 +19055,11 @@
     "uuid": "370e9149-aaf5-43cd-a783-90cfa8d37419",
     "set_uuid": "3a1f900b-1fc0-4501-b270-aec62b63a0b7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -17551,9 +19075,11 @@
     "uuid": "296d445c-243d-454c-9f5a-146c13d0cded",
     "set_uuid": "3a1f900b-1fc0-4501-b270-aec62b63a0b7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -17569,9 +19095,11 @@
     "uuid": "8b969d35-01ab-419f-b391-484aad88fd41",
     "set_uuid": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17587,9 +19115,11 @@
     "uuid": "f25c6bfd-0a0d-4fd1-ab7b-9cd1d13053e1",
     "set_uuid": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17603,9 +19133,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e731e2e4-c3bf-4dff-aca0-04201e7e17ed",
     "uuid": "effa3e3c-eb5b-4c0a-aca9-81331e6a08ac",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -17623,9 +19155,11 @@
     "uuid": "d13d2f2e-9425-403d-a95f-889d67f03425",
     "set_uuid": "72d2def7-a752-4b02-b476-0d58cf74dae3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-extra-large instead.",
-    "replaced_by": "8b969d35-01ab-419f-b391-484aad88fd41"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-extra-large instead.",
+      "replacedBy": "8b969d35-01ab-419f-b391-484aad88fd41"
+    }
   },
   {
     "name": {
@@ -17643,9 +19177,11 @@
     "uuid": "c9ac99be-86c3-4f6c-a2a5-3487041bc95e",
     "set_uuid": "72d2def7-a752-4b02-b476-0d58cf74dae3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-extra-large instead.",
-    "replaced_by": "f25c6bfd-0a0d-4fd1-ab7b-9cd1d13053e1"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-extra-large instead.",
+      "replacedBy": "f25c6bfd-0a0d-4fd1-ab7b-9cd1d13053e1"
+    }
   },
   {
     "name": {
@@ -17662,9 +19198,11 @@
     "uuid": "3271ab20-8a93-4b5b-a889-7a07d9f7e6ab",
     "set_uuid": "285fa517-3947-4641-8480-6fafe084ef37",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17681,9 +19219,11 @@
     "uuid": "06ada9fe-ceef-4fb4-88ee-37c2edee5418",
     "set_uuid": "285fa517-3947-4641-8480-6fafe084ef37",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17699,9 +19239,11 @@
     "uuid": "f14b75f3-cb07-48b3-8543-34d80747ff36",
     "set_uuid": "dfe63537-564b-4f23-ac78-39a08adeaf0b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17717,9 +19259,11 @@
     "uuid": "0de2f0a5-b32a-4f7b-b46c-1a6c25abc1ec",
     "set_uuid": "dfe63537-564b-4f23-ac78-39a08adeaf0b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17733,9 +19277,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "36742697-2320-4bc0-8a29-ad98e342349f",
     "uuid": "15e21448-3174-4565-aed7-ab84aa30d7ac",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -17753,9 +19299,11 @@
     "uuid": "775139b2-3fb4-4019-8a3e-2377211ed0ec",
     "set_uuid": "47db1bbb-aaf2-4d31-bb52-7f260a1a069d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-large instead.",
-    "replaced_by": "f14b75f3-cb07-48b3-8543-34d80747ff36"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-large instead.",
+      "replacedBy": "f14b75f3-cb07-48b3-8543-34d80747ff36"
+    }
   },
   {
     "name": {
@@ -17773,9 +19321,11 @@
     "uuid": "151bf172-2889-4c98-8f15-5b6cdcb30d4b",
     "set_uuid": "47db1bbb-aaf2-4d31-bb52-7f260a1a069d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-large instead.",
-    "replaced_by": "0de2f0a5-b32a-4f7b-b46c-1a6c25abc1ec"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-large instead.",
+      "replacedBy": "0de2f0a5-b32a-4f7b-b46c-1a6c25abc1ec"
+    }
   },
   {
     "name": {
@@ -17792,9 +19342,11 @@
     "uuid": "3adc8c4f-32ce-4cd1-8bb1-518b9b267ed2",
     "set_uuid": "91b5b043-bb34-495b-8cd0-31468dad24b3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17811,9 +19363,11 @@
     "uuid": "4bc11bec-9c86-4a6c-85d1-382c71c1352d",
     "set_uuid": "91b5b043-bb34-495b-8cd0-31468dad24b3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17829,9 +19383,11 @@
     "uuid": "f14087ac-db72-43df-a8fa-9c9b03c6a1c9",
     "set_uuid": "0a40f436-9f58-4c9d-9a63-77c61adba6e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17847,9 +19403,11 @@
     "uuid": "6ff9a81f-a2f8-4966-a48b-c8561aa4f833",
     "set_uuid": "0a40f436-9f58-4c9d-9a63-77c61adba6e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17863,9 +19421,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
     "uuid": "d9d8fee2-9e0f-4c2b-8059-f9badb3b6482",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -17883,9 +19443,11 @@
     "uuid": "c66ff3f2-3661-464c-b722-151f72d03f2a",
     "set_uuid": "18cd494e-f66e-4825-86fb-d35262cf7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-medium instead.",
-    "replaced_by": "f14087ac-db72-43df-a8fa-9c9b03c6a1c9"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-medium instead.",
+      "replacedBy": "f14087ac-db72-43df-a8fa-9c9b03c6a1c9"
+    }
   },
   {
     "name": {
@@ -17903,9 +19465,11 @@
     "uuid": "e80339a8-22c4-4b53-9a4a-a4456f6cab3f",
     "set_uuid": "18cd494e-f66e-4825-86fb-d35262cf7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-medium instead.",
-    "replaced_by": "6ff9a81f-a2f8-4966-a48b-c8561aa4f833"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-medium instead.",
+      "replacedBy": "6ff9a81f-a2f8-4966-a48b-c8561aa4f833"
+    }
   },
   {
     "name": {
@@ -17922,9 +19486,11 @@
     "uuid": "2cedf119-a2f6-484a-8bdd-83652a8d6d79",
     "set_uuid": "bc435ab5-6d31-448e-b5de-58b710ab501c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17941,9 +19507,11 @@
     "uuid": "8273e28d-20b4-4575-9449-9178af111e38",
     "set_uuid": "bc435ab5-6d31-448e-b5de-58b710ab501c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -17959,9 +19527,11 @@
     "uuid": "56b58d2a-01dd-488b-b6e9-ff49555602b4",
     "set_uuid": "6353bfab-c0fa-4cfd-bf93-11c01df2f236",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17977,9 +19547,11 @@
     "uuid": "d6100789-7076-403a-b878-7bb204093c52",
     "set_uuid": "6353bfab-c0fa-4cfd-bf93-11c01df2f236",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -17993,9 +19565,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "861fff6a-7163-495d-bcb1-caa87693fb55",
     "uuid": "5eb79adf-f94c-4bf8-9ec9-279f49ce5331",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18013,9 +19587,11 @@
     "uuid": "90ae4c5b-a49d-40ad-8dd8-b25720c13f79",
     "set_uuid": "539bf649-6bee-4fd1-b0b8-cdcf53ca17c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-small instead.",
-    "replaced_by": "56b58d2a-01dd-488b-b6e9-ff49555602b4"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-small instead.",
+      "replacedBy": "56b58d2a-01dd-488b-b6e9-ff49555602b4"
+    }
   },
   {
     "name": {
@@ -18033,9 +19609,11 @@
     "uuid": "d3147ee6-dc34-46e2-8379-02d9690ff80a",
     "set_uuid": "539bf649-6bee-4fd1-b0b8-cdcf53ca17c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-small instead.",
-    "replaced_by": "d6100789-7076-403a-b878-7bb204093c52"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-bottom-to-text-small instead.",
+      "replacedBy": "d6100789-7076-403a-b878-7bb204093c52"
+    }
   },
   {
     "name": {
@@ -18052,9 +19630,11 @@
     "uuid": "ad51f205-c2e7-4af5-9301-937594c61027",
     "set_uuid": "df8d5ef4-8eb8-48bd-8283-a82c4da8c40a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18071,9 +19651,11 @@
     "uuid": "07dd5018-1999-4b95-9a59-fe1c2fcc380f",
     "set_uuid": "df8d5ef4-8eb8-48bd-8283-a82c4da8c40a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18089,9 +19671,11 @@
     "uuid": "acd6ad6b-bab0-40fb-afbe-5df7eea7efb3",
     "set_uuid": "e9908164-5b47-4098-8de3-028cd93eaa0b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18107,9 +19691,11 @@
     "uuid": "fb02243f-0490-4eb2-aac2-fa364c6eab59",
     "set_uuid": "e9908164-5b47-4098-8de3-028cd93eaa0b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18126,9 +19712,11 @@
     "uuid": "a1aa1c65-a1e8-40d6-805f-309d5e43d129",
     "set_uuid": "c0f93eef-4d3a-4274-92e9-d5b297a4077a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18145,9 +19733,11 @@
     "uuid": "4069e932-339a-495d-bb36-c89f22af4f96",
     "set_uuid": "c0f93eef-4d3a-4274-92e9-d5b297a4077a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18165,9 +19755,11 @@
     "uuid": "9b775e1f-9348-431d-9ba8-bffb19bcbf85",
     "set_uuid": "8819d918-2f76-4980-bf68-4d6b0d12b56a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-extra-large instead.",
-    "replaced_by": "acd6ad6b-bab0-40fb-afbe-5df7eea7efb3"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-extra-large instead.",
+      "replacedBy": "acd6ad6b-bab0-40fb-afbe-5df7eea7efb3"
+    }
   },
   {
     "name": {
@@ -18185,9 +19777,11 @@
     "uuid": "2171aee7-d013-459e-a13f-33075090cbe3",
     "set_uuid": "8819d918-2f76-4980-bf68-4d6b0d12b56a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-extra-large instead.",
-    "replaced_by": "fb02243f-0490-4eb2-aac2-fa364c6eab59"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-extra-large instead.",
+      "replacedBy": "fb02243f-0490-4eb2-aac2-fa364c6eab59"
+    }
   },
   {
     "name": {
@@ -18204,9 +19798,11 @@
     "uuid": "568ba981-51b5-4443-a427-0f857ff02572",
     "set_uuid": "4aecbd35-c2b1-43c0-9e35-0b8b2266481a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18223,9 +19819,11 @@
     "uuid": "683be05e-f8d4-4910-8d07-20515f19fbbd",
     "set_uuid": "4aecbd35-c2b1-43c0-9e35-0b8b2266481a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18241,9 +19839,11 @@
     "uuid": "a8c2b073-495b-402b-b1dc-2337b0e42f37",
     "set_uuid": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18259,9 +19859,11 @@
     "uuid": "a0fa4e03-c1de-400d-8629-0ae9ffb9b9d8",
     "set_uuid": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18278,9 +19880,11 @@
     "uuid": "40acc8c4-81b4-4566-a7ce-7c3d0d8ab5c5",
     "set_uuid": "e8e48839-029b-4be1-a73a-1bcf1f7281e7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18297,9 +19901,11 @@
     "uuid": "5fde3b28-c553-4124-be3b-212d1407780c",
     "set_uuid": "e8e48839-029b-4be1-a73a-1bcf1f7281e7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18317,9 +19923,11 @@
     "uuid": "559b9fc0-389e-4e2f-985c-8741f218850a",
     "set_uuid": "b801c82b-6ad6-47aa-a6ee-fae3f07fcc2b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-large instead.",
-    "replaced_by": "a8c2b073-495b-402b-b1dc-2337b0e42f37"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-large instead.",
+      "replacedBy": "a8c2b073-495b-402b-b1dc-2337b0e42f37"
+    }
   },
   {
     "name": {
@@ -18337,9 +19945,11 @@
     "uuid": "2e16e4ef-fec6-41fb-9d96-bc6bb6c88f69",
     "set_uuid": "b801c82b-6ad6-47aa-a6ee-fae3f07fcc2b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-large instead.",
-    "replaced_by": "a0fa4e03-c1de-400d-8629-0ae9ffb9b9d8"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-large instead.",
+      "replacedBy": "a0fa4e03-c1de-400d-8629-0ae9ffb9b9d8"
+    }
   },
   {
     "name": {
@@ -18356,9 +19966,11 @@
     "uuid": "d4b563c8-9234-4eed-a2a3-7e448a174286",
     "set_uuid": "4a5b7cb8-0546-45ce-a8b3-53e02c0758e1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18375,9 +19987,11 @@
     "uuid": "cfbd6cb5-c8d3-4908-a77a-7a15cda932fb",
     "set_uuid": "4a5b7cb8-0546-45ce-a8b3-53e02c0758e1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18393,9 +20007,11 @@
     "uuid": "be965b15-08f8-43be-9953-52151d8c7670",
     "set_uuid": "4ca4c4bf-85eb-41f7-9348-6408b408275e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18411,9 +20027,11 @@
     "uuid": "2ae09505-d43f-4e2c-b8a6-014ccfef5c10",
     "set_uuid": "4ca4c4bf-85eb-41f7-9348-6408b408275e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18430,9 +20048,11 @@
     "uuid": "0b12ff10-52e2-4084-9f1b-ee7bc0b50576",
     "set_uuid": "fdee6c12-6083-47fb-9b14-e8ed03a03841",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18449,9 +20069,11 @@
     "uuid": "84f00d87-c0ea-42fd-8477-9fff028bf79c",
     "set_uuid": "fdee6c12-6083-47fb-9b14-e8ed03a03841",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18469,9 +20091,11 @@
     "uuid": "2c8f9b97-f4df-48c2-ab1a-82373d335b83",
     "set_uuid": "30dfc19e-9751-4dab-a6c3-d3480af57dfc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-medium instead.",
-    "replaced_by": "be965b15-08f8-43be-9953-52151d8c7670"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-medium instead.",
+      "replacedBy": "be965b15-08f8-43be-9953-52151d8c7670"
+    }
   },
   {
     "name": {
@@ -18489,9 +20113,11 @@
     "uuid": "36505a4f-01b6-4b83-adf1-592818eb2c0d",
     "set_uuid": "30dfc19e-9751-4dab-a6c3-d3480af57dfc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-medium instead.",
-    "replaced_by": "2ae09505-d43f-4e2c-b8a6-014ccfef5c10"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-medium instead.",
+      "replacedBy": "2ae09505-d43f-4e2c-b8a6-014ccfef5c10"
+    }
   },
   {
     "name": {
@@ -18508,9 +20134,11 @@
     "uuid": "c8a04cab-bfad-4b82-94dc-6c2b4160c7cb",
     "set_uuid": "0bcbc9fa-5512-43ba-acc3-96a584aab30a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18527,9 +20155,11 @@
     "uuid": "a57d2d1a-5e0c-4d4c-84eb-dd2339366aad",
     "set_uuid": "0bcbc9fa-5512-43ba-acc3-96a584aab30a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18545,9 +20175,11 @@
     "uuid": "909ebf8a-eebd-41b6-8fac-8fe31d2bac00",
     "set_uuid": "300645bd-1253-44a2-970e-33a2a028eb4f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18563,9 +20195,11 @@
     "uuid": "365d9c3f-d287-4feb-b020-89434dd29378",
     "set_uuid": "300645bd-1253-44a2-970e-33a2a028eb4f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -18582,9 +20216,11 @@
     "uuid": "f5c64a03-3750-4c92-afe2-43575bdb1df9",
     "set_uuid": "ad134919-4768-4be4-96bd-bc681573ab5b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18601,9 +20237,11 @@
     "uuid": "2444d220-a3d0-4565-a762-02cbc52f828a",
     "set_uuid": "ad134919-4768-4be4-96bd-bc681573ab5b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -18621,9 +20259,11 @@
     "uuid": "4435c143-a75a-47c1-a629-3574b70247a3",
     "set_uuid": "614a4d4a-48dc-4b3f-8920-e033dc4db28c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-small instead.",
-    "replaced_by": "909ebf8a-eebd-41b6-8fac-8fe31d2bac00"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-small instead.",
+      "replacedBy": "909ebf8a-eebd-41b6-8fac-8fe31d2bac00"
+    }
   },
   {
     "name": {
@@ -18641,9 +20281,11 @@
     "uuid": "a63aa24e-c956-4af5-bf4f-4c5d44bd1e16",
     "set_uuid": "614a4d4a-48dc-4b3f-8920-e033dc4db28c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-small instead.",
-    "replaced_by": "365d9c3f-d287-4feb-b020-89434dd29378"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-checkbox-to-top-small instead.",
+      "replacedBy": "365d9c3f-d287-4feb-b020-89434dd29378"
+    }
   },
   {
     "name": {
@@ -18660,9 +20302,11 @@
     "uuid": "4637c01d-66cd-451e-8950-9e72700c80d3",
     "set_uuid": "4b694866-bd3e-4b41-a991-b729b6c7bc1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18679,9 +20323,11 @@
     "uuid": "6ccbecd6-a1c4-4fcf-beb5-2b124ac3e75b",
     "set_uuid": "4b694866-bd3e-4b41-a991-b729b6c7bc1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -18738,9 +20384,11 @@
     "uuid": "face2717-9c2c-4e18-9632-4e4a595b1fc7",
     "set_uuid": "e65de693-2b8c-4c70-955d-2e6a64059ca4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-extra-large instead.",
-    "replaced_by": "d52d3141-27a5-40eb-800f-1a09acd42534"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-extra-large instead.",
+      "replacedBy": "d52d3141-27a5-40eb-800f-1a09acd42534"
+    }
   },
   {
     "name": {
@@ -18757,9 +20405,11 @@
     "uuid": "b7753c9a-8854-4927-89dd-80d47bff5fa5",
     "set_uuid": "e65de693-2b8c-4c70-955d-2e6a64059ca4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-extra-large instead.",
-    "replaced_by": "c2e3068b-c0be-4615-bbf7-c65e58ef126b"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-extra-large instead.",
+      "replacedBy": "c2e3068b-c0be-4615-bbf7-c65e58ef126b"
+    }
   },
   {
     "name": {
@@ -18846,9 +20496,11 @@
     "uuid": "3b22a4c7-525c-4482-9e58-19cbe46d318b",
     "set_uuid": "02c1f806-f32d-4b95-a790-dbc50cd57f0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-large instead.",
-    "replaced_by": "d3d9b523-90dc-4532-9cf7-37b568bd6800"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-large instead.",
+      "replacedBy": "d3d9b523-90dc-4532-9cf7-37b568bd6800"
+    }
   },
   {
     "name": {
@@ -18865,9 +20517,11 @@
     "uuid": "b92bc058-27ea-4e86-a1a2-e5dbae3c2ee8",
     "set_uuid": "02c1f806-f32d-4b95-a790-dbc50cd57f0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-large instead.",
-    "replaced_by": "ff04cae7-7f96-4db2-bf64-948c22d104ff"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-large instead.",
+      "replacedBy": "ff04cae7-7f96-4db2-bf64-948c22d104ff"
+    }
   },
   {
     "name": {
@@ -18954,9 +20608,11 @@
     "uuid": "1dc88a25-18bc-491a-ab02-2c1ec36f4c1e",
     "set_uuid": "6c3fec1e-6a96-400f-8188-cd2fd6f5039a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-medium instead.",
-    "replaced_by": "9d6dc5e8-d3f0-4f59-b062-756669ff7217"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-medium instead.",
+      "replacedBy": "9d6dc5e8-d3f0-4f59-b062-756669ff7217"
+    }
   },
   {
     "name": {
@@ -18973,9 +20629,11 @@
     "uuid": "72e6564c-2acf-4f77-80d9-b21d2d55a580",
     "set_uuid": "6c3fec1e-6a96-400f-8188-cd2fd6f5039a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-medium instead.",
-    "replaced_by": "2cf7918c-f84a-4903-a6ba-b110807842ba"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-medium instead.",
+      "replacedBy": "2cf7918c-f84a-4903-a6ba-b110807842ba"
+    }
   },
   {
     "name": {
@@ -19062,9 +20720,11 @@
     "uuid": "fd53964b-cf4a-4cdf-b088-418364b1c518",
     "set_uuid": "f8519e64-027c-4724-b5f3-772ee266ba78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-small instead.",
-    "replaced_by": "10b892a0-3c97-4af6-8ecc-3359e8cd1302"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-small instead.",
+      "replacedBy": "10b892a0-3c97-4af6-8ecc-3359e8cd1302"
+    }
   },
   {
     "name": {
@@ -19081,9 +20741,11 @@
     "uuid": "cdbb999d-c2a9-4325-9689-bede2ad3559a",
     "set_uuid": "f8519e64-027c-4724-b5f3-772ee266ba78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-height-small instead.",
-    "replaced_by": "77a26f7c-2f71-4021-a1f2-a2af7c69a111"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-height-small instead.",
+      "replacedBy": "77a26f7c-2f71-4021-a1f2-a2af7c69a111"
+    }
   },
   {
     "name": {
@@ -19129,9 +20791,11 @@
     "uuid": "da7274c6-6f45-4087-b42f-dde7d3ac1af7",
     "set_uuid": "cf9418b9-a5ff-47ee-b19d-b933629f3072",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19147,9 +20811,11 @@
     "uuid": "40de40fd-4bae-4a49-8aec-38dad2a1c5fb",
     "set_uuid": "cf9418b9-a5ff-47ee-b19d-b933629f3072",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19163,9 +20829,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
     "uuid": "2e8eff8c-60fa-4e0f-ae40-7b9f9b3679d6",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19183,9 +20851,11 @@
     "uuid": "03555438-78f5-429a-a0dd-c6777dc36372",
     "set_uuid": "b7562d01-f178-4ab0-bef4-e1f8e5f0f901",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-extra-large instead.",
-    "replaced_by": "da7274c6-6f45-4087-b42f-dde7d3ac1af7"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-extra-large instead.",
+      "replacedBy": "da7274c6-6f45-4087-b42f-dde7d3ac1af7"
+    }
   },
   {
     "name": {
@@ -19203,9 +20873,11 @@
     "uuid": "c381a3c4-e0a3-4e86-b279-f51ee6e9e532",
     "set_uuid": "b7562d01-f178-4ab0-bef4-e1f8e5f0f901",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-extra-large instead.",
-    "replaced_by": "40de40fd-4bae-4a49-8aec-38dad2a1c5fb"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-extra-large instead.",
+      "replacedBy": "40de40fd-4bae-4a49-8aec-38dad2a1c5fb"
+    }
   },
   {
     "name": {
@@ -19222,9 +20894,11 @@
     "uuid": "7824ab63-198c-4ee3-99d7-9b151898eb40",
     "set_uuid": "09f3e42a-bc6f-4439-a65a-22fd0ca251ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19241,9 +20915,11 @@
     "uuid": "90c39289-3112-49a3-8e65-d112c97f7479",
     "set_uuid": "09f3e42a-bc6f-4439-a65a-22fd0ca251ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19259,9 +20935,11 @@
     "uuid": "0820aecf-0647-4e51-ae40-44130bc86013",
     "set_uuid": "de73e367-5c1a-4532-bd93-644f066fa2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19277,9 +20955,11 @@
     "uuid": "4d55e632-588b-4e82-90c0-4fa434998d15",
     "set_uuid": "de73e367-5c1a-4532-bd93-644f066fa2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19293,9 +20973,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306b871f-cbfa-49a2-a74b-dd120bbff503",
     "uuid": "14437ed2-c60b-40ba-91e6-bed5353fc544",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19313,9 +20995,11 @@
     "uuid": "2ed03fb3-fed4-41d4-8a14-f7446bb76486",
     "set_uuid": "5be48be9-1157-411c-8357-b48451ee195e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-large instead.",
-    "replaced_by": "0820aecf-0647-4e51-ae40-44130bc86013"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-large instead.",
+      "replacedBy": "0820aecf-0647-4e51-ae40-44130bc86013"
+    }
   },
   {
     "name": {
@@ -19333,9 +21017,11 @@
     "uuid": "0108018e-6146-45c9-b032-e3d44dfb8d84",
     "set_uuid": "5be48be9-1157-411c-8357-b48451ee195e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-large instead.",
-    "replaced_by": "4d55e632-588b-4e82-90c0-4fa434998d15"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-large instead.",
+      "replacedBy": "4d55e632-588b-4e82-90c0-4fa434998d15"
+    }
   },
   {
     "name": {
@@ -19352,9 +21038,11 @@
     "uuid": "a3e22e10-1964-4d4a-8721-2eeddfed6f42",
     "set_uuid": "afc52caa-98a7-4687-9cbb-3628a5bf2d90",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19371,9 +21059,11 @@
     "uuid": "769d6bbf-64ba-4c08-8a57-580838de1d48",
     "set_uuid": "afc52caa-98a7-4687-9cbb-3628a5bf2d90",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19389,9 +21079,11 @@
     "uuid": "ae401c94-c643-446f-a44e-38c9f3104fc6",
     "set_uuid": "6f81b550-82ce-436f-9e33-93a247eaae54",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19407,9 +21099,11 @@
     "uuid": "0cd86854-57ca-4023-b544-8a4a76418164",
     "set_uuid": "6f81b550-82ce-436f-9e33-93a247eaae54",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19423,9 +21117,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
     "uuid": "02c5faff-dbb4-4633-ae57-413b3666dfca",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19443,9 +21139,11 @@
     "uuid": "8e1448f8-5806-4629-8131-4e8422b26870",
     "set_uuid": "40e31948-a58c-41f8-968b-2eaf58a1832f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-medium instead.",
-    "replaced_by": "ae401c94-c643-446f-a44e-38c9f3104fc6"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-medium instead.",
+      "replacedBy": "ae401c94-c643-446f-a44e-38c9f3104fc6"
+    }
   },
   {
     "name": {
@@ -19463,9 +21161,11 @@
     "uuid": "7df1dc32-b96d-41e3-a372-9bcaec7c2ccb",
     "set_uuid": "40e31948-a58c-41f8-968b-2eaf58a1832f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-medium instead.",
-    "replaced_by": "0cd86854-57ca-4023-b544-8a4a76418164"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-medium instead.",
+      "replacedBy": "0cd86854-57ca-4023-b544-8a4a76418164"
+    }
   },
   {
     "name": {
@@ -19482,9 +21182,11 @@
     "uuid": "9893c4bf-aa89-4b46-987f-09432943734a",
     "set_uuid": "a5705732-efdf-49ee-b292-e3087e6fed9b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19501,9 +21203,11 @@
     "uuid": "cfa36bf7-cce0-4049-970a-8f11c6d60673",
     "set_uuid": "a5705732-efdf-49ee-b292-e3087e6fed9b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19519,9 +21223,11 @@
     "uuid": "52fb10e1-a45e-4b21-9563-b72a6cf8c7e0",
     "set_uuid": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19537,9 +21243,11 @@
     "uuid": "dfa553a2-b771-4a31-9294-3800d2126952",
     "set_uuid": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19553,9 +21261,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1a76668b-c733-4ec0-ae84-774f4e6e861a",
     "uuid": "b7e7808a-16c6-481a-9257-9c1dc4e13b62",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19573,9 +21283,11 @@
     "uuid": "5e5a6837-34c9-4f01-8769-b66c3f602d1f",
     "set_uuid": "116a4042-45aa-41d3-8964-b9f9cdfb5e0f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-small instead.",
-    "replaced_by": "52fb10e1-a45e-4b21-9563-b72a6cf8c7e0"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-small instead.",
+      "replacedBy": "52fb10e1-a45e-4b21-9563-b72a6cf8c7e0"
+    }
   },
   {
     "name": {
@@ -19593,9 +21305,11 @@
     "uuid": "98014297-14dc-4547-944a-8951c7f6f253",
     "set_uuid": "116a4042-45aa-41d3-8964-b9f9cdfb5e0f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-small instead.",
-    "replaced_by": "dfa553a2-b771-4a31-9294-3800d2126952"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-row-top-to-text-small instead.",
+      "replacedBy": "dfa553a2-b771-4a31-9294-3800d2126952"
+    }
   },
   {
     "name": {
@@ -19612,9 +21326,11 @@
     "uuid": "c0f9a500-3259-4888-ab43-c180c694a24e",
     "set_uuid": "be09a814-07d8-4d09-91f5-45bc397bb1a3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19631,9 +21347,11 @@
     "uuid": "625733b1-78b3-4dd0-9636-71d59c14e013",
     "set_uuid": "be09a814-07d8-4d09-91f5-45bc397bb1a3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19767,9 +21485,11 @@
     "uuid": "0ae43893-e3ea-461f-a2fe-93239cb3a22a",
     "set_uuid": "65180f74-078a-48db-aea1-e095d37f9e00",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19783,9 +21503,11 @@
     "uuid": "17051925-5eda-45a3-8d45-d329e88bf63a",
     "set_uuid": "65180f74-078a-48db-aea1-e095d37f9e00",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19799,9 +21521,11 @@
     "uuid": "499530d7-7c3c-4bed-a4a1-d4edc2195afe",
     "set_uuid": "4ede0b34-d5a0-4670-a9e3-e44e8f07b5c6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19815,9 +21539,11 @@
     "uuid": "29ee801a-95bd-495c-9905-f2fd00ae0e19",
     "set_uuid": "4ede0b34-d5a0-4670-a9e3-e44e8f07b5c6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19831,9 +21557,11 @@
     "uuid": "17c4c578-d3e1-44c0-bd21-ee4df5cb2027",
     "set_uuid": "bfbef5d5-293c-4366-aef3-58e44a06500b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-extra-large instead.",
-    "replaced_by": "0ae43893-e3ea-461f-a2fe-93239cb3a22a"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-extra-large instead.",
+      "replacedBy": "0ae43893-e3ea-461f-a2fe-93239cb3a22a"
+    }
   },
   {
     "name": {
@@ -19847,9 +21575,11 @@
     "uuid": "b60c33b8-acc1-4af1-b30f-b467054ee417",
     "set_uuid": "bfbef5d5-293c-4366-aef3-58e44a06500b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-extra-large instead.",
-    "replaced_by": "17051925-5eda-45a3-8d45-d329e88bf63a"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-extra-large instead.",
+      "replacedBy": "17051925-5eda-45a3-8d45-d329e88bf63a"
+    }
   },
   {
     "name": {
@@ -19863,9 +21593,11 @@
     "uuid": "127b9225-cbab-42c1-8c86-4f425c7c8e27",
     "set_uuid": "e0ec88e1-fa29-4fbe-9ccf-cc96db4bbbd9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19879,9 +21611,11 @@
     "uuid": "28a5df8a-0fe4-4410-b804-9a6c26de4440",
     "set_uuid": "e0ec88e1-fa29-4fbe-9ccf-cc96db4bbbd9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -19895,9 +21629,11 @@
     "uuid": "589d6f19-ec7f-4a4f-a622-40d18d7e71f5",
     "set_uuid": "bea15b38-2401-4051-9c87-c0dc347e7d1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19911,9 +21647,11 @@
     "uuid": "92ade1a0-ea78-4930-82e7-fedafce42aed",
     "set_uuid": "bea15b38-2401-4051-9c87-c0dc347e7d1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -19927,9 +21665,11 @@
     "uuid": "9b0e3ebe-59f6-4970-aa47-06b115f5efff",
     "set_uuid": "36507892-dd39-4c89-8b26-99d04c9d2243",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19943,9 +21683,11 @@
     "uuid": "891cf7bc-419a-4b78-8c7e-03685fbf36a4",
     "set_uuid": "36507892-dd39-4c89-8b26-99d04c9d2243",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -19959,9 +21701,11 @@
     "uuid": "de6e6ae5-eae6-4f7a-89be-176674176242",
     "set_uuid": "00499404-08ab-4a8a-9939-035374dfe2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-large instead.",
-    "replaced_by": "589d6f19-ec7f-4a4f-a622-40d18d7e71f5"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-large instead.",
+      "replacedBy": "589d6f19-ec7f-4a4f-a622-40d18d7e71f5"
+    }
   },
   {
     "name": {
@@ -19975,9 +21719,11 @@
     "uuid": "fc7efe7c-ef97-424f-89c2-2211daf44b4a",
     "set_uuid": "00499404-08ab-4a8a-9939-035374dfe2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-large instead.",
-    "replaced_by": "92ade1a0-ea78-4930-82e7-fedafce42aed"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-large instead.",
+      "replacedBy": "92ade1a0-ea78-4930-82e7-fedafce42aed"
+    }
   },
   {
     "name": {
@@ -19991,9 +21737,11 @@
     "uuid": "f1cbc035-b4d0-4593-b563-a107ee2eebb0",
     "set_uuid": "9682efb2-82ef-46a4-9bd9-221f8018efad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -20007,9 +21755,11 @@
     "uuid": "e6689bf9-6ecc-4900-b8ad-85b103232e3e",
     "set_uuid": "9682efb2-82ef-46a4-9bd9-221f8018efad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -20023,9 +21773,11 @@
     "uuid": "42914d96-ee9f-4ed9-9c7a-9c8ccca68245",
     "set_uuid": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -20039,9 +21791,11 @@
     "uuid": "2268750d-4c5f-46f1-bad7-dec21818bfe6",
     "set_uuid": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -20055,9 +21809,11 @@
     "uuid": "86a1c328-0845-47d8-a189-24a22c1ce053",
     "set_uuid": "a161ad1c-ff4b-4e73-84a3-0480bc43dd3b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -20071,9 +21827,11 @@
     "uuid": "b546eac7-00ad-4ea2-992d-0c4b8d087679",
     "set_uuid": "a161ad1c-ff4b-4e73-84a3-0480bc43dd3b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -20087,9 +21845,11 @@
     "uuid": "12a6fd11-d3a5-4d72-9942-89d828d1d256",
     "set_uuid": "d51b5484-2bae-48f1-890a-fc90198ea480",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-medium instead.",
-    "replaced_by": "42914d96-ee9f-4ed9-9c7a-9c8ccca68245"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-medium instead.",
+      "replacedBy": "42914d96-ee9f-4ed9-9c7a-9c8ccca68245"
+    }
   },
   {
     "name": {
@@ -20103,9 +21863,11 @@
     "uuid": "75af7a67-e0ae-4f41-9c70-09babbc587d1",
     "set_uuid": "d51b5484-2bae-48f1-890a-fc90198ea480",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-medium instead.",
-    "replaced_by": "2268750d-4c5f-46f1-bad7-dec21818bfe6"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-medium instead.",
+      "replacedBy": "2268750d-4c5f-46f1-bad7-dec21818bfe6"
+    }
   },
   {
     "name": {
@@ -20119,9 +21881,11 @@
     "uuid": "1cd90c35-f688-4054-aec4-e1e3b200cfcf",
     "set_uuid": "8f744293-1acb-4572-8050-cd76740e5557",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -20135,9 +21899,11 @@
     "uuid": "0cb1e46b-039b-46d2-a024-b72ddd82d0b4",
     "set_uuid": "8f744293-1acb-4572-8050-cd76740e5557",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -20151,9 +21917,11 @@
     "uuid": "96d7eb12-7e92-4ee8-988b-8e7e8a7de159",
     "set_uuid": "6db35635-76fd-4ef3-9a44-c0b6354550ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -20167,9 +21935,11 @@
     "uuid": "43955cdb-afaf-4e59-bb26-3063661141d7",
     "set_uuid": "6db35635-76fd-4ef3-9a44-c0b6354550ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
-    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+      "replacedBy": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+    }
   },
   {
     "name": {
@@ -20183,9 +21953,11 @@
     "uuid": "d9cc50d4-6661-4a03-b850-ed0933f2dabb",
     "set_uuid": "7e65af83-a25c-42dc-8a8c-201e3c8cfa1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -20199,9 +21971,11 @@
     "uuid": "72ebb8a4-9bfb-4ff0-ba3a-232c885931e7",
     "set_uuid": "7e65af83-a25c-42dc-8a8c-201e3c8cfa1d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
-    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+      "replacedBy": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+    }
   },
   {
     "name": {
@@ -20215,9 +21989,11 @@
     "uuid": "db98283d-1f25-4323-9f3a-0555b9670ba6",
     "set_uuid": "3d54e517-3d92-4adb-83e4-8f1cccc63673",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-small instead.",
-    "replaced_by": "96d7eb12-7e92-4ee8-988b-8e7e8a7de159"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-small instead.",
+      "replacedBy": "96d7eb12-7e92-4ee8-988b-8e7e8a7de159"
+    }
   },
   {
     "name": {
@@ -20231,9 +22007,11 @@
     "uuid": "e25b14a7-cb9e-406b-bab6-b27575f00a52",
     "set_uuid": "3d54e517-3d92-4adb-83e4-8f1cccc63673",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-small instead.",
-    "replaced_by": "43955cdb-afaf-4e59-bb26-3063661141d7"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.47",
+      "deprecatedComment": "This token has been deprecated, use table-thumbnail-to-top-minimum-small instead.",
+      "replacedBy": "43955cdb-afaf-4e59-bb26-3063661141d7"
+    }
   },
   {
     "name": {
@@ -20247,9 +22025,11 @@
     "uuid": "9b464ca8-f246-482d-b240-e12e097aaf8b",
     "set_uuid": "97e074af-13cd-4bbd-a785-b473da69a3cb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -20263,9 +22043,11 @@
     "uuid": "b6684bce-531d-420a-befc-b4ad884059fc",
     "set_uuid": "97e074af-13cd-4bbd-a785-b473da69a3cb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
-    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+      "replacedBy": "a775a186-802e-4256-947c-7fda3ac53caa"
+    }
   },
   {
     "name": {
@@ -20281,9 +22063,11 @@
     "uuid": "896b20fc-c13e-4785-a252-00857208d51c",
     "set_uuid": "4d6e4dec-5d27-4791-b639-5e4a211a21fb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -20299,9 +22083,11 @@
     "uuid": "b046b12c-5c39-4018-8ccc-9a5cb08eb6e5",
     "set_uuid": "4d6e4dec-5d27-4791-b639-5e4a211a21fb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -20317,9 +22103,11 @@
     "uuid": "e4e422af-181f-47b5-b165-f514a0a6f41c",
     "set_uuid": "2d000eb2-5aed-48d3-822e-11522c9c38f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -20335,9 +22123,11 @@
     "uuid": "a2f75bb4-0ce4-4993-9a43-09cd2b7376bf",
     "set_uuid": "2d000eb2-5aed-48d3-822e-11522c9c38f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -20353,9 +22143,11 @@
     "uuid": "a27b0e7c-8840-4d08-8f88-39643589c554",
     "set_uuid": "58051d9f-6a04-4e64-8a6e-73858a57935c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -20371,9 +22163,11 @@
     "uuid": "6f913e5f-debc-4b7d-897d-c2704847c2e5",
     "set_uuid": "58051d9f-6a04-4e64-8a6e-73858a57935c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -20479,9 +22273,11 @@
     "uuid": "03b1351c-1309-4e1a-a18b-bf3a350814c4",
     "set_uuid": "6e3b375b-5076-4d26-a608-667a98c34f17",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead.",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -20497,9 +22293,11 @@
     "uuid": "1fda84ab-aa68-46fb-bd0f-d8174a08a41e",
     "set_uuid": "6e3b375b-5076-4d26-a608-667a98c34f17",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead.",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -20515,9 +22313,11 @@
     "uuid": "798ecb75-638c-41dd-81a0-d7ecca9960da",
     "set_uuid": "a0ca6a64-65d6-4080-baf4-f76fb375383b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -20533,9 +22333,11 @@
     "uuid": "0072dc62-b868-4c4b-afd9-9c52d876c614",
     "set_uuid": "a0ca6a64-65d6-4080-baf4-f76fb375383b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -20551,9 +22353,11 @@
     "uuid": "b6eebf3a-4733-4177-a235-6eccfacf67cd",
     "set_uuid": "f8f0b01a-2c63-4d0e-b1e4-506f278040ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -20569,9 +22373,11 @@
     "uuid": "5e448fc3-6c14-4169-84a0-1f70bbc478cb",
     "set_uuid": "f8f0b01a-2c63-4d0e-b1e4-506f278040ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -20689,9 +22495,11 @@
     "uuid": "8533ad58-9e81-4154-8ad1-57213741e814",
     "set_uuid": "9a8b0028-fefe-41fe-83a9-fed108acb3b3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead.",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -20707,9 +22515,11 @@
     "uuid": "7c1375da-c6c7-42b3-b60e-0ef6724c6303",
     "set_uuid": "9a8b0028-fefe-41fe-83a9-fed108acb3b3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead.",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -20725,9 +22535,11 @@
     "uuid": "c964fe64-fcb6-4417-977d-b15880daf164",
     "set_uuid": "9136db47-9232-460e-9e57-1143b4ba9e7b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -20743,9 +22555,11 @@
     "uuid": "ff7424ba-5f65-46ff-b408-4ffb2cfc5035",
     "set_uuid": "9136db47-9232-460e-9e57-1143b4ba9e7b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -20761,9 +22575,11 @@
     "uuid": "bfc9cd19-e115-4ff2-908d-6cd4725f68bc",
     "set_uuid": "32732b36-a364-4eec-a240-3e8eb538c15d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -20779,9 +22595,11 @@
     "uuid": "2011748e-f950-4c6e-9eee-1c0d77b7ba36",
     "set_uuid": "32732b36-a364-4eec-a240-3e8eb538c15d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -20852,7 +22670,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1,
     "uuid": "837b2ac3-0adc-438c-b249-b96bac07049f",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -20894,9 +22714,11 @@
     "uuid": "57de6911-6f5f-4a0d-9606-e7584a10d7f4",
     "set_uuid": "6dc82803-d302-4e3a-9932-3155bdd4a64f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -20912,9 +22734,11 @@
     "uuid": "9881ad7c-e9df-40b1-a368-4f8185042c3f",
     "set_uuid": "6dc82803-d302-4e3a-9932-3155bdd4a64f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -20930,9 +22754,11 @@
     "uuid": "394343df-fb5d-44be-b6d1-9975ab8a4156",
     "set_uuid": "1a1233a0-7ad4-4ea9-a453-7dfadd1d6dae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -20948,9 +22774,11 @@
     "uuid": "8dbabe33-52e7-4dc1-b2e3-81c1c62d98cb",
     "set_uuid": "1a1233a0-7ad4-4ea9-a453-7dfadd1d6dae",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -20966,9 +22794,11 @@
     "uuid": "cf1239b1-495a-482c-8aeb-3b98c6b75583",
     "set_uuid": "a2f37017-0efa-4706-849a-1808c497e136",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -20984,9 +22814,11 @@
     "uuid": "a2c40238-1fda-4482-a419-b8092a385c9b",
     "set_uuid": "a2f37017-0efa-4706-849a-1808c497e136",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -21002,9 +22834,11 @@
     "uuid": "e335436a-190c-4417-86f4-b7266c093377",
     "set_uuid": "dfa2b156-7b26-44dd-b2fc-ea33b38192de",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -21020,9 +22854,11 @@
     "uuid": "af69e3d1-92b6-4e62-93f2-c1f1f10f0a63",
     "set_uuid": "dfa2b156-7b26-44dd-b2fc-ea33b38192de",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -21038,9 +22874,11 @@
     "uuid": "1bfd3452-93c8-424a-99e4-55e5ecbee90b",
     "set_uuid": "50b571a8-0931-454b-aa73-88cda1772cb0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -21056,9 +22894,11 @@
     "uuid": "ac7b17a2-99ef-45b3-ab3b-4d3eeaf99fb9",
     "set_uuid": "50b571a8-0931-454b-aa73-88cda1772cb0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -21074,9 +22914,11 @@
     "uuid": "c9e5e973-4942-414e-b128-5569f62453a2",
     "set_uuid": "814117c5-90a4-4fad-a66d-68b68a25d8d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -21092,9 +22934,11 @@
     "uuid": "d93e04b9-1901-4ec4-947a-62c84205e61e",
     "set_uuid": "814117c5-90a4-4fad-a66d-68b68a25d8d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -21523,9 +23367,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
     "uuid": "9953fcd9-ac62-49bd-beb2-926dc9fbb8c8",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -22030,9 +23876,11 @@
     "uuid": "821e8f74-d1de-4507-9ff7-ece44e535e8c",
     "set_uuid": "ecad3ac8-e45f-460c-a0a9-13f41a3bfdf0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -22047,9 +23895,11 @@
     "uuid": "a790fd9e-4e5f-4f4c-a3ca-832540832580",
     "set_uuid": "ecad3ac8-e45f-460c-a0a9-13f41a3bfdf0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -22112,9 +23962,11 @@
     "uuid": "be4f24cf-9334-4fc4-aa72-e0347beecda7",
     "set_uuid": "f2d06ddb-31e5-4da8-9345-47ed975b7d1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -22129,9 +23981,11 @@
     "uuid": "9f0688f5-128f-47c3-8585-94d704214881",
     "set_uuid": "f2d06ddb-31e5-4da8-9345-47ed975b7d1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -22146,9 +24000,11 @@
     "uuid": "d10d2a55-2b4d-46b1-81e9-521d6c3578e1",
     "set_uuid": "10da87b7-e0a1-4793-9912-0d43dd15acaf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -22163,9 +24019,11 @@
     "uuid": "1f83245b-3d79-4326-b843-df7b6549cade",
     "set_uuid": "10da87b7-e0a1-4793-9912-0d43dd15acaf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
-    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+      "replacedBy": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+    }
   },
   {
     "name": {
@@ -22267,9 +24125,11 @@
     "uuid": "74787427-ea2f-4b94-99c0-88454e8be6cf",
     "set_uuid": "ce3f949b-cf92-4fd4-9ca5-a2e843e869ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead.",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22284,9 +24144,11 @@
     "uuid": "794ad497-1725-4a03-a7c9-425eaee3178e",
     "set_uuid": "ce3f949b-cf92-4fd4-9ca5-a2e843e869ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead.",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22301,9 +24163,11 @@
     "uuid": "7ab9177a-d035-4e78-b6b9-d80a6470bd7b",
     "set_uuid": "75396078-60ab-40f8-8783-b1a642e48ea5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Faulty measurement. Combination of two measurements Correcting to text to inner element spacing. Refactor needed",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Faulty measurement. Combination of two measurements Correcting to text to inner element spacing. Refactor needed",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22318,9 +24182,11 @@
     "uuid": "9136f55b-d28b-4802-873c-db6205b8632b",
     "set_uuid": "75396078-60ab-40f8-8783-b1a642e48ea5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Faulty measurement. Combination of two measurements Correcting to text to inner element spacing. Refactor needed",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Faulty measurement. Combination of two measurements Correcting to text to inner element spacing. Refactor needed",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22391,9 +24257,11 @@
     "uuid": "e8c03b6e-d493-43b6-ae46-a6a92de5c9b8",
     "set_uuid": "c4cfb591-0aa6-4526-abdc-62377ea96636",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead.",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -22408,9 +24276,11 @@
     "uuid": "5a77899c-1547-40da-bce3-d892cfbc0450",
     "set_uuid": "c4cfb591-0aa6-4526-abdc-62377ea96636",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead.",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -22425,9 +24295,11 @@
     "uuid": "2e3817ed-206b-45e5-b55c-6116e9731cd8",
     "set_uuid": "8799b5e4-5cfc-4f45-bf87-b9ee9942931f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -22442,9 +24314,11 @@
     "uuid": "fba49c63-444e-42fc-b27c-7ce43b8419a7",
     "set_uuid": "8799b5e4-5cfc-4f45-bf87-b9ee9942931f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -22459,9 +24333,11 @@
     "uuid": "e8127c62-d8fa-405f-a5d5-d4f79bdffa5f",
     "set_uuid": "745bcb1f-e624-438c-b119-29056c4893e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -22476,9 +24352,11 @@
     "uuid": "f51d97ac-06c4-45a4-87ff-349b3ffbc36d",
     "set_uuid": "745bcb1f-e624-438c-b119-29056c4893e2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -22493,9 +24371,11 @@
     "uuid": "91c6c1db-1f68-43b3-80ba-aa3c7ebecaec",
     "set_uuid": "b44722f5-4b5a-4b9c-879f-565dc850b2c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -22510,9 +24390,11 @@
     "uuid": "66d490aa-b658-474d-99cf-f18d15cb4098",
     "set_uuid": "b44722f5-4b5a-4b9c-879f-565dc850b2c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
-    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-horizontal instead.",
+      "replacedBy": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+    }
   },
   {
     "name": {
@@ -22524,8 +24406,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-1px",
     "uuid": "8f92e6b8-907f-42b2-81d6-83d1786495bf",
-    "deprecated": "unknown",
-    "deprecated_comment": "Should be zero. Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Should be zero. Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -22540,9 +24424,11 @@
     "uuid": "ebf7358c-b691-45d7-a1c4-c346e75e800e",
     "set_uuid": "07b4d295-fb4e-4c1a-b733-3af00c395a2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead. This gap is not used in design; the header gap is equal to all other list item gaps. Refactor may be necessary",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead. This gap is not used in design; the header gap is equal to all other list item gaps. Refactor may be necessary",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -22557,9 +24443,11 @@
     "uuid": "a06c6929-1acc-4084-a8ee-3d4ad5a0064e",
     "set_uuid": "07b4d295-fb4e-4c1a-b733-3af00c395a2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-gap-regular instead. This gap is not used in design; the header gap is equal to all other list item gaps. Refactor may be necessary",
-    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-gap-regular instead. This gap is not used in design; the header gap is equal to all other list item gaps. Refactor may be necessary",
+      "replacedBy": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+    }
   },
   {
     "name": {
@@ -22571,9 +24459,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7d44a2b5-0aa6-4770-81da-8dbd87013906",
     "uuid": "9a04f19a-9e2a-43b9-9b1f-3385aef214ac",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use tree-view-item-to-item-default instead.",
-    "replaced_by": "7d44a2b5-0aa6-4770-81da-8dbd87013906"
+    "lifecycle": {
+      "deprecatedIn": "13.11.0",
+      "deprecatedComment": "This token has been deprecated, use tree-view-item-to-item-default instead.",
+      "replacedBy": "7d44a2b5-0aa6-4770-81da-8dbd87013906"
+    }
   },
   {
     "name": {
@@ -22586,8 +24476,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-1px",
     "uuid": "7d44a2b5-0aa6-4770-81da-8dbd87013906",
-    "deprecated": "unknown",
-    "deprecated_comment": "Should be zero; no token"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Should be zero; no token"
+    }
   },
   {
     "name": {
@@ -22598,9 +24490,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "c7c837c3-47ad-4ef1-a2eb-e4629628eb44",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-small instead.",
-    "replaced_by": "a8a20ecd-480e-4681-8639-c44d6dcb0658"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-small instead.",
+      "replacedBy": "a8a20ecd-480e-4681-8639-c44d6dcb0658"
+    }
   },
   {
     "name": {
@@ -22615,9 +24509,11 @@
     "uuid": "e5e3b415-97a9-436d-b46d-9bf48d7a2104",
     "set_uuid": "fcea2a25-e08c-46d2-8e0f-474e89eeb21d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead.",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -22632,9 +24528,11 @@
     "uuid": "096032da-c0b4-4086-82e9-ab80c2b3d90b",
     "set_uuid": "fcea2a25-e08c-46d2-8e0f-474e89eeb21d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
-    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-gap-medium instead.",
+      "replacedBy": "3cd1e483-969b-492c-8d44-d29348c981a5"
+    }
   },
   {
     "name": {
@@ -22648,9 +24546,11 @@
     "uuid": "cf7044fe-e79d-44e4-8ae0-c9c23ac5b9ac",
     "set_uuid": "33f6922a-9f40-4cee-95c6-dd8f4c7cb259",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead.",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead.",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -22664,9 +24564,11 @@
     "uuid": "038d525f-357a-4441-934e-093d7342eba8",
     "set_uuid": "33f6922a-9f40-4cee-95c6-dd8f4c7cb259",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-indent-medium instead.",
-    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-indent-medium instead.",
+      "replacedBy": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+    }
   },
   {
     "name": {
@@ -22704,9 +24606,11 @@
     "uuid": "1569ef2c-0e00-4314-87d0-e8f703b9fee8",
     "set_uuid": "777bb6b8-4378-426e-a6dc-4411049ea153",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22720,9 +24624,11 @@
     "uuid": "50ce9fc5-eab5-4ab5-8dfa-a22d5b4361e9",
     "set_uuid": "777bb6b8-4378-426e-a6dc-4411049ea153",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22789,9 +24695,11 @@
     "uuid": "20a69a94-ddc0-4581-bac9-1d0d2b3e0a48",
     "set_uuid": "53394c0d-54d2-45cf-a7e1-32875bcea1ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead.",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22806,9 +24714,11 @@
     "uuid": "7bea161d-9ee0-41b0-a31b-162926b28637",
     "set_uuid": "53394c0d-54d2-45cf-a7e1-32875bcea1ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead.",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22823,9 +24733,11 @@
     "uuid": "6f33e161-86d3-40a4-b631-e7c8b9e9d337",
     "set_uuid": "7bf6c9ab-4b83-43d4-babc-77dc63542f8d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead.",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22840,9 +24752,11 @@
     "uuid": "b148e202-b43d-4089-b0d8-885fc99cb983",
     "set_uuid": "7bf6c9ab-4b83-43d4-babc-77dc63542f8d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead.",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22857,9 +24771,11 @@
     "uuid": "138541e2-022a-4b03-b4d2-c6932ec56ac2",
     "set_uuid": "a075e8d8-3c95-4d34-a5eb-3499e2aa4cef",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Design spec's show different value/measurement than token value",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead. Design spec's show different value/measurement than token value",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22874,9 +24790,11 @@
     "uuid": "aae1c8b3-2aa1-4463-ad84-a52f80a6a09b",
     "set_uuid": "a075e8d8-3c95-4d34-a5eb-3499e2aa4cef",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Design spec's show different value/measurement than token value",
-    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token list-item-padding-vertical-regular instead. Design spec's show different value/measurement than token value",
+      "replacedBy": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+    }
   },
   {
     "name": {
@@ -22891,9 +24809,11 @@
     "uuid": "7fc57ed1-9ca8-4b08-b19f-4aa8c49ca6f3",
     "set_uuid": "61b7a466-eee3-4aa9-9734-d8f739653b0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Drag handle will need to be in a frame with height equal to workflow-icon-size-[size]",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Drag handle will need to be in a frame with height equal to workflow-icon-size-[size]",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22908,9 +24828,11 @@
     "uuid": "bb805e5e-d65b-4daf-9116-288fa59ddbfd",
     "set_uuid": "61b7a466-eee3-4aa9-9734-d8f739653b0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Drag handle will need to be in a frame with height equal to workflow-icon-size-[size]",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Drag handle will need to be in a frame with height equal to workflow-icon-size-[size]",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22925,9 +24847,11 @@
     "uuid": "a6a556b7-ff51-41e3-84d0-92fa8ef01ed6",
     "set_uuid": "8a605bda-4bd2-416d-bfb3-2b9c242eb092",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -22942,9 +24866,11 @@
     "uuid": "d2e3ca68-015b-47a4-96ea-0c380e931c09",
     "set_uuid": "8a605bda-4bd2-416d-bfb3-2b9c242eb092",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -777,7 +777,9 @@
     "uuid": "8b5b5dce-a9c4-4c03-a194-8a5bc716b18a",
     "set_uuid": "a234522c-7f9e-481e-aa19-10398c0cb952",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -794,7 +796,9 @@
     "uuid": "2cfe025b-8bf8-47a3-8ff1-733cf62dd182",
     "set_uuid": "a234522c-7f9e-481e-aa19-10398c0cb952",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -811,7 +815,9 @@
     "uuid": "3f385135-015a-44dd-bde3-60389b14c2ff",
     "set_uuid": "120d71db-cd03-41a9-ab52-36ac7b1e62dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -828,7 +834,9 @@
     "uuid": "cef58f98-9fb0-4fbb-b6aa-dc5786d7658a",
     "set_uuid": "120d71db-cd03-41a9-ab52-36ac7b1e62dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -845,7 +853,9 @@
     "uuid": "2ebe9ae0-3b74-47dc-af79-e1dd5f93b9bd",
     "set_uuid": "899f64eb-79ae-4292-ad03-8cafe139d788",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -862,7 +872,9 @@
     "uuid": "1cecea81-8c7f-4658-b3a2-0e1282f7eac9",
     "set_uuid": "899f64eb-79ae-4292-ad03-8cafe139d788",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -879,7 +891,9 @@
     "uuid": "f2f62625-dfd4-46b0-9113-033820745569",
     "set_uuid": "d2115b45-9155-4037-b16e-7b8d8977da4f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -896,7 +910,9 @@
     "uuid": "819cdbf4-9e26-4fdf-895d-8f60c06efa2a",
     "set_uuid": "d2115b45-9155-4037-b16e-7b8d8977da4f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -936,9 +952,11 @@
     "uuid": "24def269-4582-46f6-a00c-8b5a28410917",
     "set_uuid": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -950,9 +968,11 @@
     "uuid": "c8590269-dcaa-44f6-9c2d-d33274c3fe5e",
     "set_uuid": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -964,9 +984,11 @@
     "uuid": "ae65b844-9758-4708-8781-2c8df35af1e9",
     "set_uuid": "36742697-2320-4bc0-8a29-ad98e342349f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -978,9 +1000,11 @@
     "uuid": "a39cef5c-631c-4942-b5d2-9121e05d47f8",
     "set_uuid": "36742697-2320-4bc0-8a29-ad98e342349f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -992,9 +1016,11 @@
     "uuid": "4459554a-d872-4a6a-a620-4a1937605d29",
     "set_uuid": "e731e2e4-c3bf-4dff-aca0-04201e7e17ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1006,9 +1032,11 @@
     "uuid": "a6aac364-d617-4e21-a1db-5523daaa3c6c",
     "set_uuid": "e731e2e4-c3bf-4dff-aca0-04201e7e17ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1020,9 +1048,11 @@
     "uuid": "ee165c7d-3e9a-4a8d-a71f-3083fd7fdc4b",
     "set_uuid": "66f28027-02df-4ff7-bab5-f2ea3fa482c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -1034,9 +1064,11 @@
     "uuid": "80f01183-a152-4c55-ac11-24edae62df64",
     "set_uuid": "66f28027-02df-4ff7-bab5-f2ea3fa482c3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -1048,9 +1080,11 @@
     "uuid": "923c46e1-b6f7-4d8a-844d-b4c0661b5e60",
     "set_uuid": "861fff6a-7163-495d-bcb1-caa87693fb55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1062,9 +1096,11 @@
     "uuid": "0f1a6c63-bc4f-444c-9a18-67b6c35464b1",
     "set_uuid": "861fff6a-7163-495d-bcb1-caa87693fb55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1076,9 +1112,11 @@
     "uuid": "0c0d6d38-6734-4312-9be5-dd48dd571841",
     "set_uuid": "7f2bb2ef-58c0-41f9-8109-0edf0ccf3d5d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1090,9 +1128,11 @@
     "uuid": "0b3ecfcf-8fb9-4faf-ab7f-ff4baf733df5",
     "set_uuid": "7f2bb2ef-58c0-41f9-8109-0edf0ccf3d5d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1104,9 +1144,11 @@
     "uuid": "44a668d6-e013-4138-a262-383994b0637f",
     "set_uuid": "d4e8c9a0-af84-445b-b7b3-ca55ced11875",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1118,9 +1160,11 @@
     "uuid": "c567f435-928c-4bf8-b9c0-ac2f22d58348",
     "set_uuid": "d4e8c9a0-af84-445b-b7b3-ca55ced11875",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1132,9 +1176,11 @@
     "uuid": "11088de1-8e3b-4021-968d-a8c59c7b00bd",
     "set_uuid": "c1e05fb1-09f6-49b9-86d9-a508cbec1dd6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1146,9 +1192,11 @@
     "uuid": "616de468-71fc-4315-87ea-47cdc508a599",
     "set_uuid": "c1e05fb1-09f6-49b9-86d9-a508cbec1dd6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1160,9 +1208,11 @@
     "uuid": "b8af0ff9-1e4b-4298-907d-3ffcde88ba03",
     "set_uuid": "de0a3da6-a982-40d9-8196-5c7b5e9f6f78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    }
   },
   {
     "name": {
@@ -1174,9 +1224,11 @@
     "uuid": "d660beeb-278b-4157-b6fc-852c680ecae7",
     "set_uuid": "de0a3da6-a982-40d9-8196-5c7b5e9f6f78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    }
   },
   {
     "name": {
@@ -1188,9 +1240,11 @@
     "uuid": "40778817-6e47-4b58-a495-c4f34cee78df",
     "set_uuid": "7c44b345-e7eb-49ff-9276-7460559d1b43",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -1202,9 +1256,11 @@
     "uuid": "942f0f34-611a-4318-9b0e-3632e7f520b3",
     "set_uuid": "7c44b345-e7eb-49ff-9276-7460559d1b43",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -1216,9 +1272,11 @@
     "uuid": "e220eb52-f821-4807-9ab7-b5f3905d769f",
     "set_uuid": "57eb05a3-85d0-4aa5-ae22-0df4b2f2f429",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1230,9 +1288,11 @@
     "uuid": "e77f525e-5043-49c1-a663-9f6c30067043",
     "set_uuid": "57eb05a3-85d0-4aa5-ae22-0df4b2f2f429",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1244,9 +1304,11 @@
     "uuid": "e0673a9f-7993-490c-b2db-e8e836837e83",
     "set_uuid": "062bb2be-32ee-4fd9-846e-5b94dc5fdf30",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1258,9 +1320,11 @@
     "uuid": "85f7f49a-7b87-4e2f-b44e-70e3ccde6291",
     "set_uuid": "062bb2be-32ee-4fd9-846e-5b94dc5fdf30",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1272,9 +1336,11 @@
     "uuid": "a0ce87ca-29e0-40e3-b7dc-c53678effd9b",
     "set_uuid": "b076e022-a80a-4a2b-aee9-baa287c88ad4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1286,9 +1352,11 @@
     "uuid": "4973c83c-792d-4bc1-9e3d-d047993292ba",
     "set_uuid": "b076e022-a80a-4a2b-aee9-baa287c88ad4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1300,9 +1368,11 @@
     "uuid": "a0b6c266-499d-4292-9be4-705ddd5e9fbc",
     "set_uuid": "c99f282c-7e8f-4d3e-9e08-fbe40a3d4676",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    }
   },
   {
     "name": {
@@ -1314,9 +1384,11 @@
     "uuid": "0b157417-e40f-481c-87e3-8563d55b3135",
     "set_uuid": "c99f282c-7e8f-4d3e-9e08-fbe40a3d4676",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+    }
   },
   {
     "name": {
@@ -1328,9 +1400,11 @@
     "uuid": "8d128c7d-ab8e-4a4e-9243-a2e919cb6e6f",
     "set_uuid": "a72fe016-4be0-44ee-8400-877e7914879c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -1342,9 +1416,11 @@
     "uuid": "acc3e1b9-532d-485e-84e4-06e744c744b3",
     "set_uuid": "a72fe016-4be0-44ee-8400-877e7914879c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -1356,9 +1432,11 @@
     "uuid": "8fec6012-7cba-4ac5-94d7-14f39fce7612",
     "set_uuid": "fe65b840-a0b2-48b5-88c4-052d48f0c0c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1370,9 +1448,11 @@
     "uuid": "93e42bfc-c2f0-40cd-a561-9045c68cb5d1",
     "set_uuid": "fe65b840-a0b2-48b5-88c4-052d48f0c0c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1384,9 +1464,11 @@
     "uuid": "0bf1ad10-235a-4c81-aba7-5bf55acc877d",
     "set_uuid": "37dfa899-aec4-4273-a8de-6a8d2ff08c57",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1398,9 +1480,11 @@
     "uuid": "9dffd6f3-6230-425e-9208-296cf4d5c185",
     "set_uuid": "37dfa899-aec4-4273-a8de-6a8d2ff08c57",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1412,9 +1496,11 @@
     "uuid": "815523cd-8c01-4125-bb22-3a548f1cc702",
     "set_uuid": "3d33bea5-f19d-438a-88d3-908188ff3e2e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1426,9 +1512,11 @@
     "uuid": "090b3da5-0aa3-4bf8-b3bd-dd8dabb40721",
     "set_uuid": "3d33bea5-f19d-438a-88d3-908188ff3e2e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1440,9 +1528,11 @@
     "uuid": "9c536051-7794-4282-bf07-c920cda83cbe",
     "set_uuid": "1afe4259-26f6-405d-8db1-9f976a846917",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -1454,9 +1544,11 @@
     "uuid": "fd1c11a6-53d5-4253-a7d7-c4131c4b1a5e",
     "set_uuid": "1afe4259-26f6-405d-8db1-9f976a846917",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -1468,9 +1560,11 @@
     "uuid": "c38259e9-87f4-4e7d-a041-692ca676a638",
     "set_uuid": "676c9089-353a-4ea0-8692-6aae56552143",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1482,9 +1576,11 @@
     "uuid": "5c4f1f7a-2218-4d03-ac83-9750c2c9336b",
     "set_uuid": "676c9089-353a-4ea0-8692-6aae56552143",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Using consistent spacing regardless of text or visual",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Using consistent spacing regardless of text or visual",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1650,9 +1746,11 @@
     "uuid": "5b2e9907-858e-41f9-9c63-a37e30ec472e",
     "set_uuid": "b449c7b9-e88c-47ad-ac3c-09b4c6ac59ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1664,9 +1762,11 @@
     "uuid": "67715127-dfd9-44ed-a3bf-4816e9dafb34",
     "set_uuid": "b449c7b9-e88c-47ad-ac3c-09b4c6ac59ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -1678,9 +1778,11 @@
     "uuid": "2af29e94-8c2c-475c-bde0-4e3f2ebd5df4",
     "set_uuid": "67a7d15d-10d6-476e-b130-cd7a0bc9300b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1692,9 +1794,11 @@
     "uuid": "e5202547-d71b-4e1f-8d60-fe1e63cf18f9",
     "set_uuid": "67a7d15d-10d6-476e-b130-cd7a0bc9300b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -1706,9 +1810,11 @@
     "uuid": "894526c7-315d-4325-be16-8e99a8a2586b",
     "set_uuid": "8c72f949-3f29-4e48-98fa-2d1670245c0c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1720,9 +1826,11 @@
     "uuid": "ae78edbb-1b08-44d6-9c5a-37baf2fe94f6",
     "set_uuid": "8c72f949-3f29-4e48-98fa-2d1670245c0c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -1734,9 +1842,11 @@
     "uuid": "409b876c-ae13-4d31-8487-9bfcd9b8be69",
     "set_uuid": "f5a258bc-64be-4497-87d9-1946e1684415",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -1748,9 +1858,11 @@
     "uuid": "262dd415-ea5d-4f07-9493-030ac33a2dce",
     "set_uuid": "f5a258bc-64be-4497-87d9-1946e1684415",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -1762,9 +1874,11 @@
     "uuid": "6ff7a5b7-4344-4498-887d-3af9585035a7",
     "set_uuid": "1ba30b7a-fa69-41da-828b-37df5a59d0ac",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1776,9 +1890,11 @@
     "uuid": "ae87b22b-17dd-46a1-9c40-ec4fbe701e95",
     "set_uuid": "1ba30b7a-fa69-41da-828b-37df5a59d0ac",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -1790,9 +1906,11 @@
     "uuid": "3c96bdad-6e05-4a1b-930b-92d35adf5d9d",
     "set_uuid": "4bc3ba2a-1e76-464a-9886-2db2d8dd961c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1804,9 +1922,11 @@
     "uuid": "10e326b3-bcce-47df-a1ab-0e3ab9964dd2",
     "set_uuid": "4bc3ba2a-1e76-464a-9886-2db2d8dd961c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1818,9 +1938,11 @@
     "uuid": "4cca2097-286e-46d5-bc8e-273ea50354e7",
     "set_uuid": "5facff87-0dd6-4193-9634-dedd452ca35e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1832,9 +1954,11 @@
     "uuid": "c77f6b68-32b7-499c-81d9-50855cc68279",
     "set_uuid": "5facff87-0dd6-4193-9634-dedd452ca35e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1846,9 +1970,11 @@
     "uuid": "29fa8da5-3f74-4141-bfb1-0f2847655345",
     "set_uuid": "fa5beb85-a5d3-42cb-aa40-e5dc4b5976d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1860,9 +1986,11 @@
     "uuid": "dd7bc474-d5f1-46fe-8a6e-b1645c34c982",
     "set_uuid": "fa5beb85-a5d3-42cb-aa40-e5dc4b5976d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1874,9 +2002,11 @@
     "uuid": "5c80900c-ff68-4b78-86fa-571bbf1eb9aa",
     "set_uuid": "7f421435-8922-49e3-a598-8f1391051554",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -1888,9 +2018,11 @@
     "uuid": "8a23edfc-b993-48bb-917f-377051e02dff",
     "set_uuid": "7f421435-8922-49e3-a598-8f1391051554",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -1902,9 +2034,11 @@
     "uuid": "fff86b73-4e28-4453-9ba3-7c40998ace07",
     "set_uuid": "73e613ee-50a2-4666-b091-9cc36cf8f717",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1916,9 +2050,11 @@
     "uuid": "14624bfc-b08f-4637-991b-94a703a7b808",
     "set_uuid": "73e613ee-50a2-4666-b091-9cc36cf8f717",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -1930,9 +2066,11 @@
     "uuid": "b9324a3c-557e-4832-8418-1d7783e7b9be",
     "set_uuid": "ad42620f-70e0-49a2-8727-01314f2dc88b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1944,9 +2082,11 @@
     "uuid": "053363f2-5b8e-4365-8353-3cffac169608",
     "set_uuid": "ad42620f-70e0-49a2-8727-01314f2dc88b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -1958,9 +2098,11 @@
     "uuid": "4ccb4a02-6aa9-459a-a459-1d0ebbe2dc11",
     "set_uuid": "e82f9abf-54e8-483c-8a0a-338becca7ba3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1972,9 +2114,11 @@
     "uuid": "7ae3b6ee-2f80-4596-9d4a-08a5bf9612a7",
     "set_uuid": "e82f9abf-54e8-483c-8a0a-338becca7ba3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -1986,9 +2130,11 @@
     "uuid": "3eaca9fb-25c0-4a1d-8c44-320cc0e0305b",
     "set_uuid": "11128037-8bd7-46a1-9915-3655e1824ee4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -2000,9 +2146,11 @@
     "uuid": "64343da6-f1a6-4615-b2b8-41f9509679e5",
     "set_uuid": "11128037-8bd7-46a1-9915-3655e1824ee4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -2014,9 +2162,11 @@
     "uuid": "dd9e6e28-a382-46a1-a6e0-f73c8cc0ed70",
     "set_uuid": "ede2c7d6-a602-42f3-a1e0-54e642bcd5f5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    }
   },
   {
     "name": {
@@ -2028,9 +2178,11 @@
     "uuid": "cf58ae75-8f3f-4b9e-809b-ee78abbb2f2f",
     "set_uuid": "ede2c7d6-a602-42f3-a1e0-54e642bcd5f5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+    }
   },
   {
     "name": {
@@ -2042,9 +2194,11 @@
     "uuid": "64cdd254-d3fe-40e6-97a8-76dd8156afa8",
     "set_uuid": "30720515-0648-4cdd-a5cd-411d5dd9d6d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    }
   },
   {
     "name": {
@@ -2056,9 +2210,11 @@
     "uuid": "989aee4c-5c90-454a-b68d-a7564669c2bd",
     "set_uuid": "30720515-0648-4cdd-a5cd-411d5dd9d6d6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+    }
   },
   {
     "name": {
@@ -2070,9 +2226,11 @@
     "uuid": "9654369a-5bf8-4436-a331-aeac1fd25a70",
     "set_uuid": "3c029bf1-8fef-4356-9b95-f5d15b6b54d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    }
   },
   {
     "name": {
@@ -2084,9 +2242,11 @@
     "uuid": "cb4f356c-2dcd-4043-8f5c-3da904716b48",
     "set_uuid": "3c029bf1-8fef-4356-9b95-f5d15b6b54d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token accessory-item-padding-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+    }
   },
   {
     "name": {
@@ -2098,9 +2258,11 @@
     "uuid": "47f5ab02-22db-4d82-be1d-804669d7fbd4",
     "set_uuid": "2c5317e6-a13f-4592-8e71-c37953fb4a55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -2112,9 +2274,11 @@
     "uuid": "7332a4d3-3775-4247-a4c0-fb01f0604d63",
     "set_uuid": "2c5317e6-a13f-4592-8e71-c37953fb4a55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -2162,9 +2326,11 @@
     "uuid": "31f44472-9681-469c-8ba2-9efc27eb981d",
     "set_uuid": "c5ff0c89-a9ad-4f9e-a050-afea29822149",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2176,9 +2342,11 @@
     "uuid": "9fa90167-54ec-4343-a14c-4cd18963dcc5",
     "set_uuid": "c5ff0c89-a9ad-4f9e-a050-afea29822149",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2190,9 +2358,11 @@
     "uuid": "d03d1199-f49d-4e57-8434-b94efe5da440",
     "set_uuid": "d4ed0bd1-8d06-42e0-a480-8d07291a1b61",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2204,9 +2374,11 @@
     "uuid": "b33acdfa-525e-45c6-ab2b-c959760c4024",
     "set_uuid": "d4ed0bd1-8d06-42e0-a480-8d07291a1b61",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2218,9 +2390,11 @@
     "uuid": "0190ca9d-9f28-45b2-9dc7-c715089faebb",
     "set_uuid": "480244fc-5cb5-4156-b03f-b1aef8c8e111",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2232,9 +2406,11 @@
     "uuid": "e8602fbe-1bf9-4aec-9cb0-5b4e994558c9",
     "set_uuid": "480244fc-5cb5-4156-b03f-b1aef8c8e111",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2246,9 +2422,11 @@
     "uuid": "4db24ebf-e169-4220-b895-787fe09f8658",
     "set_uuid": "bb51e98e-bf71-4348-86b2-3a560cc2035d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2260,9 +2438,11 @@
     "uuid": "cc2c2606-500a-45e2-b460-2b498dcddb26",
     "set_uuid": "bb51e98e-bf71-4348-86b2-3a560cc2035d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
-    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+      "replacedBy": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+    }
   },
   {
     "name": {
@@ -2274,9 +2454,11 @@
     "uuid": "15bf492b-3a65-4577-8a3b-df09026b96a7",
     "set_uuid": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -2288,9 +2470,11 @@
     "uuid": "bed358a2-0559-4501-a147-b375887f25af",
     "set_uuid": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -2302,9 +2486,11 @@
     "uuid": "c7914376-3769-4172-8467-fb811b3c155f",
     "set_uuid": "306b871f-cbfa-49a2-a74b-dd120bbff503",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -2316,9 +2502,11 @@
     "uuid": "621c9cf1-02e2-478b-9f47-0804f0183531",
     "set_uuid": "306b871f-cbfa-49a2-a74b-dd120bbff503",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -2330,9 +2518,11 @@
     "uuid": "9bf3970e-eb76-4be5-82c4-0df2538df753",
     "set_uuid": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -2344,9 +2534,11 @@
     "uuid": "e0ae8c97-73ee-4b09-839f-5ebfb6eb0d7a",
     "set_uuid": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -2358,9 +2550,11 @@
     "uuid": "c71c0953-d9da-4e22-93a1-6982c7665ed6",
     "set_uuid": "320554e7-5437-4c16-a851-3e5b74e6a6af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -2372,9 +2566,11 @@
     "uuid": "cb2a6539-4cee-420c-aeef-dbdd3220039d",
     "set_uuid": "320554e7-5437-4c16-a851-3e5b74e6a6af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -2386,9 +2582,11 @@
     "uuid": "477d659b-6489-4e90-84db-75a93174559a",
     "set_uuid": "1a76668b-c733-4ec0-ae84-774f4e6e861a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -2400,9 +2598,11 @@
     "uuid": "54a0e5cf-3e4a-454b-9dba-a6a2c277fa5e",
     "set_uuid": "1a76668b-c733-4ec0-ae84-774f4e6e861a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -2414,9 +2614,11 @@
     "uuid": "c3a280b0-bc84-4a7c-8048-c689f8deef86",
     "set_uuid": "2b17325c-eec1-43e2-9a31-957adf67e44d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -2428,9 +2630,11 @@
     "uuid": "a3d3f9e9-a784-445a-a052-22f84b832512",
     "set_uuid": "2b17325c-eec1-43e2-9a31-957adf67e44d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -2442,9 +2646,11 @@
     "uuid": "ef82b92a-2cbd-4b70-920c-4b999b018e07",
     "set_uuid": "81bfcc6f-348b-4728-bfdc-10f2f181b041",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -2456,9 +2662,11 @@
     "uuid": "259c0cf5-d321-4a6b-a3ae-b8c58fc1c9d6",
     "set_uuid": "81bfcc6f-348b-4728-bfdc-10f2f181b041",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -2470,9 +2678,11 @@
     "uuid": "72d6ae5c-e133-4e7f-bc96-3e4c28d586fd",
     "set_uuid": "955bbeaf-dc4e-460b-8957-d145d4b6fc3e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -2484,9 +2694,11 @@
     "uuid": "bac14298-68f0-4fb6-a152-c95ab19fd27f",
     "set_uuid": "955bbeaf-dc4e-460b-8957-d145d4b6fc3e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -2498,9 +2710,11 @@
     "uuid": "0fafc819-d65b-4952-849a-b3c426e9a4a9",
     "set_uuid": "dbd9a29e-259d-4291-a24a-2926989edc46",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -2512,9 +2726,11 @@
     "uuid": "24853983-c1b0-422d-84b6-05b9313066ed",
     "set_uuid": "dbd9a29e-259d-4291-a24a-2926989edc46",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
-    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+      "replacedBy": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+    }
   },
   {
     "name": {
@@ -2526,9 +2742,11 @@
     "uuid": "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
     "set_uuid": "3b07cd46-add6-4cd9-b3f8-626f113905dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -2540,9 +2758,11 @@
     "uuid": "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3",
     "set_uuid": "3b07cd46-add6-4cd9-b3f8-626f113905dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -2993,7 +3213,9 @@
     "uuid": "6fcfc18c-c5e0-4f50-beab-6c4a10bfdaa7",
     "set_uuid": "623e55f9-ec0f-48f1-91ed-d88e36d41d18",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3006,7 +3228,9 @@
     "uuid": "1352ad8f-a8ec-459d-8ae3-71c27038a29d",
     "set_uuid": "623e55f9-ec0f-48f1-91ed-d88e36d41d18",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3019,7 +3243,9 @@
     "uuid": "9c2db47b-f017-432a-a44f-238bc461c4c1",
     "set_uuid": "e16424f5-12e3-4577-a3a4-414aa9eaacbf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3032,7 +3258,9 @@
     "uuid": "2be65bca-0f16-4754-bc8a-4a491ba87b90",
     "set_uuid": "e16424f5-12e3-4577-a3a4-414aa9eaacbf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3045,7 +3273,9 @@
     "uuid": "c9c18669-11bf-4ba3-b36f-26115981327c",
     "set_uuid": "587b1bdb-f6a8-4526-a454-db5dc2997e67",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3058,7 +3288,9 @@
     "uuid": "d396d74a-425d-4f06-837f-349f81ebf486",
     "set_uuid": "587b1bdb-f6a8-4526-a454-db5dc2997e67",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3071,7 +3303,9 @@
     "uuid": "490fac13-d347-4c21-85fa-57814bff7537",
     "set_uuid": "c12846fb-bd7e-4df0-8345-5148f68a5e7e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3084,7 +3318,9 @@
     "uuid": "434b019c-efde-437a-967b-b841ec95e621",
     "set_uuid": "c12846fb-bd7e-4df0-8345-5148f68a5e7e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -3099,8 +3335,10 @@
     "uuid": "ba7492f3-1a19-4d75-98cc-34a0d46ea802",
     "set_uuid": "4c5c2390-1571-4141-9ebd-a3e0b1e58322",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3115,8 +3353,10 @@
     "uuid": "9c38e8f6-cca7-4f7f-a7c3-9d4ee7af24b8",
     "set_uuid": "4c5c2390-1571-4141-9ebd-a3e0b1e58322",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3131,8 +3371,10 @@
     "uuid": "ae9bbf8d-a896-4667-9034-2fd2dfeb1981",
     "set_uuid": "62e0b1be-4808-48b9-9781-6f1e7dc03bfa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3147,8 +3389,10 @@
     "uuid": "24dd2c12-17f0-4d38-9af3-a3b112c40c74",
     "set_uuid": "62e0b1be-4808-48b9-9781-6f1e7dc03bfa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3163,8 +3407,10 @@
     "uuid": "1e644622-9b4a-4cce-9cf7-2474d58f4956",
     "set_uuid": "0d3919ac-7385-44e7-81b8-c01bc74694ea",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3179,8 +3425,10 @@
     "uuid": "049e0fe7-03d4-4d9b-bdcd-9c8a06852010",
     "set_uuid": "0d3919ac-7385-44e7-81b8-c01bc74694ea",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3195,8 +3443,10 @@
     "uuid": "e8e0164f-2588-4c8e-9b85-543ce5a8fadb",
     "set_uuid": "6cc29d18-30d9-48bf-88c0-3e56945725b3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3211,8 +3461,10 @@
     "uuid": "d7c1f2a1-b679-42ae-8512-27883d9789f9",
     "set_uuid": "6cc29d18-30d9-48bf-88c0-3e56945725b3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+    }
   },
   {
     "name": {
@@ -3223,7 +3475,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "025e39f4-dfe7-4a8a-beb5-bd0577f72eac",
     "uuid": "ac20a6da-31a7-4c8b-b361-0ad820cd8429",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3405,7 +3659,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "751d636e-efb5-411e-a5b8-06b11439cc90",
     "uuid": "81415747-aa3f-4ef3-b0bc-7c33f07a4316",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3449,7 +3705,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ed1f46fd-a586-46a5-8cc1-d843a57e2cc2",
     "uuid": "c530129f-248c-4e36-ba7f-05d6d6a53962",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3519,9 +3777,11 @@
     "uuid": "7ea18d45-d6e1-4ef0-859d-4d39a3e0527a",
     "set_uuid": "f68f57de-df8c-49b5-9af8-566c2382f669",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -3537,9 +3797,11 @@
     "uuid": "2a77de7a-20cb-40a2-b3a9-252fcaa7a7d2",
     "set_uuid": "f68f57de-df8c-49b5-9af8-566c2382f669",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -3555,9 +3817,11 @@
     "uuid": "e0b53a9a-e95a-45b8-b9b2-a16b70096c05",
     "set_uuid": "78b56170-dc93-4f41-a110-94f9415c2222",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -3573,9 +3837,11 @@
     "uuid": "a7c0e1fc-bc57-450e-bdc2-1c2cf2823d98",
     "set_uuid": "78b56170-dc93-4f41-a110-94f9415c2222",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -3591,9 +3857,11 @@
     "uuid": "dd684a30-2e49-4096-8b1c-40fbd6c8cac2",
     "set_uuid": "4507a27d-3072-47f0-a2b9-ca8523e7d3c9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -3609,9 +3877,11 @@
     "uuid": "b98d3a2d-94fb-4491-9650-1c9a62365a19",
     "set_uuid": "4507a27d-3072-47f0-a2b9-ca8523e7d3c9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -3625,7 +3895,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "7858fdf3-e35f-4bc5-997a-0d480ec1cb32",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3641,9 +3913,11 @@
     "uuid": "20658099-94df-4c6c-a2f2-558c92174121",
     "set_uuid": "c1aa6fda-f075-415a-b9f4-008885d7fccd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -3659,9 +3933,11 @@
     "uuid": "68c4dc34-49cb-4174-bd06-5f5dfbd0b64e",
     "set_uuid": "c1aa6fda-f075-415a-b9f4-008885d7fccd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -3674,7 +3950,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "7fb81dcf-3329-4353-917d-75de8f43c05d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3689,9 +3967,11 @@
     "uuid": "71b53c8b-fbbb-4f84-847a-45db5ad8006f",
     "set_uuid": "08c0704d-7431-47b9-a69c-1d2f22276cf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -3706,9 +3986,11 @@
     "uuid": "26d578cb-9228-4643-b042-8b00ba4d9b61",
     "set_uuid": "08c0704d-7431-47b9-a69c-1d2f22276cf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -3723,9 +4005,11 @@
     "uuid": "77792f9d-b462-48e6-a4de-abf804bed3cd",
     "set_uuid": "c6883771-d661-4330-9be6-508218cc5854",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -3740,9 +4024,11 @@
     "uuid": "fcc139c1-08ed-4641-932d-5050237abfaa",
     "set_uuid": "c6883771-d661-4330-9be6-508218cc5854",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -3757,9 +4043,11 @@
     "uuid": "e84ef1dc-392b-4ab9-a13b-76364484a28d",
     "set_uuid": "9b70b304-6f74-466e-9515-cfd8aa2e42de",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -3774,9 +4062,11 @@
     "uuid": "0d3045e2-a493-406a-a247-8d20f35db2d9",
     "set_uuid": "9b70b304-6f74-466e-9515-cfd8aa2e42de",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -3791,9 +4081,11 @@
     "uuid": "7b68e88f-8ddd-496e-9fae-7fbe44317965",
     "set_uuid": "8fca1357-25ac-4bbf-afe5-86c4b70431d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -3808,9 +4100,11 @@
     "uuid": "87d3f491-f45f-4bee-9dbd-00086cca5858",
     "set_uuid": "8fca1357-25ac-4bbf-afe5-86c4b70431d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -3823,7 +4117,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "3f7cee20-c187-4066-be4b-f5a1335736f5",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3839,9 +4135,11 @@
     "uuid": "9379019f-5498-45d1-8590-deb8a234a3d4",
     "set_uuid": "81a3d661-160e-448d-8f3a-994a01b4c0e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -3857,9 +4155,11 @@
     "uuid": "539800f6-7bbc-4b67-8b61-99d1ee2f69a4",
     "set_uuid": "81a3d661-160e-448d-8f3a-994a01b4c0e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -3875,9 +4175,11 @@
     "uuid": "faf7879f-d9c1-4bf1-8af7-95f48240bcf0",
     "set_uuid": "3efc3753-19da-4e87-9c07-f0b379a3ac98",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -3893,9 +4195,11 @@
     "uuid": "9525d928-4cdb-4cf5-8616-2024ed6fb7c0",
     "set_uuid": "3efc3753-19da-4e87-9c07-f0b379a3ac98",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -3911,9 +4215,11 @@
     "uuid": "a93c8845-c89b-4e8d-b06e-c34e7c7b0e99",
     "set_uuid": "700aa9e4-d819-490f-ac2f-b0311b643620",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -3929,9 +4235,11 @@
     "uuid": "c51f02a2-35d4-460f-9f14-a97d9e8e6616",
     "set_uuid": "700aa9e4-d819-490f-ac2f-b0311b643620",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -3945,7 +4253,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "151915e5-f946-474f-9595-18d8a159a6ff",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3961,9 +4271,11 @@
     "uuid": "9ab112d7-af82-4b28-9bc2-a1216af87aea",
     "set_uuid": "5f116e74-21ad-4397-8fd0-72697de194c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -3979,9 +4291,11 @@
     "uuid": "a1c55785-3ae3-4c23-81e2-f088e76e4e04",
     "set_uuid": "5f116e74-21ad-4397-8fd0-72697de194c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -3994,8 +4308,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "89f16f89-fd7d-41d7-8e5c-464007fd0277",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -4010,9 +4326,11 @@
     "uuid": "9fa71233-f98e-4d48-b2af-29552a62a479",
     "set_uuid": "2f97eb00-aff0-41b5-b896-dc8bbc80f231",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -4027,9 +4345,11 @@
     "uuid": "7b3ab0f8-8bde-461f-b658-6848d64de0e3",
     "set_uuid": "2f97eb00-aff0-41b5-b896-dc8bbc80f231",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -4044,9 +4364,11 @@
     "uuid": "622a39c4-4ed1-4637-8e8d-e8e6a72099b2",
     "set_uuid": "7ba0ae7a-0e9f-4bec-a08c-d016a25b94c4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -4061,9 +4383,11 @@
     "uuid": "417eb2ee-3fe9-47fc-a122-d466eb4e7b26",
     "set_uuid": "7ba0ae7a-0e9f-4bec-a08c-d016a25b94c4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -4078,9 +4402,11 @@
     "uuid": "43ec5915-b039-4210-9bc0-ce547f90ce32",
     "set_uuid": "15f664f0-b351-4a6c-b7cd-b252d3979a38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -4095,9 +4421,11 @@
     "uuid": "7c2b5cc0-01c0-4e5f-a157-1d2432f8bbc1",
     "set_uuid": "15f664f0-b351-4a6c-b7cd-b252d3979a38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -4112,9 +4440,11 @@
     "uuid": "b79e5061-87c4-495c-ab01-90dcc5ae14ab",
     "set_uuid": "8cdd703c-9931-43bd-9ff9-3cc129f7316e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -4129,9 +4459,11 @@
     "uuid": "927e7b5a-57b4-4d47-9ad8-e287199e68a3",
     "set_uuid": "8cdd703c-9931-43bd-9ff9-3cc129f7316e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -4148,9 +4480,11 @@
     "uuid": "248144ce-6640-40ce-96a3-162c406c7edf",
     "set_uuid": "3507c44d-62d4-4422-a62e-d463a23eb9cf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -4167,9 +4501,11 @@
     "uuid": "ec794a47-71af-42ea-87f2-048fab8dbf9d",
     "set_uuid": "3507c44d-62d4-4422-a62e-d463a23eb9cf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -4186,9 +4522,11 @@
     "uuid": "0f40702e-876a-4fb4-aeb7-ea56c26c081b",
     "set_uuid": "8cee0a0d-2faf-4620-ad54-0c48780a9add",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -4205,9 +4543,11 @@
     "uuid": "73025a05-6203-460b-830b-458f8109abce",
     "set_uuid": "8cee0a0d-2faf-4620-ad54-0c48780a9add",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -4224,9 +4564,11 @@
     "uuid": "cce2dfd4-b10f-4386-8f16-2bc2d47e49f5",
     "set_uuid": "dcce6c23-1a67-49db-826f-e4e3e2d94f01",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -4243,9 +4585,11 @@
     "uuid": "03d088d2-4ec9-45bc-896d-8423bf72317e",
     "set_uuid": "dcce6c23-1a67-49db-826f-e4e3e2d94f01",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -4262,9 +4606,11 @@
     "uuid": "2d900e70-913e-4d45-9ef4-2ef8d80798fc",
     "set_uuid": "3975bf43-b0fb-4ab9-92fb-c4936e1d31b9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -4281,9 +4627,11 @@
     "uuid": "01ad9b7d-926e-4db4-a86a-a804fdfc7d68",
     "set_uuid": "3975bf43-b0fb-4ab9-92fb-c4936e1d31b9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -4300,9 +4648,11 @@
     "uuid": "8a573d4a-0543-4e77-8f54-5ad1706d87e7",
     "set_uuid": "461753a3-581e-4675-bcff-13386fe17123",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -4319,9 +4669,11 @@
     "uuid": "8926578a-c326-4a75-aafb-d90112aaedb5",
     "set_uuid": "461753a3-581e-4675-bcff-13386fe17123",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "b32fb20b-31a7-43da-ba38-b9a177d0cffa"
+    }
   },
   {
     "name": {
@@ -4338,9 +4690,11 @@
     "uuid": "f9729ef3-9807-4401-80dd-b1c209c00065",
     "set_uuid": "5d8df662-c7ca-4b45-931d-92c4b27c00c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -4357,9 +4711,11 @@
     "uuid": "b28a0156-4930-484c-a518-ee00e0292db5",
     "set_uuid": "5d8df662-c7ca-4b45-931d-92c4b27c00c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "ece70425-e509-45cc-8336-76fc8afdb921"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "ece70425-e509-45cc-8336-76fc8afdb921"
+    }
   },
   {
     "name": {
@@ -4376,9 +4732,11 @@
     "uuid": "da53a8e5-95c3-48dd-a9c0-5ed2de25240d",
     "set_uuid": "ac8e642d-666a-4d38-be97-6fe05edf1006",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -4395,9 +4753,11 @@
     "uuid": "87e221ab-fb8c-4d59-9d4b-9815a672cc23",
     "set_uuid": "ac8e642d-666a-4d38-be97-6fe05edf1006",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -4414,9 +4774,11 @@
     "uuid": "574ddef0-b45b-49a1-b057-fb2eacfbd36f",
     "set_uuid": "6d6c6035-1f3f-4e6c-8140-f5dc5a06a8d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -4433,9 +4795,11 @@
     "uuid": "c2181581-6aa1-4e1f-80bc-1ca2e85ea01b",
     "set_uuid": "6d6c6035-1f3f-4e6c-8140-f5dc5a06a8d8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
-    "replaced_by": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-small instead.",
+      "replacedBy": "ba072414-2cdd-4773-86a5-11ca47c08e23"
+    }
   },
   {
     "name": {
@@ -4451,9 +4815,11 @@
     "uuid": "78286e58-d73a-42a8-a13c-a910d7fbb82d",
     "set_uuid": "91d122d2-799b-45c3-aa4e-4f1a0c7336b2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4469,9 +4835,11 @@
     "uuid": "246058b4-e152-4673-91ab-34384fceb798",
     "set_uuid": "91d122d2-799b-45c3-aa4e-4f1a0c7336b2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4487,9 +4855,11 @@
     "uuid": "7e21ccc7-ba55-4e0f-b5a5-1bd95406546f",
     "set_uuid": "2ec841a0-c05a-43d6-a77f-093ccf710819",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4505,9 +4875,11 @@
     "uuid": "6247903e-2c00-4242-b2d5-da2864b6aa87",
     "set_uuid": "2ec841a0-c05a-43d6-a77f-093ccf710819",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4523,9 +4895,11 @@
     "uuid": "adac6224-8e2f-4cdb-8684-9365164a1499",
     "set_uuid": "e0425fc4-00bc-4bbd-9d07-576303dca294",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4541,9 +4915,11 @@
     "uuid": "1def1d88-0098-4e00-987f-17a8656047da",
     "set_uuid": "e0425fc4-00bc-4bbd-9d07-576303dca294",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4559,9 +4935,11 @@
     "uuid": "f265e6d5-8bbd-464e-b6c7-637224756e95",
     "set_uuid": "785eb0f4-da05-495d-820b-b0b0423b1c14",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4577,9 +4955,11 @@
     "uuid": "580b677d-5d7e-4306-87ee-640a4613254b",
     "set_uuid": "785eb0f4-da05-495d-820b-b0b0423b1c14",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4594,9 +4974,11 @@
     "uuid": "62c3618c-f28f-4b56-9227-a061dc54d19d",
     "set_uuid": "987dc285-af97-4789-9b3f-e5b5d5ec9fb8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4611,9 +4993,11 @@
     "uuid": "1357cf8e-6e41-4d3c-be39-9aa87d010b78",
     "set_uuid": "987dc285-af97-4789-9b3f-e5b5d5ec9fb8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4628,9 +5012,11 @@
     "uuid": "bdf0fc6a-404c-492c-86bb-5d2ba06714e6",
     "set_uuid": "82ae361f-08a5-4b1a-836c-b04ef78f4858",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4645,9 +5031,11 @@
     "uuid": "2af47c9c-dba6-4340-b5fc-af00dcbaa05c",
     "set_uuid": "82ae361f-08a5-4b1a-836c-b04ef78f4858",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4662,9 +5050,11 @@
     "uuid": "d5db6c17-700e-4782-9c29-001269b50200",
     "set_uuid": "e1b2120f-2776-4ba9-80f8-a0179fc1c875",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4679,9 +5069,11 @@
     "uuid": "631146ab-f3f2-4ea0-aac1-2bea622d0c85",
     "set_uuid": "e1b2120f-2776-4ba9-80f8-a0179fc1c875",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4696,9 +5088,11 @@
     "uuid": "c5778e77-0ff1-431a-a72e-37f3066d3257",
     "set_uuid": "f5f8ca7b-afdb-45e7-a800-ce1c2ba42455",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4713,9 +5107,11 @@
     "uuid": "2f62718d-3df8-498b-9520-baf8be65f3bd",
     "set_uuid": "f5f8ca7b-afdb-45e7-a800-ce1c2ba42455",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4732,9 +5128,11 @@
     "uuid": "39f7e2c2-219b-4f4d-a45a-c0e2e458312e",
     "set_uuid": "c2526e95-2c98-44ae-85f9-1cadab28a1f7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4751,9 +5149,11 @@
     "uuid": "88fbbbe8-6dda-4d11-8d13-ed0fabaf0088",
     "set_uuid": "c2526e95-2c98-44ae-85f9-1cadab28a1f7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4770,9 +5170,11 @@
     "uuid": "101de772-de06-40dc-b3fb-9f3ff4ff4b45",
     "set_uuid": "8d37cc81-84fc-46d8-b629-860adf5da2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4789,9 +5191,11 @@
     "uuid": "d00bddef-eb79-4c0a-8794-52fa5b3d9b5c",
     "set_uuid": "8d37cc81-84fc-46d8-b629-860adf5da2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4808,9 +5212,11 @@
     "uuid": "b1e50285-c36d-4d95-a609-255a39845436",
     "set_uuid": "423eb2e6-f1c8-4f22-8440-24e4357a997e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4827,9 +5233,11 @@
     "uuid": "45385813-55dc-4a9f-81f8-c77a482b7268",
     "set_uuid": "423eb2e6-f1c8-4f22-8440-24e4357a997e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4846,9 +5254,11 @@
     "uuid": "6138a3a4-4d5f-42ae-b1eb-6d2b44b51072",
     "set_uuid": "36306a18-68d0-4f08-9787-d068b6886597",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4865,9 +5275,11 @@
     "uuid": "bc3eee47-eb83-4ed7-9414-f9fbf620395b",
     "set_uuid": "36306a18-68d0-4f08-9787-d068b6886597",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -4882,9 +5294,11 @@
     "uuid": "8ac99ac4-b63c-4824-a49f-35f0820cde81",
     "set_uuid": "3a61c18d-594e-48c4-b97a-1d0f5cb8fc7d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4899,9 +5313,11 @@
     "uuid": "4a5f821c-2703-48ba-85d2-15c922514839",
     "set_uuid": "3a61c18d-594e-48c4-b97a-1d0f5cb8fc7d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -4916,9 +5332,11 @@
     "uuid": "b7093f51-e97a-4cdc-b068-f00ef8bb6658",
     "set_uuid": "51fc01cc-6abc-4f90-863b-c32a7832bde8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4933,9 +5351,11 @@
     "uuid": "ef7a07e3-a405-4788-a62b-771b0db019a8",
     "set_uuid": "51fc01cc-6abc-4f90-863b-c32a7832bde8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -4950,9 +5370,11 @@
     "uuid": "54198ff3-d745-40b1-bcc0-2bca4fe1955e",
     "set_uuid": "44f67c88-cec3-4f0e-8450-37238b579fb9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4967,9 +5389,11 @@
     "uuid": "854384ce-1548-4e55-b19e-042b7a82db0e",
     "set_uuid": "44f67c88-cec3-4f0e-8450-37238b579fb9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -4984,9 +5408,11 @@
     "uuid": "0516bc3d-36a1-4dcb-9d1d-1fce7c431890",
     "set_uuid": "8920c8e0-863d-433e-aeec-3f860b840e3c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5001,9 +5427,11 @@
     "uuid": "2bdf7b47-450a-4da9-bddb-f4cef626c889",
     "set_uuid": "8920c8e0-863d-433e-aeec-3f860b840e3c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5020,9 +5448,11 @@
     "uuid": "ca7c26d4-38eb-4382-b524-a27c73a34b7a",
     "set_uuid": "3b949237-530a-41f5-8d54-50bbc8365c87",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5039,9 +5469,11 @@
     "uuid": "45f97901-f614-42bc-b22b-c0b6cebb945b",
     "set_uuid": "3b949237-530a-41f5-8d54-50bbc8365c87",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5058,9 +5490,11 @@
     "uuid": "a3ee5984-d111-47f6-98b7-ad96b525e1ef",
     "set_uuid": "52aedc0a-d0c8-4eaf-aa08-023aacc78f2c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5077,9 +5511,11 @@
     "uuid": "14cb8fe0-892a-438f-a794-9b013ef96d96",
     "set_uuid": "52aedc0a-d0c8-4eaf-aa08-023aacc78f2c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5096,9 +5532,11 @@
     "uuid": "35900436-1a71-4a06-8b21-53b98398f7bc",
     "set_uuid": "7a986039-e496-4c6c-8536-3d19f2a7232c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5115,9 +5553,11 @@
     "uuid": "b7cde8bc-0553-4045-8fc1-edaf8f429950",
     "set_uuid": "7a986039-e496-4c6c-8536-3d19f2a7232c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5134,9 +5574,11 @@
     "uuid": "0f68ff7a-b68e-4688-9da1-bbce083d2b98",
     "set_uuid": "64c68ea1-20c2-4c2a-821f-cad39e8476de",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5153,9 +5595,11 @@
     "uuid": "178832d2-9ead-4804-a025-5883eec850d6",
     "set_uuid": "64c68ea1-20c2-4c2a-821f-cad39e8476de",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5171,9 +5615,11 @@
     "uuid": "efcd740a-033e-493a-a902-e2f657897bd4",
     "set_uuid": "84872a73-c77a-41e4-9ea1-8b00eb983283",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5189,9 +5635,11 @@
     "uuid": "263428f7-3b5a-449a-87d1-874cebf50fa8",
     "set_uuid": "84872a73-c77a-41e4-9ea1-8b00eb983283",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5207,9 +5655,11 @@
     "uuid": "24784275-a117-4767-98ee-5d8a08c89296",
     "set_uuid": "1bf807cd-f255-4e31-b337-83ff635bd043",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5225,9 +5675,11 @@
     "uuid": "7a17cc60-fa76-4234-a99e-c4f711e63f5f",
     "set_uuid": "1bf807cd-f255-4e31-b337-83ff635bd043",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5243,9 +5695,11 @@
     "uuid": "7a3120a8-3c98-4227-afb4-5d6a8aa78e14",
     "set_uuid": "0aa91d86-b000-453b-bfe8-ba2320288282",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5261,9 +5715,11 @@
     "uuid": "7b4b7283-1223-4d2e-9f24-5ed6dada4711",
     "set_uuid": "0aa91d86-b000-453b-bfe8-ba2320288282",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5279,9 +5735,11 @@
     "uuid": "9aac1df2-1693-43f1-ae43-b23c21a42f71",
     "set_uuid": "797ba48e-a1ff-4c18-8489-0d59be960616",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5297,9 +5755,11 @@
     "uuid": "5da7e575-d0c3-44e7-bbfa-6fa58972343b",
     "set_uuid": "797ba48e-a1ff-4c18-8489-0d59be960616",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5315,9 +5775,11 @@
     "uuid": "aa10c6ff-8cf6-4e68-8181-ca5e64f5c26f",
     "set_uuid": "a5ad9ef8-fed7-4726-8ae6-5a87b8ee66c1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5333,9 +5795,11 @@
     "uuid": "a6da1cb9-6085-4c58-b3dc-3b1377f64fa4",
     "set_uuid": "a5ad9ef8-fed7-4726-8ae6-5a87b8ee66c1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5351,9 +5815,11 @@
     "uuid": "97435915-44ba-4ace-993f-a0fac52e41f2",
     "set_uuid": "5aa2d68f-472b-420e-892d-08025e1e962f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5369,9 +5835,11 @@
     "uuid": "f4f9d889-130a-4e71-9a9c-1ee82c2a4a4b",
     "set_uuid": "5aa2d68f-472b-420e-892d-08025e1e962f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5387,9 +5855,11 @@
     "uuid": "2cdb6de8-d494-467d-bf9d-7fa96829bf82",
     "set_uuid": "58d6a35b-1158-43fb-8b0c-06d479682ebf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5405,9 +5875,11 @@
     "uuid": "7bb6c4c7-4157-4da9-bf06-1d2527022d6a",
     "set_uuid": "58d6a35b-1158-43fb-8b0c-06d479682ebf",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5423,9 +5895,11 @@
     "uuid": "2aad124e-19f5-404c-921e-e2060bc48f07",
     "set_uuid": "da1ccd21-d162-464a-8772-2f0609b7accc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5441,9 +5915,11 @@
     "uuid": "1a5b6e87-12a8-4fda-a8f7-2928b0b68a46",
     "set_uuid": "da1ccd21-d162-464a-8772-2f0609b7accc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -5456,9 +5932,11 @@
     "uuid": "096ddcb7-5afd-416f-9a11-4275556c4b52",
     "set_uuid": "ad37a519-be52-492e-a816-03ed7608fe65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
-    "replaced_by": "f35ec29c-b8ee-46c9-9c8c-c40171a15920"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.19",
+      "deprecatedComment": "This token has been deprecated, use field-default-width-medium instead.",
+      "replacedBy": "f35ec29c-b8ee-46c9-9c8c-c40171a15920"
+    }
   },
   {
     "name": {
@@ -5471,9 +5949,11 @@
     "uuid": "08c2390a-353b-4e6b-b025-dbaeaa5fdff2",
     "set_uuid": "ad37a519-be52-492e-a816-03ed7608fe65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
-    "replaced_by": "db379ff6-9ef2-44ee-9fce-32f1a53d68da"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.19",
+      "deprecatedComment": "This token has been deprecated, use field-default-width-medium instead.",
+      "replacedBy": "db379ff6-9ef2-44ee-9fce-32f1a53d68da"
+    }
   },
   {
     "name": {
@@ -5484,12 +5964,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "23090def-780a-48cb-b644-8edd55189d46",
     "uuid": "a903b595-ffe8-43ae-af9b-7b6577191dc5",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use field-default-width-extra-large instead.",
-    "replaced_by": [
-      "23090def-780a-48cb-b644-8edd55189d46",
-      "068a256a-8dfc-4616-bdc1-8895441ba90b"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.24",
+      "deprecatedComment": "This token has been deprecated, use field-default-width-extra-large instead.",
+      "replacedBy": [
+        "23090def-780a-48cb-b644-8edd55189d46",
+        "068a256a-8dfc-4616-bdc1-8895441ba90b"
+      ]
+    }
   },
   {
     "name": {
@@ -5500,12 +5982,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c6d08f8b-4e8c-478a-8b08-5b69d2da1a5e",
     "uuid": "cc43e053-1255-403f-aaf5-2182f5438592",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use field-default-width-large instead.",
-    "replaced_by": [
-      "c6d08f8b-4e8c-478a-8b08-5b69d2da1a5e",
-      "88dfd273-555a-49bc-9271-a63ad45964e2"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.24",
+      "deprecatedComment": "This token has been deprecated, use field-default-width-large instead.",
+      "replacedBy": [
+        "c6d08f8b-4e8c-478a-8b08-5b69d2da1a5e",
+        "88dfd273-555a-49bc-9271-a63ad45964e2"
+      ]
+    }
   },
   {
     "name": {
@@ -5516,12 +6000,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f35ec29c-b8ee-46c9-9c8c-c40171a15920",
     "uuid": "935927d3-b25e-468a-999a-938643901e50",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
-    "replaced_by": [
-      "f35ec29c-b8ee-46c9-9c8c-c40171a15920",
-      "db379ff6-9ef2-44ee-9fce-32f1a53d68da"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.24",
+      "deprecatedComment": "This token has been deprecated, use field-default-width-medium instead.",
+      "replacedBy": [
+        "f35ec29c-b8ee-46c9-9c8c-c40171a15920",
+        "db379ff6-9ef2-44ee-9fce-32f1a53d68da"
+      ]
+    }
   },
   {
     "name": {
@@ -5532,12 +6018,14 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "39c39c14-0500-4bf6-a542-967697aaff41",
     "uuid": "d316d676-b4cf-4d16-b89c-63ef1d969861",
-    "deprecated": "unknown",
-    "deprecated_comment": "This token has been deprecated, use field-default-width-small instead.",
-    "replaced_by": [
-      "39c39c14-0500-4bf6-a542-967697aaff41",
-      "976298d3-326f-43da-aa71-bbd2dc1fad3d"
-    ]
+    "lifecycle": {
+      "deprecatedIn": "13.0.0-beta.24",
+      "deprecatedComment": "This token has been deprecated, use field-default-width-small instead.",
+      "replacedBy": [
+        "39c39c14-0500-4bf6-a542-967697aaff41",
+        "976298d3-326f-43da-aa71-bbd2dc1fad3d"
+      ]
+    }
   },
   {
     "name": {
@@ -5547,9 +6035,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
     "uuid": "693651ef-71c7-4096-91a5-1c84cb861021",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token focus-ring-gap instead.",
-    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token focus-ring-gap instead.",
+      "replacedBy": "fb035d45-e63b-4cd4-b220-675a52e99399"
+    }
   },
   {
     "name": {
@@ -5766,8 +6256,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "4a00c810-c099-4de1-85b8-aaa7ed9538bb",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -5903,9 +6395,11 @@
     "uuid": "ac4d18d5-361c-4425-82c3-83979d58f682",
     "set_uuid": "1ead9248-4325-443a-9223-08175b82df95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5918,9 +6412,11 @@
     "uuid": "e68f2798-6a55-499a-b591-0cfc130607ba",
     "set_uuid": "1ead9248-4325-443a-9223-08175b82df95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
-    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+      "replacedBy": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+    }
   },
   {
     "name": {
@@ -5933,9 +6429,11 @@
     "uuid": "c0e06d21-7372-401f-9ec2-926e2b1faf26",
     "set_uuid": "f888e2bb-2fe5-45df-891f-3168a6737aed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5948,9 +6446,11 @@
     "uuid": "e84bc865-c89f-403e-bb14-2a11f03fd364",
     "set_uuid": "f888e2bb-2fe5-45df-891f-3168a6737aed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
-    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+      "replacedBy": "cc707192-e70f-4965-8582-55fa97d02184"
+    }
   },
   {
     "name": {
@@ -5963,9 +6463,11 @@
     "uuid": "5561a148-fd77-44d3-b29d-3ed7389122a1",
     "set_uuid": "e01b062a-4928-4999-9da0-17ef4fe2f05a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5978,9 +6480,11 @@
     "uuid": "74f8a686-0e06-4f7c-9e3d-694749beb420",
     "set_uuid": "e01b062a-4928-4999-9da0-17ef4fe2f05a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
-    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+      "replacedBy": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+    }
   },
   {
     "name": {
@@ -5993,9 +6497,11 @@
     "uuid": "70de4f97-bc4a-44af-9995-1042e3c7c78f",
     "set_uuid": "5a394022-1daa-4052-852d-a47c256e13c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -6008,9 +6514,11 @@
     "uuid": "d11ab0de-19bd-4f56-8798-0192fd0cfe0e",
     "set_uuid": "5a394022-1daa-4052-852d-a47c256e13c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
-    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+      "replacedBy": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+    }
   },
   {
     "name": {
@@ -6054,9 +6562,11 @@
     "uuid": "146add82-4f20-46c3-bacf-4d24d60d0e10",
     "set_uuid": "99abd526-5415-44cc-bee7-f6fd6cfb6396",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -6069,9 +6579,11 @@
     "uuid": "ec387876-31d5-42a5-99aa-02c5d35e6223",
     "set_uuid": "99abd526-5415-44cc-bee7-f6fd6cfb6396",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
-    "replaced_by": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-padding-horizontal-medium instead.",
+      "replacedBy": "52a75511-eb1b-4de2-a1bb-959365d8dc1a"
+    }
   },
   {
     "name": {
@@ -6081,8 +6593,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "9b1f15bf-ea4f-4f82-8c4f-3770b7f47353",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6092,8 +6606,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "e2d9e241-469a-4b03-bd6a-a105a8ed5e00",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6103,8 +6619,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "4d93210f-f01a-4d1c-8c10-2cb4b9d14626",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6114,8 +6632,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
     "uuid": "a86ae363-b6b4-4da0-9630-97336922b3a1",
-    "deprecated": "unknown",
-    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+    }
   },
   {
     "name": {
@@ -6417,9 +6937,11 @@
     "uuid": "24a438ce-be6a-477e-aa0e-a3e97e286904",
     "set_uuid": "ce43ae27-fb9c-422f-9f82-494c0491edd8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -6434,9 +6956,11 @@
     "uuid": "b4ce04fa-bc03-44c9-afef-a38810ac9c65",
     "set_uuid": "ce43ae27-fb9c-422f-9f82-494c0491edd8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -6451,9 +6975,11 @@
     "uuid": "307fb510-8759-41ee-89d2-fcfe4d554b85",
     "set_uuid": "a71a56bf-2c9f-45de-b0b4-9e03f1a9febb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -6468,9 +6994,11 @@
     "uuid": "8991287c-763f-4a39-ad5b-7ccdbc39b3f6",
     "set_uuid": "a71a56bf-2c9f-45de-b0b4-9e03f1a9febb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -6485,9 +7013,11 @@
     "uuid": "7cde8c74-2ac9-4468-a25e-06c1a6cd9cbe",
     "set_uuid": "72908bb2-fb57-4455-aed4-0f3f40ab3365",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -6502,9 +7032,11 @@
     "uuid": "53a33d46-8d81-4f13-8c79-c4d9257a5b68",
     "set_uuid": "72908bb2-fb57-4455-aed4-0f3f40ab3365",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -6519,9 +7051,11 @@
     "uuid": "4b47e7a8-b330-4c6c-a497-9ee9eed0c50a",
     "set_uuid": "f9da434a-7742-4d38-ad52-05dec8d09cfa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -6536,9 +7070,11 @@
     "uuid": "56e2cc0c-7d56-454e-bb4f-4517f412eeac",
     "set_uuid": "f9da434a-7742-4d38-ad52-05dec8d09cfa",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -6553,9 +7089,11 @@
     "uuid": "aa27af6e-baef-4d7c-bf8c-f9a972e51713",
     "set_uuid": "f0974e76-c721-44ca-ad5a-2594b63aaaea",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -6570,9 +7108,11 @@
     "uuid": "45f94495-0f53-42b2-94f6-7a6d91eb2ca1",
     "set_uuid": "f0974e76-c721-44ca-ad5a-2594b63aaaea",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -6587,9 +7127,11 @@
     "uuid": "1d601d0a-d6d0-4711-9fb9-71898c2bcc9a",
     "set_uuid": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -6604,9 +7146,11 @@
     "uuid": "09d55113-8d94-429f-b0c8-ffabe8ccba27",
     "set_uuid": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -6621,9 +7165,11 @@
     "uuid": "7ce11af3-b94b-4239-a310-f8d09635779a",
     "set_uuid": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -6638,9 +7184,11 @@
     "uuid": "dc4ec555-72eb-4328-aba4-e8d594102f45",
     "set_uuid": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-large instead.",
-    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-large instead.",
+      "replacedBy": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+    }
   },
   {
     "name": {
@@ -6655,9 +7203,11 @@
     "uuid": "4366909e-3bfb-481c-abdc-4ae71f965bc3",
     "set_uuid": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -6672,9 +7222,11 @@
     "uuid": "205f0c77-6588-4cc7-927f-3ba767200bac",
     "set_uuid": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
-    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-large instead.",
+      "replacedBy": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+    }
   },
   {
     "name": {
@@ -6689,9 +7241,11 @@
     "uuid": "3d393d59-b358-48a7-82c6-a7802408cd0d",
     "set_uuid": "7140744e-5e07-4967-baac-3651f8cc408f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead.",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -6706,9 +7260,11 @@
     "uuid": "b496071f-4151-4bc2-86eb-f2e41947e0f6",
     "set_uuid": "7140744e-5e07-4967-baac-3651f8cc408f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
-    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-2x-large instead.",
+      "replacedBy": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+    }
   },
   {
     "name": {
@@ -6723,9 +7279,11 @@
     "uuid": "ff1fadc2-9ec0-456f-a054-4512e51c85c8",
     "set_uuid": "8cbec20e-d19d-4281-9447-16c128db23a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -6740,9 +7298,11 @@
     "uuid": "8588bf80-96df-40fb-8b6f-61d06899f8dd",
     "set_uuid": "8cbec20e-d19d-4281-9447-16c128db23a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
-    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-extra-small instead.",
+      "replacedBy": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+    }
   },
   {
     "name": {
@@ -6757,9 +7317,11 @@
     "uuid": "50763a0d-c6eb-47f0-8b56-4c86ee22a430",
     "set_uuid": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -6774,9 +7336,11 @@
     "uuid": "77dc4cd4-8e4e-4873-b6f3-d573eb7fc315",
     "set_uuid": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-small instead.",
-    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-small instead.",
+      "replacedBy": "1247c1ab-9e31-482a-832c-d32911a1e698"
+    }
   },
   {
     "name": {
@@ -6785,9 +7349,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
     "uuid": "d9d51235-f3fe-4e2a-bdca-b6a104d9a9e5",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token text-gap-medium instead.",
-    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token text-gap-medium instead.",
+      "replacedBy": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+    }
   },
   {
     "name": {
@@ -6812,9 +7378,11 @@
     "uuid": "0a392deb-fee3-4968-bc52-1377f9e23307",
     "set_uuid": "1b567a73-7b2e-44bd-8e4d-1e324343083f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -6829,9 +7397,11 @@
     "uuid": "16b8c9c7-a601-4ff9-bf9d-c5a118738506",
     "set_uuid": "1b567a73-7b2e-44bd-8e4d-1e324343083f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token base-gap-medium instead.",
-    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token base-gap-medium instead.",
+      "replacedBy": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+    }
   },
   {
     "name": {
@@ -6841,9 +7411,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",
     "uuid": "a3e53161-c38a-4ee0-88c2-4a36fd530e51",
-    "deprecated": "unknown",
-    "deprecated_comment": "Use semantic token container-padding-3x-large instead.",
-    "replaced_by": "e595caf6-37f9-4f84-b81b-dd44ed0d6431"
+    "lifecycle": {
+      "deprecatedIn": "14.3.0",
+      "deprecatedComment": "Use semantic token container-padding-3x-large instead.",
+      "replacedBy": "e595caf6-37f9-4f84-b81b-dd44ed0d6431"
+    }
   },
   {
     "name": {
@@ -7051,7 +7623,9 @@
     "uuid": "40abc60f-ab65-41ef-b724-a0f0bdd94d14",
     "set_uuid": "dccab61e-8eed-4fa6-99c3-b997c987dd62",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7063,7 +7637,9 @@
     "uuid": "9e882a20-b8e1-4e9b-89f9-26f21db3cd78",
     "set_uuid": "dccab61e-8eed-4fa6-99c3-b997c987dd62",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7075,7 +7651,9 @@
     "uuid": "6392e605-932e-456d-be53-149b624a04e2",
     "set_uuid": "6650d78d-2317-41c2-bb9b-e2789cffb5c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7087,7 +7665,9 @@
     "uuid": "9948e083-8c75-48f7-8e58-32c75ec76116",
     "set_uuid": "6650d78d-2317-41c2-bb9b-e2789cffb5c0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7099,7 +7679,9 @@
     "uuid": "25908278-79d3-47f4-9b53-adbdd1c13e2a",
     "set_uuid": "c50ba02d-538f-456c-9d8d-f6ca5b1b5881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7111,7 +7693,9 @@
     "uuid": "df0dc6c3-59fc-4ee0-87a9-c3d49a07cf9c",
     "set_uuid": "c50ba02d-538f-456c-9d8d-f6ca5b1b5881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7123,7 +7707,9 @@
     "uuid": "1423caf1-75ca-4ca8-aa6a-22dcf3655b0e",
     "set_uuid": "10abd2ac-fdb8-4dee-86a6-1588acc7b366",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7135,7 +7721,9 @@
     "uuid": "4c4cb541-7d42-4bb4-9c86-7197c4600896",
     "set_uuid": "10abd2ac-fdb8-4dee-86a6-1588acc7b366",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7147,7 +7735,9 @@
     "uuid": "85cdef34-0682-45eb-ac06-98c76883cdf7",
     "set_uuid": "e1029ff5-5b9c-4717-8cdb-4ced6b554c01",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {
@@ -7159,7 +7749,9 @@
     "uuid": "b720c214-babe-426d-9629-9ec60d5e8622",
     "set_uuid": "e1029ff5-5b9c-4717-8cdb-4ced6b554c01",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "14.5.0"
+    }
   },
   {
     "name": {

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -641,7 +641,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "30fa3891-135b-405a-bf0f-3cc17f711079",
     "uuid": "a553db3e-a051-4023-87eb-da6545b983b2",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -654,7 +656,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "1eea917c-52e7-4295-b0e1-d33c2e73a137",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -667,7 +671,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "9513cf13-8537-443f-81ce-f9d88292ba32",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -680,7 +686,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "4b6aaf76-e0ab-4be0-81c0-d5f64cacee88",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -1186,7 +1186,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c7b1b312-cd81-4c65-8a67-017f91aee40b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1198,7 +1200,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "279d9a16-279f-4788-b5b0-af825a4b5d40",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1210,7 +1214,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "4cc06d86-326e-4b6f-a751-99445bb1d131",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1222,7 +1228,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "3b531775-a1fd-4a40-b169-7c42b8c6de38",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1234,7 +1242,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "1d4235ff-c183-4d6c-8277-9783e3e1ce7a",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1246,7 +1256,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "0bc51146-a3e5-48c4-8324-4490b9d30f4d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1258,7 +1270,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "ec87fefe-f35f-41a0-9be1-6d076f0db230",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1270,7 +1284,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "91231878-73dc-46ce-a277-1d14e0e36842",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1403,7 +1419,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0.06em",
     "uuid": "c4dbe044-dc8c-4722-b36c-5442cd2bc279",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1500,7 +1518,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "fc6098a2-3263-433c-8378-ba609629ef53",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1512,7 +1532,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "64972012-5050-41d0-9c9b-269b533a58b7",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1524,7 +1546,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "a6b7c26e-3ff5-4241-b9cc-3026604fe30e",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1536,7 +1560,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "cf8f93e2-2b79-4a4c-bb31-313e013148e3",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1548,7 +1574,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "b7364639-2686-4e12-9ede-d6543d0d0d6d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1560,7 +1588,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "53f16a1c-9d44-4384-9a7e-88a2c4319486",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1572,7 +1602,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c1966f09-1c6e-4fe0-89ad-8fb8e847e3ba",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1584,7 +1616,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "4f0f95d3-098a-4852-bd21-785f5bf054b5",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1639,7 +1673,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/text-transform.json",
     "value": "uppercase",
     "uuid": "8646d403-21f9-4e77-8a21-92289c303715",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1703,7 +1739,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "320bcd8e-2bb8-4e9e-9b1d-4838b2966857",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1715,7 +1753,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "3d27f76e-b068-4f06-bea8-ee31fcbc49b2",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1727,7 +1767,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "f6478d1d-5dcf-43eb-a4fc-498479b29aa7",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1739,7 +1781,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "2a15a805-fd08-4f8e-82e6-9264ef8937cb",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1751,7 +1795,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "42d2049f-cda2-4ae4-8d0a-41f7789f768b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1763,7 +1809,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "1c524d85-9fca-433c-b5c4-5eaa456cc3a2",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1775,7 +1823,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "7a878a3f-b663-41ee-8357-6e62f2e51d80",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1787,7 +1837,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "fc5df058-f678-4dc8-953f-e2738798ee2b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -1842,7 +1894,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/text-transform.json",
     "value": "uppercase",
     "uuid": "0e161c32-c412-4cda-bacb-7eaa548b5534",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2528,7 +2582,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "dac03eec-6910-4176-bfca-33f8a57cf3d7",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2540,7 +2596,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "aea9787b-ee0b-40cc-9089-5973e52b18bd",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2552,7 +2610,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b5704c75-2914-4268-9023-7f7452e826c1",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2564,7 +2624,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "9da0ba4c-b4e3-4052-8b2e-d2fde714bb9d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2576,7 +2638,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "9136e25e-563b-4485-bad7-41809d5317de",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2588,7 +2652,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "83cc347c-7a1a-4665-9de4-cf19903f1043",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2600,7 +2666,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "be854057-43b1-40ce-bdc7-69960cd7638c",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2612,7 +2680,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "5ca91bc2-215b-4cbb-b966-80bfffd569ad",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2707,7 +2777,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "bddd6a96-c280-47ca-8858-20df055e488d",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2969,7 +3041,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "5f88eb81-7052-4c21-9896-f14cb09f0e70",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2981,7 +3055,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "e882ea46-8f0a-4313-84f5-85bb8d9f1f5e",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -2993,7 +3069,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c5551fd5-4ee2-4c93-b91f-9ed295fa63a4",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3005,7 +3083,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "ff84a748-5923-451d-967c-a346d2dee46c",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3017,7 +3097,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "bc5d65e0-e13a-424c-a260-9268a0dee66c",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3029,7 +3111,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "c297a503-fc3c-4939-8c5a-6611b9b04719",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3041,7 +3125,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "67271ca0-c9fd-4047-a615-6314d7333f7a",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3053,7 +3139,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "75437f9a-7ee8-4194-b4b3-0746be097396",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3249,7 +3337,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "7bd831cd-3fe0-402b-a105-f65b8e8023e2",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3261,7 +3351,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "b5f79fde-07f7-4c07-897e-0bfdf27e2839",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3273,7 +3365,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "5f30418a-aa76-434e-bca9-902d5be0d929",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3285,7 +3379,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "66958795-6459-4750-8c68-dc39ab383837",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3297,7 +3393,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "71c8e302-6bc1-4f45-b804-c847dd153d1b",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3309,7 +3407,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "98c61df3-057d-4345-881e-0c04628757f3",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3321,7 +3421,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "73906871-24e5-48cc-9140-ec700c08d144",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3333,7 +3435,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "29ad1c96-62e4-4143-88e8-fc8e08913a52",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {
@@ -3455,7 +3559,9 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "82a831b4-b624-475b-b2be-4eb949e48626",
-    "deprecated": "unknown"
+    "lifecycle": {
+      "deprecatedIn": "13.0.0"
+    }
   },
   {
     "name": {

--- a/sdk/core/src/authoring/lifecycle.rs
+++ b/sdk/core/src/authoring/lifecycle.rs
@@ -127,27 +127,35 @@ pub struct DeprecateTokenInput {
     pub uuid: String,
     /// Path to the `*.tokens.json` cascade file that contains this token.
     pub target: PathBuf,
-    /// The active dataset `specVersion` string to stamp as the `deprecated` value.
+    /// The active dataset `specVersion` string to stamp as `lifecycle.deprecatedIn`.
     pub spec_version: String,
-    /// Human-readable deprecation explanation / migration guidance.
+    /// Human-readable deprecation explanation / migration guidance
+    /// (`lifecycle.deprecatedComment`).
     pub deprecated_comment: Option<String>,
-    /// Replacement token UUID (string) or UUIDs (array of strings).
+    /// Replacement token UUID (string) or UUIDs (array of strings)
+    /// (`lifecycle.replacedBy`).
     pub replaced_by: Option<Value>,
-    /// Spec version when the token will be removed.
+    /// Spec version when the token will be removed (`lifecycle.plannedRemoval`).
     pub planned_removal: Option<String>,
     pub rationale: Option<String>,
 }
 
 /// Deprecate a token and enforce the lifecycle cross-field contract.
 ///
-/// **Contract** (`token-format.md` L145–155):
-/// - If `replaced_by` is an **array**, `deprecated_comment` is **REQUIRED** (L149).
-/// - If `replaced_by` is present, `deprecated` MUST also be set (L151) — always
-///   satisfied here because we always set `deprecated`.
-/// - If `planned_removal` is present, it MUST NOT precede `deprecated` (L153).
+/// Writes into the nested `lifecycle` object (see `token-format.md`'s lifecycle
+/// section), merging with any existing `lifecycle.introduced` rather than
+/// clobbering it.
 ///
-/// Additionally, `deprecated_comment` **SHOULD** accompany `deprecated` (L147);
-/// this is advisory and does not block the operation.
+/// **Contract**:
+/// - If `lifecycle.replacedBy` is an **array**, `lifecycle.deprecatedComment` is
+///   **REQUIRED**.
+/// - If `lifecycle.replacedBy` is present, `lifecycle.deprecatedIn` MUST also be
+///   set — always satisfied here because we always set `deprecatedIn`.
+/// - If `lifecycle.plannedRemoval` is present, it MUST NOT precede
+///   `lifecycle.deprecatedIn`.
+///
+/// Additionally, `lifecycle.deprecatedComment` **SHOULD** accompany
+/// `lifecycle.deprecatedIn`; this is advisory and does not block the operation.
 pub fn deprecate_token(
     input: DeprecateTokenInput,
     registry: &SchemaRegistry,
@@ -194,22 +202,31 @@ pub fn deprecate_token(
         .as_object_mut()
         .ok_or("token is not a JSON object")?;
 
-    token.insert(
-        "deprecated".into(),
+    // Merge into any existing `lifecycle` object (e.g. preserving `introduced`)
+    // rather than clobbering it.
+    let mut lifecycle = match token.remove("lifecycle") {
+        Some(Value::Object(m)) => m,
+        _ => Map::new(),
+    };
+
+    lifecycle.insert(
+        "deprecatedIn".into(),
         Value::String(input.spec_version.clone()),
     );
 
     if let Some(comment) = &input.deprecated_comment {
-        token.insert("deprecated_comment".into(), Value::String(comment.clone()));
+        lifecycle.insert("deprecatedComment".into(), Value::String(comment.clone()));
     }
 
     if let Some(replaced_by) = input.replaced_by {
-        token.insert("replaced_by".into(), replaced_by);
+        lifecycle.insert("replacedBy".into(), replaced_by);
     }
 
     if let Some(planned) = &input.planned_removal {
-        token.insert("plannedRemoval".into(), Value::String(planned.clone()));
+        lifecycle.insert("plannedRemoval".into(), Value::String(planned.clone()));
     }
+
+    token.insert("lifecycle".into(), Value::Object(lifecycle));
 
     if let Some(rationale) = &input.rationale {
         if !rationale.is_empty() {
@@ -239,8 +256,8 @@ pub struct RenameTokenInput {
     pub target: PathBuf,
     /// New name object (`{ "property": "…", … }`) or plain SPEC-017 string.
     pub new_name: Value,
-    /// Optional UUID of a token that should receive a `replaced_by` pointer back
-    /// to this token (the "retire old name" step, L64).
+    /// Optional UUID of a token that should receive a `lifecycle.replacedBy`
+    /// pointer back to this token (the "retire old name" step, L64).
     pub replaced_by_target: Option<String>,
     pub rationale: Option<String>,
 }
@@ -249,8 +266,8 @@ pub struct RenameTokenInput {
 ///
 /// **Contract** (`authoring-workflow.md` L64 / L69):
 /// - UUID MUST be preserved.
-/// - Optionally sets a `replaced_by` pointer on a separate token in the same file
-///   (the "retire old name" step).
+/// - Optionally sets a `lifecycle.replacedBy` pointer on a separate token in the
+///   same file (the "retire old name" step).
 pub fn rename_token(
     input: RenameTokenInput,
     registry: &SchemaRegistry,
@@ -275,11 +292,16 @@ pub fn rename_token(
     let token_val = arr[idx].clone();
     validate_token_object(&input.uuid, &token_val, registry).map_err(|e| e.to_string())?;
 
-    // Retire the old-name token with a replaced_by pointer.
+    // Retire the old-name token with a lifecycle.replacedBy pointer.
     if let Some(old_uuid) = &input.replaced_by_target {
         let old_idx = find_by_uuid(&arr, old_uuid)?;
         if let Some(old_token) = arr[old_idx].as_object_mut() {
-            old_token.insert("replaced_by".into(), Value::String(input.uuid.clone()));
+            let mut lifecycle = match old_token.remove("lifecycle") {
+                Some(Value::Object(m)) => m,
+                _ => Map::new(),
+            };
+            lifecycle.insert("replacedBy".into(), Value::String(input.uuid.clone()));
+            old_token.insert("lifecycle".into(), Value::Object(lifecycle));
         }
     }
 
@@ -624,8 +646,11 @@ mod tests {
         assert!(result.is_ok(), "deprecate_token failed: {:?}", result.err());
         let arr: Vec<Value> =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(arr[0]["deprecated"], json!("1.1.0"));
-        assert_eq!(arr[0]["deprecated_comment"], json!("use new-token instead"));
+        assert_eq!(arr[0]["lifecycle"]["deprecatedIn"], json!("1.1.0"));
+        assert_eq!(
+            arr[0]["lifecycle"]["deprecatedComment"],
+            json!("use new-token instead")
+        );
     }
 
     #[test]
@@ -777,7 +802,7 @@ mod tests {
         let arr: Vec<Value> =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         let old = arr.iter().find(|t| t["uuid"] == json!(old_uuid)).unwrap();
-        assert_eq!(old["replaced_by"], json!(new_uuid));
+        assert_eq!(old["lifecycle"]["replacedBy"], json!(new_uuid));
     }
 
     #[test]

--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -494,12 +494,14 @@ fn build_token_value(
         serde_json::Value::String(Uuid::new_v4().to_string()),
     );
 
-    // authoring-workflow.md L71: MUST stamp `introduced` with the active dataset
-    // specVersion at creation time.
-    obj.insert(
+    // authoring-workflow.md L71: MUST stamp `lifecycle.introduced` with the active
+    // dataset specVersion at creation time.
+    let mut lifecycle = serde_json::Map::new();
+    lifecycle.insert(
         "introduced".into(),
         serde_json::Value::String(spec_version.to_string()),
     );
+    obj.insert("lifecycle".into(), serde_json::Value::Object(lifecycle));
 
     serde_json::Value::Object(obj)
 }

--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -489,12 +489,9 @@ fn diff_recursive(old: &Value, new: &Value, prefix: String, out: &mut Vec<Proper
                         diff_recursive(old_val, new_val, path, out);
                     }
                     None => {
-                        out.push(PropertyChange {
-                            path,
-                            change_type: ChangeType::Deleted,
-                            new_value: None,
-                            original_value: Some(old_val.clone()),
-                        });
+                        // Per spec/diff.md: comparison MUST recurse to the leaf level with
+                        // full dot-separated paths, even for a wholly-removed subtree.
+                        record_deleted(old_val, path, out);
                     }
                 }
             }
@@ -506,12 +503,7 @@ fn diff_recursive(old: &Value, new: &Value, prefix: String, out: &mut Vec<Proper
                     } else {
                         format!("{prefix}.{key}")
                     };
-                    out.push(PropertyChange {
-                        path,
-                        change_type: ChangeType::Added,
-                        new_value: Some(new_val.clone()),
-                        original_value: None,
-                    });
+                    record_added(new_val, path, out);
                 }
             }
         }
@@ -524,6 +516,50 @@ fn diff_recursive(old: &Value, new: &Value, prefix: String, out: &mut Vec<Proper
                 original_value: Some(old.clone()),
             });
         }
+    }
+}
+
+/// Record a wholly-new subtree as leaf-level Added changes (per spec/diff.md's
+/// recurse-to-leaf-level rule), rather than one Added change for the whole value.
+fn record_added(value: &Value, prefix: String, out: &mut Vec<PropertyChange>) {
+    if let Value::Object(map) = value {
+        for (key, v) in map {
+            let path = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            record_added(v, path, out);
+        }
+    } else {
+        out.push(PropertyChange {
+            path: prefix,
+            change_type: ChangeType::Added,
+            new_value: Some(value.clone()),
+            original_value: None,
+        });
+    }
+}
+
+/// Record a wholly-removed subtree as leaf-level Deleted changes (per spec/diff.md's
+/// recurse-to-leaf-level rule), rather than one Deleted change for the whole value.
+fn record_deleted(value: &Value, prefix: String, out: &mut Vec<PropertyChange>) {
+    if let Value::Object(map) = value {
+        for (key, v) in map {
+            let path = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            record_deleted(v, path, out);
+        }
+    } else {
+        out.push(PropertyChange {
+            path: prefix,
+            change_type: ChangeType::Deleted,
+            new_value: None,
+            original_value: Some(value.clone()),
+        });
     }
 }
 
@@ -735,13 +771,35 @@ mod tests {
             "matched token must not be deprecated"
         );
         assert_eq!(report.updated.len(), 1, "must be classified as updated");
-        // `lifecycle` is an entirely new key on `new` (absent on `old`), so
-        // diff_recursive reports it as one Added change at "lifecycle" rather
-        // than recursing into "lifecycle.deprecatedIn".
+        // `lifecycle` is an entirely new key on `new` (absent on `old`), but
+        // diff_recursive still decomposes it to leaf level per spec/diff.md's
+        // recurse-to-leaf-level rule, rather than reporting one blob change at
+        // "lifecycle".
         assert!(report.updated[0]
             .property_changes
             .iter()
-            .any(|c| c.path == "lifecycle"));
+            .any(|c| c.path == "lifecycle.deprecatedIn"));
+    }
+
+    #[test]
+    fn added_and_deleted_objects_decompose_to_leaf_paths() {
+        // A wholly new/removed nested object must be reported as individual
+        // leaf-level Added/Deleted changes, not one blob change for the object.
+        let added = diff_properties(&json!({}), &json!({"lifecycle": {"a": 1, "b": 2}}));
+        let mut added_paths: Vec<&str> = added.iter().map(|c| c.path.as_str()).collect();
+        added_paths.sort();
+        assert_eq!(added_paths, vec!["lifecycle.a", "lifecycle.b"]);
+        assert!(added
+            .iter()
+            .all(|c| c.change_type == ChangeType::Added && c.original_value.is_none()));
+
+        let deleted = diff_properties(&json!({"lifecycle": {"a": 1, "b": 2}}), &json!({}));
+        let mut deleted_paths: Vec<&str> = deleted.iter().map(|c| c.path.as_str()).collect();
+        deleted_paths.sort();
+        assert_eq!(deleted_paths, vec!["lifecycle.a", "lifecycle.b"]);
+        assert!(deleted
+            .iter()
+            .all(|c| c.change_type == ChangeType::Deleted && c.new_value.is_none()));
     }
 
     // ── Added / deleted ─────────────────────────────────────────────────

--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -310,8 +310,8 @@ fn pair_tokens<'a>(
     }
 
     // Pass 3: Replacement link fallback for unmatched tokens.
-    // If an old token carries `replaced_by` (a UUID string), look up that UUID
-    // in the new graph. If the new token is also unpaired, pair them.
+    // If an old token carries `lifecycle.replacedBy` (a UUID string), look up
+    // that UUID in the new graph. If the new token is also unpaired, pair them.
     // Build new UUID → key index for unpaired new tokens.
     let mut new_by_uuid: HashMap<&str, &str> = HashMap::new();
     for (key, t) in &new.tokens {
@@ -326,7 +326,11 @@ fn pair_tokens<'a>(
         if matched_old.contains(old_key.as_str()) {
             continue;
         }
-        let target_uuid = old_tok.raw.get("replaced_by").and_then(|v| v.as_str());
+        let target_uuid = old_tok
+            .raw
+            .get("lifecycle")
+            .and_then(|l| l.get("replacedBy"))
+            .and_then(|v| v.as_str());
         if let Some(uuid) = target_uuid {
             if let Some(&new_key) = new_by_uuid.get(uuid) {
                 if let Some(new_tok) = new.tokens.get(new_key) {
@@ -439,10 +443,20 @@ fn is_deprecated(raw: &Value) -> bool {
     false
 }
 
-/// Check if the raw JSON has a top-level `deprecated` field.
+/// Check if the raw JSON has a top-level `deprecated` field (legacy format) or a
+/// nested `lifecycle.deprecatedIn` field (cascade format) — the diff tool operates
+/// on either format, including cross-format pairs.
 fn has_deprecated_field(raw: &Value) -> bool {
-    raw.as_object()
+    if raw
+        .as_object()
         .map(|o| o.contains_key("deprecated"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    raw.get("lifecycle")
+        .and_then(|l| l.as_object())
+        .map(|l| l.contains_key("deprecatedIn"))
         .unwrap_or(false)
 }
 
@@ -654,7 +668,7 @@ mod tests {
         let old = make_graph(vec![]);
         let new = make_graph(vec![(
             "dep-token",
-            json!({"name": {"property": "dep-token"}, "deprecated": true, "value": "1"}),
+            json!({"name": {"property": "dep-token"}, "lifecycle": {"deprecatedIn": true}, "value": "1"}),
         )]);
         let report = semantic_diff(&old, &new);
         assert_eq!(report.deprecated.len(), 1);
@@ -689,7 +703,7 @@ mod tests {
     fn detect_reverted_token() {
         let old = make_graph(vec![(
             "rev-token",
-            json!({"name": {"property": "rev"}, "uuid": "uuid-1", "deprecated": true, "value": "1"}),
+            json!({"name": {"property": "rev"}, "uuid": "uuid-1", "lifecycle": {"deprecatedIn": true}, "value": "1"}),
         )]);
         let new = make_graph(vec![(
             "rev-token",
@@ -713,7 +727,7 @@ mod tests {
         )]);
         let new = make_graph(vec![(
             "token",
-            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff", "deprecated": true}),
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff", "lifecycle": {"deprecatedIn": true}}),
         )]);
         let report = semantic_diff(&old, &new);
         assert!(
@@ -721,10 +735,13 @@ mod tests {
             "matched token must not be deprecated"
         );
         assert_eq!(report.updated.len(), 1, "must be classified as updated");
+        // `lifecycle` is an entirely new key on `new` (absent on `old`), so
+        // diff_recursive reports it as one Added change at "lifecycle" rather
+        // than recursing into "lifecycle.deprecatedIn".
         assert!(report.updated[0]
             .property_changes
             .iter()
-            .any(|c| c.path == "deprecated"));
+            .any(|c| c.path == "lifecycle"));
     }
 
     // ── Added / deleted ─────────────────────────────────────────────────
@@ -812,7 +829,7 @@ mod tests {
             ),
             (
                 "to-revert",
-                json!({"name": {"property": "to-revert"}, "uuid": "u4", "deprecated": true, "value": "4"}),
+                json!({"name": {"property": "to-revert"}, "uuid": "u4", "lifecycle": {"deprecatedIn": true}, "value": "4"}),
             ),
         ]);
         let new = make_graph(vec![
@@ -826,7 +843,7 @@ mod tests {
             ),
             (
                 "to-deprecate",
-                json!({"name": {"property": "to-deprecate"}, "deprecated": true, "value": "dep"}),
+                json!({"name": {"property": "to-deprecate"}, "lifecycle": {"deprecatedIn": true}, "value": "dep"}),
             ),
             (
                 "to-update",
@@ -848,15 +865,14 @@ mod tests {
 
     #[test]
     fn replaced_by_pairs_deprecated_to_new() {
-        // Old token is deprecated with replaced_by pointing to new token's UUID.
-        // No shared UUID or name — pairing via replaced_by (pass 3).
+        // Old token is deprecated with lifecycle.replacedBy pointing to new token's
+        // UUID. No shared UUID or name — pairing via replacedBy (pass 3).
         let old = make_graph(vec![(
             "old-token",
             json!({
                 "name": {"property": "old-prop"},
                 "uuid": "uuid-old",
-                "deprecated": "3.0.0",
-                "replaced_by": "uuid-new",
+                "lifecycle": {"deprecatedIn": "3.0.0", "replacedBy": "uuid-new"},
                 "value": "#fff"
             }),
         )]);
@@ -869,7 +885,11 @@ mod tests {
             }),
         )]);
         let report = semantic_diff(&old, &new);
-        assert_eq!(report.renamed.len(), 1, "should pair via replaced_by");
+        assert_eq!(
+            report.renamed.len(),
+            1,
+            "should pair via lifecycle.replacedBy"
+        );
         assert!(report.added.is_empty(), "new token should not be added");
         assert!(report.deleted.is_empty(), "old token should not be deleted");
     }

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -58,16 +58,12 @@ const SCALE_SET_SCHEMA: &str =
 
 /// Fields that belong on the outer token entry (hoisted from mode entries when
 /// they are identical across all modes).
-const OUTER_LIFECYCLE_FIELDS: &[&str] = &[
-    "deprecated",
-    "deprecated_comment",
-    "renamed",
-    "replaced_by",
-    "plannedRemoval",
-    "introduced",
-    "private",
-    "description",
-];
+///
+/// `lifecycle` is the cascade-format nested lifecycle object (see
+/// `normalize_lifecycle_for_legacy`, which converts it to flat legacy fields
+/// after hoisting); it is compared/copied as a whole `Value::Object` here, so
+/// hoisting occurs only when every mode entry's `lifecycle` object is identical.
+const OUTER_LIFECYCLE_FIELDS: &[&str] = &["lifecycle", "private", "description"];
 
 // ── Summary ───────────────────────────────────────────────────────────────────
 
@@ -525,63 +521,93 @@ fn convert_array(
     Ok(out)
 }
 
-/// Convert cascade lifecycle fields to legacy format on a token entry.
+/// Convert a cascade nested `lifecycle` object to flat legacy fields on a token entry.
 ///
-/// - `deprecated: "version"` → `deprecated: true`
-/// - `replaced_by: "uuid"` → `renamed: "<property-name>"` (string form, resolved via map)
-/// - `replaced_by: ["uuid", ...]` → `renamed: "<property-name>"` when all elements
+/// - `lifecycle.deprecatedIn: "version"` (or any truthy value) → `deprecated: true`
+/// - `lifecycle.deprecatedComment` → `deprecated_comment` (copied verbatim)
+/// - `lifecycle.replacedBy: "uuid"` → `renamed: "<property-name>"` (string form, resolved via map)
+/// - `lifecycle.replacedBy: ["uuid", ...]` → `renamed: "<property-name>"` when all elements
 ///   resolve to the **same** legacy name (multi-member scale/color-set pointing at one
 ///   logical token); left unset when they resolve to multiple distinct names (genuine
-///   multi-target rename — `deprecated_comment` explains it).
-/// - `plannedRemoval`, `introduced` → removed (no legacy equivalent)
+///   multi-target rename — `deprecatedComment` explains it).
+/// - `lifecycle.plannedRemoval`, `lifecycle.introduced` → dropped (no legacy equivalent)
+///
+/// The `lifecycle` key itself is always removed — legacy format has no nested wrapper.
+///
+/// `deprecated`/`deprecated_comment` are spliced into `lifecycle`'s original map
+/// position (rather than appended fresh) so byte-identical legacy output ordering
+/// matches the pre-nesting flat-field layout, where these were their own keys
+/// already present ahead of `sets`. `renamed` has no such position to preserve —
+/// it never existed until derived here — so it is simply appended at the end,
+/// matching prior behavior.
 fn normalize_lifecycle_for_legacy(
     entry: &mut Map<String, Value>,
     uuid_to_name: &HashMap<String, String>,
 ) {
-    // deprecated: version string → boolean true
-    if let Some(dep) = entry.get("deprecated") {
-        if dep.is_string() {
-            entry.insert("deprecated".into(), Value::Bool(true));
-        }
-    }
+    if let Some(Value::Object(lifecycle)) = entry.get("lifecycle").cloned() {
+        // Fields that reuse `lifecycle`'s exact map position.
+        let mut in_place = Map::new();
 
-    // replaced_by → renamed (resolve UUID(s) to property name)
-    if let Some(replaced) = entry.remove("replaced_by") {
-        if let Some(uuid) = replaced.as_str() {
-            // Single-string form.
-            if let Some(name) = uuid_to_name.get(uuid) {
-                entry.insert("renamed".into(), Value::String(name.clone()));
+        // deprecatedIn: truthy (string version, or a loose boolean true in test
+        // fixtures) → boolean true. Explicit `false`/`null` → not deprecated.
+        if let Some(dep) = lifecycle.get("deprecatedIn") {
+            if !matches!(dep, Value::Bool(false) | Value::Null) {
+                in_place.insert("deprecated".into(), Value::Bool(true));
             }
-        } else if let Some(arr) = replaced.as_array() {
-            // Array form: collect all distinct resolved names.
-            let mut distinct: Vec<&str> = Vec::new();
-            for elem in arr {
-                if let Some(uuid) = elem.as_str() {
-                    if let Some(name) = uuid_to_name.get(uuid) {
-                        let s = name.as_str();
-                        if !distinct.contains(&s) {
-                            distinct.push(s);
+        }
+
+        if let Some(comment) = lifecycle.get("deprecatedComment") {
+            in_place.insert("deprecated_comment".into(), comment.clone());
+        }
+
+        let mut rebuilt = Map::new();
+        for (k, v) in entry.iter() {
+            if k == "lifecycle" {
+                for (fk, fv) in &in_place {
+                    rebuilt.insert(fk.clone(), fv.clone());
+                }
+            } else {
+                rebuilt.insert(k.clone(), v.clone());
+            }
+        }
+        *entry = rebuilt;
+
+        // replacedBy → renamed (resolve UUID(s) to property name); appended fresh.
+        if let Some(replaced) = lifecycle.get("replacedBy") {
+            if let Some(uuid) = replaced.as_str() {
+                // Single-string form.
+                if let Some(name) = uuid_to_name.get(uuid) {
+                    entry.insert("renamed".into(), Value::String(name.clone()));
+                }
+            } else if let Some(arr) = replaced.as_array() {
+                // Array form: collect all distinct resolved names.
+                let mut distinct: Vec<&str> = Vec::new();
+                for elem in arr {
+                    if let Some(uuid) = elem.as_str() {
+                        if let Some(name) = uuid_to_name.get(uuid) {
+                            let s = name.as_str();
+                            if !distinct.contains(&s) {
+                                distinct.push(s);
+                            }
                         }
                     }
                 }
+                // Emit renamed only when all resolvable elements point at the same logical
+                // token (e.g. two scale-set members with the same property name). Unresolvable
+                // UUIDs are skipped rather than treated as ambiguous: if a replacement token is
+                // absent from this conversion run the resolvable elements still identify the
+                // replacement name, so emitting renamed is correct. If elements resolve to two
+                // or more distinct names the mapping is genuinely ambiguous; deprecatedComment
+                // explains it. An empty array (or all unresolvable) produces no renamed.
+                if distinct.len() == 1 {
+                    entry.insert("renamed".into(), Value::String(distinct[0].to_string()));
+                }
+                // Multiple distinct targets or empty: no 1:1 mapping.
             }
-            // Emit renamed only when all resolvable elements point at the same logical
-            // token (e.g. two scale-set members with the same property name). Unresolvable
-            // UUIDs are skipped rather than treated as ambiguous: if a replacement token is
-            // absent from this conversion run the resolvable elements still identify the
-            // replacement name, so emitting renamed is correct. If elements resolve to two
-            // or more distinct names the mapping is genuinely ambiguous; deprecated_comment
-            // explains it. An empty array (or all unresolvable) produces no renamed.
-            if distinct.len() == 1 {
-                entry.insert("renamed".into(), Value::String(distinct[0].to_string()));
-            }
-            // Multiple distinct targets or empty: no 1:1 mapping.
         }
-    }
 
-    // Drop fields with no legacy equivalent.
-    entry.remove("plannedRemoval");
-    entry.remove("introduced");
+        // plannedRemoval, introduced: no legacy equivalent — simply not copied.
+    }
 
     // Recurse into sets entries.
     if let Some(sets) = entry.get_mut("sets").and_then(|v| v.as_object_mut()) {
@@ -592,36 +618,69 @@ fn normalize_lifecycle_for_legacy(
         }
     }
 
-    // Hoist `renamed` to the outer level when it is absent there but consistently
-    // the same across all mode entries. This matches the structural convention of the
-    // committed legacy files (lifecycle fields uniform across all modes belong at the
-    // outer level, not inside each set entry). This can happen when the cascade source
-    // stores per-mode `replaced_by` UUIDs that all resolve to the same legacy token
-    // name (e.g. desktop/mobile scale members of one logical replacement token).
-    if entry.get("renamed").is_none() {
-        let hoist_val: Option<Value> = entry
-            .get("sets")
-            .and_then(|s| s.as_object())
-            .filter(|sets| !sets.is_empty())
-            .and_then(|sets| {
-                let mut iter = sets
-                    .values()
-                    .filter_map(|v| v.as_object()?.get("renamed").cloned());
-                let first = iter.next()?;
-                if iter.all(|v| v == first) {
-                    Some(first)
-                } else {
-                    None
+    // Hoist individual flat legacy fields to the outer level when each is absent
+    // there but consistently the same across all mode entries. This matters because
+    // the initial whole-`lifecycle`-object hoist (OUTER_LIFECYCLE_FIELDS, above) is
+    // all-or-nothing: if per-mode `lifecycle.replacedBy` UUIDs differ (e.g. desktop
+    // and mobile pointing at different-but-equivalent replacement tokens) the whole
+    // object fails to hoist even though `deprecatedIn`/`deprecatedComment` were
+    // identical. This second pass recovers that per-field hoisting after each mode's
+    // own `lifecycle` has already been converted to flat legacy fields above.
+    //
+    // `deprecated`/`deprecated_comment` splice in immediately before `sets` — verified
+    // against real committed data (`packages/tokens/src/layout.json`'s `field-width`
+    // token, which has exactly this shape: consistent deprecation, differing
+    // per-mode replacedBy). `renamed` has no such position to preserve — it's a
+    // brand-new key first derived above, appended at the end.
+    hoist_flat_field_if_consistent(entry, "deprecated", true);
+    hoist_flat_field_if_consistent(entry, "deprecated_comment", true);
+    hoist_flat_field_if_consistent(entry, "renamed", false);
+}
+
+/// Hoist `field` to the outer level when it is absent there but consistently the
+/// same across all mode entries, removing it from each mode entry once hoisted.
+/// When `before_sets` is true, the hoisted key is spliced in immediately before
+/// `sets`; otherwise it is appended at the end of `entry`.
+fn hoist_flat_field_if_consistent(entry: &mut Map<String, Value>, field: &str, before_sets: bool) {
+    if entry.get(field).is_some() {
+        return;
+    }
+    let hoist_val: Option<Value> = entry
+        .get("sets")
+        .and_then(|s| s.as_object())
+        .filter(|sets| !sets.is_empty())
+        .and_then(|sets| {
+            // Every mode entry must carry `field` with the SAME value — a mode
+            // entry lacking it entirely must not be conflated with one whose
+            // value happens to agree with the others.
+            let first = sets.values().next()?.as_object()?.get(field)?;
+            if sets
+                .values()
+                .all(|v| v.as_object().and_then(|o| o.get(field)) == Some(first))
+            {
+                Some(first.clone())
+            } else {
+                None
+            }
+        });
+    if let Some(val) = hoist_val {
+        if before_sets {
+            let mut rebuilt = Map::new();
+            for (k, v) in entry.iter() {
+                if k == "sets" {
+                    rebuilt.insert(field.to_string(), val.clone());
                 }
-            });
-        if let Some(val) = hoist_val {
-            entry.insert("renamed".into(), val);
-            // Remove from mode entries — the value is now represented at the outer level.
-            if let Some(sets) = entry.get_mut("sets").and_then(|v| v.as_object_mut()) {
-                for set_entry in sets.values_mut() {
-                    if let Some(obj) = set_entry.as_object_mut() {
-                        obj.remove("renamed");
-                    }
+                rebuilt.insert(k.clone(), v.clone());
+            }
+            *entry = rebuilt;
+        } else {
+            entry.insert(field.to_string(), val);
+        }
+        // Remove from mode entries — the value is now represented at the outer level.
+        if let Some(sets) = entry.get_mut("sets").and_then(|v| v.as_object_mut()) {
+            for set_entry in sets.values_mut() {
+                if let Some(obj) = set_entry.as_object_mut() {
+                    obj.remove(field);
                 }
             }
         }
@@ -920,34 +979,35 @@ mod tests {
     fn consistent_lifecycle_field_hoisted_to_outer() {
         let arr = json!([
             {"name": {"property": "old-color", "colorScheme": "light"},
-             "value": "#fff", "uuid": "lc-0001", "deprecated": true, "renamed": "new-color"},
+             "value": "#fff", "uuid": "lc-0001", "lifecycle": {"deprecatedIn": true}},
             {"name": {"property": "old-color", "colorScheme": "dark"},
-             "value": "#000", "uuid": "lc-0002", "deprecated": true, "renamed": "new-color"}
+             "value": "#000", "uuid": "lc-0002", "lifecycle": {"deprecatedIn": true}}
         ]);
         let mut summary = LegacySummary::default();
         let out = convert_array(arr.as_array().unwrap(), &mut summary, &HashMap::new()).unwrap();
 
         let entry = &out["old-color"];
         assert_eq!(entry["deprecated"], true);
-        assert_eq!(entry["renamed"], "new-color");
         assert!(entry["sets"]["light"].get("deprecated").is_none());
         assert!(entry["sets"]["dark"].get("deprecated").is_none());
     }
 
     #[test]
     fn inconsistent_lifecycle_field_stays_in_mode_entry() {
+        // light has no lifecycle at all; dark is deprecated — the whole `lifecycle`
+        // object differs across modes (present vs absent), so it must NOT hoist.
         let arr = json!([
             {"name": {"property": "mixed-color", "colorScheme": "light"},
-             "value": "#fff", "uuid": "lc-0003", "deprecated": false},
+             "value": "#fff", "uuid": "lc-0003"},
             {"name": {"property": "mixed-color", "colorScheme": "dark"},
-             "value": "#000", "uuid": "lc-0004", "deprecated": true}
+             "value": "#000", "uuid": "lc-0004", "lifecycle": {"deprecatedIn": true}}
         ]);
         let mut summary = LegacySummary::default();
         let out = convert_array(arr.as_array().unwrap(), &mut summary, &HashMap::new()).unwrap();
 
         let entry = &out["mixed-color"];
         assert!(entry.get("deprecated").is_none());
-        assert_eq!(entry["sets"]["light"]["deprecated"], false);
+        assert!(entry["sets"]["light"].get("deprecated").is_none());
         assert_eq!(entry["sets"]["dark"]["deprecated"], true);
     }
 
@@ -1001,8 +1061,10 @@ mod tests {
             "$schema": ".../alias.json",
             "value": "1px",
             "uuid": "old-uuid-empty",
-            "deprecated": "unknown",
-            "replaced_by": []
+            "lifecycle": {
+                "deprecatedIn": "unknown",
+                "replacedBy": []
+            }
         }]);
         let global: HashMap<String, String> = HashMap::new();
         let mut summary = LegacySummary::default();
@@ -1026,8 +1088,10 @@ mod tests {
                 "$schema": ".../alias.json",
                 "$ref": "known-uuid-0001",
                 "uuid": "old-partial-uuid",
-                "deprecated": "unknown",
-                "replaced_by": ["known-uuid-0001", "no-such-uuid-xyz"]
+                "lifecycle": {
+                    "deprecatedIn": "unknown",
+                    "replacedBy": ["known-uuid-0001", "no-such-uuid-xyz"]
+                }
             },
             {
                 "name": {"property": "new-token"},
@@ -1068,8 +1132,10 @@ mod tests {
                 "uuid": "old-desktop-uuid-0001",
                 "set_uuid": "old-set-uuid-0001",
                 "set_schema": ".../scale-set.json",
-                "deprecated": "unknown",
-                "replaced_by": "new-desktop-uuid-0001"
+                "lifecycle": {
+                    "deprecatedIn": "unknown",
+                    "replacedBy": "new-desktop-uuid-0001"
+                }
             },
             {
                 "name": {"property": "old-width", "scale": "mobile"},
@@ -1078,8 +1144,10 @@ mod tests {
                 "uuid": "old-mobile-uuid-0001",
                 "set_uuid": "old-set-uuid-0001",
                 "set_schema": ".../scale-set.json",
-                "deprecated": "unknown",
-                "replaced_by": "new-mobile-uuid-0001"
+                "lifecycle": {
+                    "deprecatedIn": "unknown",
+                    "replacedBy": "new-mobile-uuid-0001"
+                }
             },
             {
                 "name": {"property": "new-width", "scale": "desktop"},
@@ -1141,9 +1209,11 @@ mod tests {
                 "$schema": ".../alias.json",
                 "$ref": "new-desktop-uuid",
                 "uuid": "old-uuid-0001",
-                "deprecated": "unknown",
-                "deprecated_comment": "Use new-width instead.",
-                "replaced_by": ["new-desktop-uuid", "new-mobile-uuid"]
+                "lifecycle": {
+                    "deprecatedIn": "unknown",
+                    "deprecatedComment": "Use new-width instead.",
+                    "replacedBy": ["new-desktop-uuid", "new-mobile-uuid"]
+                }
             },
             // new-width desktop: both scale members share the same property name.
             {
@@ -1197,9 +1267,11 @@ mod tests {
                 "$schema": ".../alias.json",
                 "$ref": "target-a-uuid",
                 "uuid": "old-uuid-0002",
-                "deprecated": "unknown",
-                "deprecated_comment": "Split into token-a and token-b.",
-                "replaced_by": ["target-a-uuid", "target-b-uuid"]
+                "lifecycle": {
+                    "deprecatedIn": "unknown",
+                    "deprecatedComment": "Split into token-a and token-b.",
+                    "replacedBy": ["target-a-uuid", "target-b-uuid"]
+                }
             },
             {
                 "name": {"property": "token-a"},
@@ -1249,8 +1321,10 @@ mod tests {
                 "$schema": ".../color.json",
                 "value": "#fff",
                 "uuid": "old-0001",
-                "deprecated": true,
-                "replaced_by": "set-outer-uuid-0001"
+                "lifecycle": {
+                    "deprecatedIn": true,
+                    "replacedBy": "set-outer-uuid-0001"
+                }
             },
             // new-set light mode: carries set_uuid = "set-outer-uuid-0001".
             {

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -306,8 +306,10 @@ mod relational_conformance {
             json!({
                 "name": {"property": "old"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "deprecated": "3.0.0",
-                "replaced_by": "bbbbbbbb-9999-4000-8000-000000000099",
+                "lifecycle": {
+                    "deprecatedIn": "3.0.0",
+                    "replacedBy": "bbbbbbbb-9999-4000-8000-000000000099"
+                },
                 "value": "#fff"
             }),
         )]);
@@ -323,8 +325,10 @@ mod relational_conformance {
                 json!({
                     "name": {"property": "old"},
                     "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                    "deprecated": "3.0.0",
-                    "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001",
+                    "lifecycle": {
+                        "deprecatedIn": "3.0.0",
+                        "replacedBy": "aaaaaaaa-0002-4000-8000-000000000001"
+                    },
                     "value": "#fff"
                 }),
             ),
@@ -349,8 +353,10 @@ mod relational_conformance {
             json!({
                 "name": {"property": "split"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "deprecated": "3.0.0",
-                "replaced_by": ["aaaaaaaa-0002-4000-8000-000000000001"],
+                "lifecycle": {
+                    "deprecatedIn": "3.0.0",
+                    "replacedBy": ["aaaaaaaa-0002-4000-8000-000000000001"]
+                },
                 "value": "#fff"
             }),
         )]);
@@ -365,7 +371,7 @@ mod relational_conformance {
             json!({
                 "name": {"property": "bad"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001",
+                "lifecycle": {"replacedBy": "aaaaaaaa-0002-4000-8000-000000000001"},
                 "value": "#fff"
             }),
         )]);
@@ -380,7 +386,7 @@ mod relational_conformance {
             json!({
                 "name": {"property": "bad"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "plannedRemoval": "4.0.0",
+                "lifecycle": {"plannedRemoval": "4.0.0"},
                 "value": "#fff"
             }),
         )]);
@@ -395,8 +401,7 @@ mod relational_conformance {
             json!({
                 "name": {"property": "bad"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "deprecated": "3.2.0",
-                "plannedRemoval": "3.1.0",
+                "lifecycle": {"deprecatedIn": "3.2.0", "plannedRemoval": "3.1.0"},
                 "value": "#fff"
             }),
         )]);
@@ -416,8 +421,7 @@ mod relational_conformance {
             json!({
                 "name": {"property": "ok"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "deprecated": "3.2.0",
-                "plannedRemoval": "4.0.0",
+                "lifecycle": {"deprecatedIn": "3.2.0", "plannedRemoval": "4.0.0"},
                 "value": "#fff"
             }),
         )]);
@@ -433,8 +437,7 @@ mod relational_conformance {
             json!({
                 "name": {"property": "ok"},
                 "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
-                "deprecated": "3.2.0",
-                "plannedRemoval": "3.10.0",
+                "lifecycle": {"deprecatedIn": "3.2.0", "plannedRemoval": "3.10.0"},
                 "value": "#fff"
             }),
         )]);

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -785,38 +785,64 @@ fn build_flat(
     Value::Object(out)
 }
 
-/// Convert legacy lifecycle fields to cascade model on a token map.
+/// Convert legacy flat lifecycle fields to a cascade nested `lifecycle` object on a
+/// token map.
 ///
-/// - `deprecated: true` → `deprecated: "unknown"` (authors should backfill)
-/// - `renamed: "<name>"` → `replaced_by: "<uuid>"` (resolved via name_to_uuid map)
+/// - `deprecated: true` → `lifecycle.deprecatedIn: "unknown"` (authors should backfill)
+/// - `deprecated_comment` → `lifecycle.deprecatedComment` (copied verbatim)
+/// - `renamed: "<name>"` → `lifecycle.replacedBy: "<uuid>"` (resolved via name_to_uuid map)
 /// - `status` → removed (derivable in cascade model)
+///
+/// `entry` may already carry flat `replaced_by`/`plannedRemoval`/`introduced` (defensive:
+/// `OUTER_LIFECYCLE_FIELDS` copies these superset field names even though legacy source
+/// files never populate them) — these fold into `lifecycle` unchanged rather than being
+/// silently dropped.
 fn normalize_lifecycle_for_cascade(
     entry: &mut Map<String, Value>,
     name_to_uuid: &HashMap<&str, &str>,
 ) {
-    // deprecated: boolean true → version string "unknown"
-    if let Some(dep) = entry.get("deprecated") {
+    let mut lifecycle = Map::new();
+
+    // deprecated: boolean true → version string "unknown"; false → not deprecated.
+    if let Some(dep) = entry.remove("deprecated") {
         if dep.as_bool() == Some(true) {
-            entry.insert("deprecated".into(), Value::String("unknown".into()));
-        } else if dep.as_bool() == Some(false) {
-            entry.remove("deprecated");
+            lifecycle.insert("deprecatedIn".into(), Value::String("unknown".into()));
         }
     }
 
-    // renamed → replaced_by (resolve name to UUID via the file's token map)
+    if let Some(comment) = entry.remove("deprecated_comment") {
+        lifecycle.insert("deprecatedComment".into(), comment);
+    }
+
+    // renamed → replacedBy (resolve name to UUID via the file's token map)
     if let Some(renamed) = entry
         .remove("renamed")
         .and_then(|v| v.as_str().map(String::from))
     {
         if let Some(&uuid) = name_to_uuid.get(renamed.as_str()) {
-            entry.insert("replaced_by".into(), Value::String(uuid.to_string()));
+            lifecycle.insert("replacedBy".into(), Value::String(uuid.to_string()));
         }
         // If the target name isn't found in this file, drop silently — the
-        // target may be in another file and replaced_by must be set manually.
+        // target may be in another file and replacedBy must be set manually.
+    }
+
+    // Defensive passthrough for cascade-only fields legacy never populates.
+    if let Some(replaced_by) = entry.remove("replaced_by") {
+        lifecycle.insert("replacedBy".into(), replaced_by);
+    }
+    if let Some(planned) = entry.remove("plannedRemoval") {
+        lifecycle.insert("plannedRemoval".into(), planned);
+    }
+    if let Some(introduced) = entry.remove("introduced") {
+        lifecycle.insert("introduced".into(), introduced);
     }
 
     // status → remove (derivable, not part of cascade model)
     entry.remove("status");
+
+    if !lifecycle.is_empty() {
+        entry.insert("lifecycle".into(), Value::Object(lifecycle));
+    }
 }
 
 /// Insert `value` or `$ref` into the output map from a source object.
@@ -959,10 +985,10 @@ mod tests {
         );
         assert_eq!(tokens.len(), 2);
         for t in &tokens {
-            // deprecated: true → "unknown" in cascade model
-            assert_eq!(t["deprecated"], "unknown");
-            assert_eq!(t["deprecated_comment"], "use new-token instead");
-            // renamed is stripped (replaced_by with UUID should be set manually)
+            // deprecated: true → lifecycle.deprecatedIn: "unknown" in cascade model
+            assert_eq!(t["lifecycle"]["deprecatedIn"], "unknown");
+            assert_eq!(t["lifecycle"]["deprecatedComment"], "use new-token instead");
+            // renamed is stripped (replacedBy with UUID should be set manually)
             assert!(t.get("renamed").is_none(), "renamed should be stripped");
         }
     }
@@ -980,13 +1006,13 @@ mod tests {
                 }
             })),
         );
-        // desktop entry overrides outer deprecated=true with false → removed
+        // desktop entry overrides outer deprecated=true with false → no lifecycle at all
         assert!(
-            tokens[0].get("deprecated").is_none(),
-            "deprecated: false should be stripped"
+            tokens[0].get("lifecycle").is_none(),
+            "deprecated: false should not produce a lifecycle object"
         );
         // mobile entry inherits outer deprecated=true → "unknown"
-        assert_eq!(tokens[1]["deprecated"], "unknown");
+        assert_eq!(tokens[1]["lifecycle"]["deprecatedIn"], "unknown");
     }
 
     #[test]
@@ -1076,14 +1102,14 @@ mod tests {
         let token = &out1.as_array().unwrap()[0];
 
         assert_eq!(
-            token["replaced_by"], "aaaaaaaa-0002-4000-8000-000000000001",
-            "renamed should resolve to replaced_by via cross-file UUID lookup"
+            token["lifecycle"]["replacedBy"], "aaaaaaaa-0002-4000-8000-000000000001",
+            "renamed should resolve to lifecycle.replacedBy via cross-file UUID lookup"
         );
         assert!(
             token.get("renamed").is_none(),
             "renamed should be stripped from cascade output"
         );
-        assert_eq!(token["deprecated"], "unknown");
+        assert_eq!(token["lifecycle"]["deprecatedIn"], "unknown");
 
         // Cleanup.
         let _ = fs::remove_dir_all(&tmp);

--- a/sdk/core/src/validate/rules/spec010.rs
+++ b/sdk/core/src/validate/rules/spec010.rs
@@ -25,7 +25,7 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
         for t in ctx.graph.tokens.values() {
-            let Some(replaced_by) = t.raw.get("replaced_by") else {
+            let Some(replaced_by) = t.raw.get("lifecycle").and_then(|l| l.get("replacedBy")) else {
                 continue;
             };
 
@@ -49,7 +49,7 @@ impl ValidationRule for Rule {
                         token: Some(t.name.clone()),
                         rule_id: Some(self.id().to_string()),
                         severity: Severity::Error,
-                        message: format!("replaced_by target UUID not found: {uuid}"),
+                        message: format!("lifecycle.replacedBy target UUID not found: {uuid}"),
                         instance_path: None,
                         schema_path: None,
                     });

--- a/sdk/core/src/validate/rules/spec011.rs
+++ b/sdk/core/src/validate/rules/spec011.rs
@@ -25,15 +25,17 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
         for t in ctx.graph.tokens.values() {
-            let Some(replaced_by) = t.raw.get("replaced_by") else {
+            let Some(lifecycle) = t.raw.get("lifecycle") else {
+                continue;
+            };
+            let Some(replaced_by) = lifecycle.get("replacedBy") else {
                 continue;
             };
             if !replaced_by.is_array() {
                 continue;
             }
-            let has_comment = t
-                .raw
-                .get("deprecated_comment")
+            let has_comment = lifecycle
+                .get("deprecatedComment")
                 .and_then(|v| v.as_str())
                 .is_some_and(|s| !s.is_empty());
             if !has_comment {
@@ -43,7 +45,7 @@ impl ValidationRule for Rule {
                     rule_id: Some(self.id().to_string()),
                     severity: Severity::Error,
                     message: format!(
-                        "replaced_by is an array but deprecated_comment is missing on token {}",
+                        "lifecycle.replacedBy is an array but lifecycle.deprecatedComment is missing on token {}",
                         t.name
                     ),
                     instance_path: None,

--- a/sdk/core/src/validate/rules/spec012.rs
+++ b/sdk/core/src/validate/rules/spec012.rs
@@ -25,14 +25,13 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
         for t in ctx.graph.tokens.values() {
-            if t.raw.get("replaced_by").is_none() {
+            let Some(lifecycle) = t.raw.get("lifecycle").and_then(|l| l.as_object()) else {
+                continue;
+            };
+            if !lifecycle.contains_key("replacedBy") {
                 continue;
             }
-            let has_deprecated = t
-                .raw
-                .as_object()
-                .map(|o| o.contains_key("deprecated"))
-                .unwrap_or(false);
+            let has_deprecated = lifecycle.contains_key("deprecatedIn");
             if !has_deprecated {
                 out.push(Diagnostic {
                     file: t.file.clone(),
@@ -40,7 +39,7 @@ impl ValidationRule for Rule {
                     rule_id: Some(self.id().to_string()),
                     severity: Severity::Error,
                     message: format!(
-                        "Token {} has replaced_by but is not marked deprecated",
+                        "Token {} has lifecycle.replacedBy but is not marked deprecated",
                         t.name
                     ),
                     instance_path: None,

--- a/sdk/core/src/validate/rules/spec013.rs
+++ b/sdk/core/src/validate/rules/spec013.rs
@@ -25,10 +25,13 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
         for t in ctx.graph.tokens.values() {
-            let Some(planned) = t.raw.get("plannedRemoval").and_then(|v| v.as_str()) else {
+            let Some(lifecycle) = t.raw.get("lifecycle") else {
                 continue;
             };
-            let deprecated_str = t.raw.get("deprecated").and_then(|v| v.as_str());
+            let Some(planned) = lifecycle.get("plannedRemoval").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let deprecated_str = lifecycle.get("deprecatedIn").and_then(|v| v.as_str());
 
             if deprecated_str.is_none() {
                 out.push(Diagnostic {

--- a/sdk/core/src/validate/rules/spec014.rs
+++ b/sdk/core/src/validate/rules/spec014.rs
@@ -30,7 +30,12 @@ impl ValidationRule for Rule {
             let Some(last_modified) = t.raw.get("lastModified").and_then(|v| v.as_str()) else {
                 continue;
             };
-            let Some(introduced) = t.raw.get("introduced").and_then(|v| v.as_str()) else {
+            let Some(introduced) = t
+                .raw
+                .get("lifecycle")
+                .and_then(|l| l.get("introduced"))
+                .and_then(|v| v.as_str())
+            else {
                 continue;
             };
 

--- a/sdk/core/src/validate/rules/spec036.rs
+++ b/sdk/core/src/validate/rules/spec036.rs
@@ -39,8 +39,13 @@ impl ValidationRule for Rule {
 
         for t in ctx.graph.tokens.values() {
             // Skip tokens that are themselves deprecated — no cascaded warning needed.
-            // Use as_str() so deprecated: null or deprecated: false does not suppress the warning.
-            if t.raw.get("deprecated").and_then(|v| v.as_str()).is_some() {
+            // Use as_str() so a missing/non-string deprecatedIn does not suppress the warning.
+            if t.raw
+                .get("lifecycle")
+                .and_then(|l| l.get("deprecatedIn"))
+                .and_then(|v| v.as_str())
+                .is_some()
+            {
                 continue;
             }
 
@@ -57,7 +62,7 @@ impl ValidationRule for Rule {
             let dep_version = comp
                 .raw
                 .get("lifecycle")
-                .and_then(|l| l.get("deprecated"))
+                .and_then(|l| l.get("deprecatedIn"))
                 .and_then(|v| v.as_str());
 
             if let Some(version) = dep_version {
@@ -150,7 +155,7 @@ mod tests {
     fn deprecated_component_warns() {
         let diags = run(
             json!({"name": {"component": "old-widget", "property": "color"}, "value": "#000"}),
-            json!({"name": "old-widget", "lifecycle": {"deprecated": "1.0.0-draft"}}),
+            json!({"name": "old-widget", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
         );
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
@@ -163,8 +168,8 @@ mod tests {
     #[test]
     fn already_deprecated_token_no_warning() {
         let diags = run(
-            json!({"name": {"component": "old-widget", "property": "color"}, "value": "#000", "deprecated": "1.0.0-draft"}),
-            json!({"name": "old-widget", "lifecycle": {"deprecated": "1.0.0-draft"}}),
+            json!({"name": {"component": "old-widget", "property": "color"}, "value": "#000", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
+            json!({"name": "old-widget", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
         );
         assert!(diags.is_empty());
     }
@@ -173,7 +178,7 @@ mod tests {
     fn string_name_token_skipped() {
         let diags = run(
             json!({"name": "old-widget-color", "value": "#000"}),
-            json!({"name": "old-widget", "lifecycle": {"deprecated": "1.0.0-draft"}}),
+            json!({"name": "old-widget", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
         );
         assert!(diags.is_empty());
     }
@@ -183,7 +188,7 @@ mod tests {
         // SPEC-018 owns the "component not declared" error — SPEC-036 stays silent.
         let diags = run(
             json!({"name": {"component": "ghost-component", "property": "color"}, "value": "#000"}),
-            json!({"name": "other-component", "lifecycle": {"deprecated": "1.0.0-draft"}}),
+            json!({"name": "other-component", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
         );
         assert!(diags.is_empty());
     }
@@ -192,8 +197,8 @@ mod tests {
     fn deprecated_false_does_not_suppress_warning() {
         // deprecated: false should NOT be treated as deprecated — warning must still fire.
         let diags = run(
-            json!({"name": {"component": "old-widget", "property": "color"}, "value": "#000", "deprecated": false}),
-            json!({"name": "old-widget", "lifecycle": {"deprecated": "1.0.0-draft"}}),
+            json!({"name": {"component": "old-widget", "property": "color"}, "value": "#000", "lifecycle": {"deprecatedIn": false}}),
+            json!({"name": "old-widget", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
         );
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
@@ -203,7 +208,7 @@ mod tests {
     fn unrelated_token_no_component_field_no_warning() {
         let diags = run(
             json!({"name": {"property": "border-radius"}, "value": "4px"}),
-            json!({"name": "button", "lifecycle": {"deprecated": "1.0.0-draft"}}),
+            json!({"name": "button", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}),
         );
         assert!(diags.is_empty());
     }

--- a/sdk/core/src/validate/rules/spec037.rs
+++ b/sdk/core/src/validate/rules/spec037.rs
@@ -39,8 +39,13 @@ impl ValidationRule for Rule {
 
         for t in ctx.graph.tokens.values() {
             // Skip tokens that are themselves deprecated — no cascaded warning needed.
-            // Use as_str() so deprecated: null or deprecated: false does not suppress warnings.
-            if t.raw.get("deprecated").and_then(|v| v.as_str()).is_some() {
+            // Use as_str() so a missing/non-string deprecatedIn does not suppress warnings.
+            if t.raw
+                .get("lifecycle")
+                .and_then(|l| l.get("deprecatedIn"))
+                .and_then(|v| v.as_str())
+                .is_some()
+            {
                 continue;
             }
 
@@ -65,7 +70,7 @@ impl ValidationRule for Rule {
                             .find(|p| p.get("name").and_then(|n| n.as_str()) == Some(part_name))
                     })
                     .and_then(|p| p.get("lifecycle"))
-                    .and_then(|l| l.get("deprecated"))
+                    .and_then(|l| l.get("deprecatedIn"))
                     .and_then(|v| v.as_str());
 
                 if let Some(version) = dep_version {
@@ -101,7 +106,7 @@ impl ValidationRule for Rule {
                             })
                         })
                         .and_then(|s| s.get("lifecycle"))
-                        .and_then(|l| l.get("deprecated"))
+                        .and_then(|l| l.get("deprecatedIn"))
                         .and_then(|v| v.as_str());
 
                     if let Some(version) = dep_version {
@@ -147,7 +152,7 @@ impl ValidationRule for Rule {
                             })
                         })
                         .and_then(|entry| entry.get("lifecycle"))
-                        .and_then(|l| l.get("deprecated"))
+                        .and_then(|l| l.get("deprecatedIn"))
                         .and_then(|v| v.as_str());
 
                     if let Some(version) = dep_version {
@@ -246,7 +251,7 @@ mod tests {
     fn deprecated_anatomy_warns() {
         let diags = run(
             json!({"name": {"component": "slider", "anatomy": "handle", "property": "background-color"}, "value": "#fff"}),
-            json!({"name": "slider", "anatomy": [{"name": "handle", "lifecycle": {"deprecated": "1.0.0-draft"}}]}),
+            json!({"name": "slider", "anatomy": [{"name": "handle", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}]}),
         );
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
@@ -272,7 +277,7 @@ mod tests {
     fn deprecated_state_warns() {
         let diags = run(
             json!({"name": {"component": "button", "state": ["pressed"], "property": "background-color"}, "value": "#ccc"}),
-            json!({"name": "button", "states": [{"name": "pressed", "lifecycle": {"deprecated": "1.0.0-draft"}}]}),
+            json!({"name": "button", "states": [{"name": "pressed", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}]}),
         );
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
@@ -305,7 +310,7 @@ mod tests {
                         "values": [
                             {"value": "primary"},
                             {"value": "secondary"},
-                            {"value": "cta", "lifecycle": {"deprecated": "1.0.0-draft", "deprecatedComment": "Use primary instead."}}
+                            {"value": "cta", "lifecycle": {"deprecatedIn": "1.0.0-draft", "deprecatedComment": "Use primary instead."}}
                         ]
                     }
                 }
@@ -329,9 +334,9 @@ mod tests {
             json!({
                 "name": {"component": "slider", "anatomy": "handle", "property": "background-color"},
                 "value": "#fff",
-                "deprecated": "1.0.0-draft"
+                "lifecycle": {"deprecatedIn": "1.0.0-draft"}
             }),
-            json!({"name": "slider", "anatomy": [{"name": "handle", "lifecycle": {"deprecated": "1.0.0-draft"}}]}),
+            json!({"name": "slider", "anatomy": [{"name": "handle", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}]}),
         );
         assert!(diags.is_empty());
     }
@@ -343,9 +348,9 @@ mod tests {
             json!({
                 "name": {"component": "button", "state": ["pressed"], "property": "background-color"},
                 "value": "#ccc",
-                "deprecated": false
+                "lifecycle": {"deprecatedIn": false}
             }),
-            json!({"name": "button", "states": [{"name": "pressed", "lifecycle": {"deprecated": "1.0.0-draft"}}]}),
+            json!({"name": "button", "states": [{"name": "pressed", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}]}),
         );
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
@@ -358,7 +363,7 @@ mod tests {
         // SPEC-018 owns "component not declared" — SPEC-037 stays silent.
         let diags = run(
             json!({"name": {"component": "ghost", "anatomy": "handle", "property": "color"}, "value": "#000"}),
-            json!({"name": "other-component", "anatomy": [{"name": "handle", "lifecycle": {"deprecated": "1.0.0-draft"}}]}),
+            json!({"name": "other-component", "anatomy": [{"name": "handle", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}]}),
         );
         assert!(diags.is_empty());
     }
@@ -370,8 +375,8 @@ mod tests {
             json!({"name": {"component": "slider", "anatomy": "handle", "state": ["pressed"], "property": "color"}, "value": "#000"}),
             json!({
                 "name": "slider",
-                "anatomy": [{"name": "handle", "lifecycle": {"deprecated": "1.0.0-draft"}}],
-                "states": [{"name": "pressed", "lifecycle": {"deprecated": "1.0.0-draft"}}]
+                "anatomy": [{"name": "handle", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}],
+                "states": [{"name": "pressed", "lifecycle": {"deprecatedIn": "1.0.0-draft"}}]
             }),
         );
         assert_eq!(diags.len(), 2);


### PR DESCRIPTION
## Description

Restructures cascade token deprecation/lifecycle metadata into a nested `lifecycle`
object (`introduced`, `deprecatedIn`, `deprecatedComment`, `replacedBy`,
`plannedRemoval`), matching the component schema's existing `lifecycle` pattern. The
old flat `deprecated` field held a version string but read as boolean-ish, and
diverged from the component schema's naming.

Also backfills the `deprecated: "unknown"` migration placeholder (left over from the
legacy→cascade migration) with the real `@adobe/spectrum-tokens` release version for
all 1,323 affected tokens, recovered from CHANGELOG history and git archaeology.

### Changes

- **`packages/design-data-spec/schemas/token.schema.json`**: new `$defs.lifecycle`,
  referenced from `tokenWithValue`/`tokenWithRef` in place of the 5 removed flat fields.
- **`packages/design-data-spec/schemas/component.schema.json`**: renamed
  `lifecycle.deprecated` → `lifecycle.deprecatedIn` so token and component schemas match.
- **`packages/design-data/tokens/*.tokens.json`** (7 of 8 files): 1,323 tokens migrated
  into the nested shape, with real deprecation versions backfilled.
- **`packages/design-data/scripts/{backfill-deprecated-versions,migrate-lifecycle-nesting}.js`**:
  new re-runnable migration scripts.
- **`sdk/core/src`** (`legacy.rs`, `migrate.rs`, `diff.rs`, `authoring/{lifecycle,session}.rs`,
  `validate/rules/spec0{10,11,12,13,14,36,37}.rs`): cascade↔legacy conversion, diff pairing,
  and validation rules retargeted to `lifecycle.*`.
- **`packages/design-data-spec/spec/{token-format,authoring-workflow,evolution}.md`**:
  documentation updated for the nested shape.
- ~23 conformance fixtures under `packages/design-data-spec/conformance/` updated to match.

**Legacy output (`@adobe/spectrum-tokens`) is unchanged** — `deprecated`/
`deprecated_comment`/`renamed` stay flat there; verified byte-identical.

## Motivation and Context

`deprecated` on a token is a version string (e.g. `"14.5.0"`), not a boolean, but the
flat name reads like one. The component schema already solved this with a nested
`lifecycle` object; tokens were the odd one out. The spec is still `1.0.0-draft`, so
this breaking rename is cheapest now, before external consumers pin to it.

## How Has This Been Tested?

- `cargo test --workspace` — 1257 passed, 2 ignored (includes ~30 conformance-fixture
  test modules covering SPEC-010–014/036/037 validation, diff pairing, and legacy
  generation round-trips).
- `cargo clippy --workspace -- -D warnings` — clean.
- `cargo fmt --all` — applied.
- `moon run design-data:validate-dataset` — clean (only pre-existing unrelated
  SPEC-050 warnings).
- `moon run design-data:legacy-output` — byte-identical to the committed
  `packages/tokens/src/*.json` (verified via direct binary diff, bypassing moon cache).
- `moon run design-data:roundtrip-verify` — "Roundtrip OK".
- `token-diff-generator` and `token-changeset-generator` AVA suites — green, zero
  edits needed (they operate on legacy-format output, which is unaffected).
- Changeset lint (`node tools/changeset-linter/src/cli.js check --fail-on-warnings`) — passes.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change) — cascade schema only; legacy package output unaffected.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
