### PR TITLE
perf(sdk): speed up Rust test/build loop (nextest, lld, doctest task)

### DIFF
--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -22,6 +22,7 @@
     "sdk:fmt-check",
     "sdk:lint",
     "sdk:test",
+    "sdk:test-doc",
     "sdk-wasm:ci",
     "tokens:test",
     "tokens:validateDesignData",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
+      # lld links noticeably faster than the default bfd linker, applied via
+      # sdk/.cargo/config.toml (scoped to x86_64-unknown-linux-gnu only).
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
+      # cargo-nextest runs sdk:test — schedules all tests across one pool
+      # instead of one binary at a time (~27 integration-test binaries).
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       # Persist the Cargo build cache (sdk/target/) across PR runs.
       # On a warm hit this turns a full 455-crate recompile into an incremental
       # build — the single biggest CI speedup in this repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       # instead of one binary at a time (~27 integration-test binaries).
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-nextest
+          tool: cargo-nextest@0.9.114
       # Persist the Cargo build cache (sdk/target/) across PR runs.
       # On a warm hit this turns a full 455-crate recompile into an incremental
       # build — the single biggest CI speedup in this repo.

--- a/sdk/.cargo/config.toml
+++ b/sdk/.cargo/config.toml
@@ -19,3 +19,10 @@
 # See: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+
+# lld links noticeably faster than the default bfd linker. Scoped to Linux CI
+# only (default macOS ld-prime is already fast and isn't the bottleneck there;
+# warm-cache CI rebuilds are link-time-dominated since deps are cached and only
+# changed crates recompile + relink).
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/sdk/CLAUDE.md
+++ b/sdk/CLAUDE.md
@@ -45,5 +45,27 @@ New YAML/moon.yml: `# Copyright YYYY Adobe. All rights reserved.`
 
 ## Testing
 
-`cargo test --workspace` runs all unit and integration tests.
+`moon run sdk:test` runs all unit and integration tests via `cargo nextest run --workspace`
+(schedules all tests across one pool instead of one binary at a time — much faster with
+\~27 integration-test binaries across the workspace). Doctests aren't run by nextest;
+`moon run sdk:test-doc` (`cargo test --workspace --doc`) covers those separately.
 No AVA — the Rust crates do not use JavaScript testing frameworks.
+
+Local install: `cargo install cargo-nextest@0.9.114 --locked` (or `cargo binstall cargo-nextest`).
+Pinned to 0.9.114 because newer releases require rustc 1.91+, ahead of this repo's
+pinned `rust-toolchain.toml` (1.88.0). CI installs via `taiki-e/install-action`,
+which fetches a prebuilt binary and isn't affected by this constraint.
+
+### Local test performance (macOS)
+
+On managed macOS machines, both Gatekeeper/XProtect and CrowdStrike Falcon re-scan
+freshly built test binaries on exec, which can dominate wall-clock time — not
+compile/link (see bead `spectrum-design-data-tdb`). Two independent mitigations,
+neither of which this repo can configure for you:
+
+* **Gatekeeper**: `sudo spctl developer-mode enable-terminal`, then enable your
+  terminal app under **System Settings → Privacy & Security → Developer Tools**.
+* **CrowdStrike Falcon**: request a path exclusion for `sdk/target/` (or your
+  Cargo target dir) from your org's CrowdStrike admin/IT security team. Don't
+  attempt to disable or bypass the Falcon agent yourself — it's centrally
+  managed via MDM.

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -62,15 +62,41 @@ tasks:
       - "/packages/design-data/guidelines/*.json"
     deps:
       - codegen-check
+  # cargo-nextest schedules all tests across one global thread pool instead of
+  # one binary at a time, which matters here: tui/tests/ alone has 23 separate
+  # integration-test binaries. Doctests aren't run by nextest, so they're a
+  # separate task below (test-doc) — see .github/ci-targets.json.
   test:
     command: cargo
     args:
-      - test
+      - nextest
+      - run
       - --workspace
     inputs:
       - "@globs(sources)"
       - "core/src/registry_data.rs"
       # Embedded snapshot sources — re-run tests when token data changes.
+      - "/packages/design-data/tokens/*.tokens.json"
+      - "/packages/tokens/schemas/**/*.json"
+      - "/packages/tokens/naming-exceptions.json"
+      - "/packages/tokens/manifest.json"
+      - "/packages/design-data/mode-sets/*.json"
+      - "/packages/design-data/components/*.json"
+      - "/packages/design-data/fields/*.json"
+      - "/packages/design-data/guidelines/*.json"
+    deps:
+      - codegen-check
+  # nextest doesn't run doctests — this covers the runnable ```rust examples
+  # in core/src (write.rs, naming.rs, legacy.rs, migrate.rs, cascade.rs, etc).
+  test-doc:
+    command: cargo
+    args:
+      - test
+      - --workspace
+      - --doc
+    inputs:
+      - "@globs(sources)"
+      - "core/src/registry_data.rs"
       - "/packages/design-data/tokens/*.tokens.json"
       - "/packages/tokens/schemas/**/*.json"
       - "/packages/tokens/naming-exceptions.json"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ships the drafted enhancements from the `sdk/` build/test performance investigation
(bead `spectrum-design-data-tdb`): `moon run sdk:test` now runs `cargo nextest run
--workspace` (schedules all tests across one pool instead of one binary at a time —
~27 integration-test binaries across the workspace), doctests move to a new
`sdk:test-doc` task (nextest doesn't run them), CI installs `lld` for faster Linux
linking, and `sdk/CLAUDE.md` documents the investigation's conclusion.

## Related Issue

Closes bead `spectrum-design-data-tdb` (Investigate improve Rust SDK compile-time
performance).

## Motivation and Context

Local `cargo build`/`cargo test` in `sdk/` was taking 4+ minutes on incremental
builds during PR review. Investigation (already closed) found the real cause was
**not** compile/link time but **CrowdStrike Falcon + macOS Gatekeeper/XProtect
re-scanning freshly built test binaries on exec** — 369s → 15s (~24x) once the
source tree was moved under an IT-allowlisted path. That mitigation is external to
this repo (an IT/MDM change), so this PR ships the build-tooling side: nextest for
faster test scheduling, `lld` for faster CI linking, and documentation of the
CrowdStrike finding so other developers aren't misled into thinking it's a
compile-time problem.

## How Has This Been Tested?

- `cargo nextest --version` confirms install (pinned to `0.9.114` — newer releases
  require rustc 1.91+, ahead of this repo's pinned `rust-toolchain.toml` 1.88.0; CI
  installs a prebuilt binary via `taiki-e/install-action`, unaffected by this pin).
- `moon run sdk:test` — full workspace run, **1290 tests passed, 1 skipped**.
- `moon run sdk:test-doc` — doctests across `core/src` (`write.rs`, `cascade.rs`)
  pass.
- Along the way, root-caused an apparent "hang" in the `design-data-wasm` crate's
  test binary to a blocked stdin read in one sandboxed tool environment (not
  CrowdStrike, not reproducible in CI where runners have non-tty stdin) — confirmed
  by direct reproduction and by redirecting stdin from `/dev/null`.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — no changeset
  needed (internal-only Rust crates, tooling/CI change only).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
