### PR TITLE
feat(design-data-spec,sdk): add CTR conformance fixtures

### DIFF
--- a/.changeset/ctr-conformance-fixtures.md
+++ b/.changeset/ctr-conformance-fixtures.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-spec": patch
+---
+
+Add conformance fixtures for the Component/Token Relationship (CTR) rules
+(closes spectrum-design-data-x29.5).
+
+- **conformance/invalid/SPEC-051..057**: one dataset + expected-errors
+  fixture per CTR rule (undeclared component/part/option/state, unresolved
+  `$ref`, duplicate `uuid`, missing `legacyKey` warning).
+- **conformance/valid/SPEC-051**: a zero-diagnostic baseline CTR dataset
+  covering both value-owning and relationship-only shapes.
+- **conformance/generation/ctr-legacy-key**: proves a value-owning CTR
+  reproduces its legacy token byte-identically and a relationship-only
+  CTR is filtered out of legacy output.
+- **scripts/check-layout.mjs**: registers the new fixture paths.

--- a/packages/design-data-spec/conformance/generation/ctr-legacy-key/expected/button.json
+++ b/packages/design-data-spec/conformance/generation/ctr-legacy-key/expected/button.json
@@ -1,0 +1,8 @@
+{
+  "button-border-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "component": "button",
+    "value": "rgb(0, 0, 0)",
+    "uuid": "cccccccc-0001-4000-8000-000000000001"
+  }
+}

--- a/packages/design-data-spec/conformance/generation/ctr-legacy-key/expected/tokens.json
+++ b/packages/design-data-spec/conformance/generation/ctr-legacy-key/expected/tokens.json
@@ -1,0 +1,7 @@
+{
+  "spacing-100": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "bbbbbbbb-0001-4000-8000-000000000001"
+  }
+}

--- a/packages/design-data-spec/conformance/generation/ctr-legacy-key/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/generation/ctr-legacy-key/input/tokens.tokens.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": { "property": "spacing-100" },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "bbbbbbbb-0001-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/generation/ctr-legacy-key/relationships/button.json
+++ b/packages/design-data-spec/conformance/generation/ctr-legacy-key/relationships/button.json
@@ -1,0 +1,14 @@
+[
+  {
+    "scope": { "component": "button", "property": "border-color" },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 0, 0)",
+    "uuid": "cccccccc-0001-4000-8000-000000000001",
+    "legacyKey": "button-border-color"
+  },
+  {
+    "scope": { "component": "button", "property": "icon-color" },
+    "context": "informative icon color",
+    "$ref": "bbbbbbbb-0001-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/invalid/SPEC-051/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-051/dataset.json
@@ -1,0 +1,16 @@
+{
+  "relationships": [
+    {
+      "scope": { "component": "ghost", "property": "background-color" },
+      "value": "#ff0000"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-051/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-051/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-051",
+      "severity": "error",
+      "message_pattern": ".*undeclared component.*ghost.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-052/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-052/dataset.json
@@ -1,0 +1,24 @@
+{
+  "relationships": [
+    {
+      "scope": {
+        "component": "button",
+        "part": "capsule",
+        "property": "background-color"
+      },
+      "value": "#ff0000"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" },
+      "anatomy": [
+        { "name": "icon", "description": "Leading icon." },
+        { "name": "label", "description": "Button text.", "required": true }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-052/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-052/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-052",
+      "severity": "error",
+      "message_pattern": ".*undeclared anatomy part.*capsule.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-053/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-053/dataset.json
@@ -1,0 +1,26 @@
+{
+  "relationships": [
+    {
+      "scope": {
+        "component": "button",
+        "property": "background-color",
+        "options": { "style": "ghost" }
+      },
+      "value": "#ff0000"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" },
+      "options": {
+        "style": {
+          "type": "enum",
+          "values": [{ "value": "fill" }, { "value": "outline" }]
+        }
+      }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-053/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-053/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-053",
+      "severity": "error",
+      "message_pattern": ".*style.*ghost.*not declared.*button.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-054/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-054/dataset.json
@@ -1,0 +1,24 @@
+{
+  "relationships": [
+    {
+      "scope": {
+        "component": "button",
+        "property": "background-color",
+        "options": { "state": ["jello"] }
+      },
+      "value": "#ff0000"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" },
+      "states": [
+        { "name": "hover", "trigger": "interaction", "precedence": 50 },
+        { "name": "disabled", "trigger": "prop", "precedence": 100 }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-054/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-054/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-054",
+      "severity": "error",
+      "message_pattern": ".*undeclared state.*jello.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-055/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-055/dataset.json
@@ -1,0 +1,16 @@
+{
+  "relationships": [
+    {
+      "scope": { "component": "button", "property": "background-color" },
+      "$ref": "99999999-9999-9999-9999-999999999999"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-055/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-055/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-055",
+      "severity": "error",
+      "message_pattern": ".*alias target not found.*99999999-9999-9999-9999-999999999999.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-056/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-056/dataset.json
@@ -1,0 +1,22 @@
+{
+  "relationships": [
+    {
+      "scope": { "component": "button", "property": "background-color" },
+      "value": "#ff0000",
+      "uuid": "11111111-1111-1111-1111-111111111111"
+    },
+    {
+      "scope": { "component": "button", "property": "border-color" },
+      "value": "#00ff00",
+      "uuid": "11111111-1111-1111-1111-111111111111"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-056/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-056/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-056",
+      "severity": "error",
+      "message_pattern": ".*Duplicate relationship uuid.*11111111-1111-1111-1111-111111111111.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-057/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-057/dataset.json
@@ -1,0 +1,21 @@
+{
+  "relationships": [
+    {
+      "scope": {
+        "component": "button",
+        "property": "background-color"
+      },
+      "value": "#ff0000",
+      "setUuid": "22222222-2222-2222-2222-222222222222",
+      "setSchema": "color-set"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-057/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-057/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-057",
+      "severity": "warning",
+      "message_pattern": ".*may need a legacyKey.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-051/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-051/dataset.json
@@ -1,0 +1,42 @@
+{
+  "relationships": [
+    {
+      "scope": {
+        "component": "button",
+        "part": "label",
+        "property": "background-color",
+        "options": { "style": "fill", "state": ["hover"] }
+      },
+      "value": "#ff0000",
+      "uuid": "33333333-3333-3333-3333-333333333333",
+      "legacyKey": "button-label-background-color-fill-hover"
+    },
+    {
+      "scope": { "component": "button", "property": "border-color" },
+      "context": "informative border color",
+      "$ref": "33333333-3333-3333-3333-333333333333"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": { "category": "actions" },
+      "anatomy": [
+        { "name": "icon", "description": "Leading icon." },
+        { "name": "label", "description": "Button text.", "required": true }
+      ],
+      "options": {
+        "style": {
+          "type": "enum",
+          "values": [{ "value": "fill" }, { "value": "outline" }]
+        }
+      },
+      "states": [
+        { "name": "hover", "trigger": "interaction", "precedence": 50 },
+        { "name": "disabled", "trigger": "prop", "precedence": 100 }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/scripts/check-layout.mjs
+++ b/packages/design-data-spec/scripts/check-layout.mjs
@@ -49,6 +49,17 @@ const requiredPaths = [
   "conformance/generation/mode-set-token/expected",
   "spec/relationship-format.md",
   "schemas/relationship.schema.json",
+  "conformance/invalid/SPEC-051",
+  "conformance/invalid/SPEC-052",
+  "conformance/invalid/SPEC-053",
+  "conformance/invalid/SPEC-054",
+  "conformance/invalid/SPEC-055",
+  "conformance/invalid/SPEC-056",
+  "conformance/invalid/SPEC-057",
+  "conformance/valid/SPEC-051",
+  "conformance/generation/ctr-legacy-key/input",
+  "conformance/generation/ctr-legacy-key/relationships",
+  "conformance/generation/ctr-legacy-key/expected",
 ];
 
 for (const rel of requiredPaths) {

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -542,6 +542,20 @@ mod validation_conformance {
             graph = graph.with_components(comp_records);
         }
 
+        if let Some(relationships) = dataset.get("relationships").and_then(|v| v.as_array()) {
+            let rel_records: Vec<crate::graph::RelationshipRecord> = relationships
+                .iter()
+                .enumerate()
+                .map(|(index, raw)| crate::graph::RelationshipRecord {
+                    file: std::path::PathBuf::from("dataset.json"),
+                    index,
+                    uuid: raw.get("uuid").and_then(|v| v.as_str()).map(String::from),
+                    raw: raw.clone(),
+                })
+                .collect();
+            graph = graph.with_relationships(rel_records);
+        }
+
         if let Some(mode_sets) = dataset.get("modeSets").and_then(|v| v.as_array()) {
             let ms_records: Vec<ModeSetRecord> = mode_sets
                 .iter()
@@ -1618,5 +1632,10 @@ mod generation_conformance {
     #[test]
     fn mode_set_edit() {
         run_fixture("mode-set-edit");
+    }
+
+    #[test]
+    fn ctr_legacy_key() {
+        run_fixture("ctr-legacy-key");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the conformance fixture layer and full end-to-end verification for the
Component/Token Relationship (CTR) rules (SPEC-051..057), the last remaining
piece of the CTR epic (`spectrum-design-data-x29`). The rule logic and Rust
validator itself already existed from earlier PRs — this fills in the JSON
fixture layer that every other rule in the repo has, plus a `generation/`
case proving legacy byte-identity for CTRs.

- **conformance/invalid/SPEC-051..057**: one dataset + `expected-errors.json`
  per rule (undeclared component/anatomy part/option/state, unresolved
  `$ref`, duplicate `uuid`, missing-`legacyKey` warning).
- **conformance/valid/SPEC-051**: a zero-diagnostic baseline CTR dataset
  covering both value-owning and relationship-only shapes.
- **conformance/generation/ctr-legacy-key**: proves a value-owning CTR (with
  `legacyKey`) reproduces its legacy token byte-identically, and a
  relationship-only CTR (no `legacyKey`) is filtered out of legacy output.
- **sdk/core/src/lib.rs**: the fixture test harness (`build_graph`) didn't
  parse a `relationships` array from `dataset.json` — without this, the new
  fixtures would never populate `TokenGraph.relationships` and the SPEC-051..057
  rules would never fire against them.
- **scripts/check-layout.mjs**: registers the new fixture paths.

## Related Issue

Closes `spectrum-design-data-x29.5`; closes the parent epic `spectrum-design-data-x29`.

## Motivation and Context

The CTR epic's rule implementation and inline unit tests already existed, but
had no fixture-driven conformance coverage (the pattern every other rule in
this repo follows) and no proof that the legacy generator's byte-identity
contract holds for CTRs specifically.

## How Has This Been Tested?

- `moon run sdk:test` — full Rust workspace, all tests pass, including the
  new `generation_conformance::ctr_legacy_key` test.
- `moon run design-data:roundtrip-verify` — confirms no drift in
  `packages/tokens/src` (`Roundtrip OK`).
- `moon run design-data-spec:check` — fixture layout check passes.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset
  lints clean.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
