### PR TITLE
fix(docs): restore s2-tokens-viewer component colors and stop tab cascade

### DIFF
--- a/.changeset/fix-viewer-cascade-and-component-colors.md
+++ b/.changeset/fix-viewer-cascade-and-component-colors.md
@@ -1,0 +1,12 @@
+---
+"s2-tokens-viewer": patch
+---
+
+Fix broken tabs (closes viewer report from Matt Davey).
+
+- **index.html**: stop dropping failed fetches from the results array before
+  `init()` destructures it positionally — a single missing file no longer
+  shifts every later tab's data into the wrong slot.
+- **scripts/resolve.mjs**: regenerate `tokens/color-component.json` at build
+  time from the CTR-authored per-component token files (removed upstream in
+  #1330), restoring the Component colors tab.

--- a/docs/s2-tokens-viewer/.gitignore
+++ b/docs/s2-tokens-viewer/.gitignore
@@ -1,1 +1,2 @@
 tokens/resolved.json
+tokens/color-component.json

--- a/docs/s2-tokens-viewer/index.html
+++ b/docs/s2-tokens-viewer/index.html
@@ -1308,11 +1308,14 @@
       async function fetchAndValidateData() {
         const dataPromises = config.jsonFiles.map(fetchJsonData);
         const results = await Promise.all(dataPromises);
-        const validData = results.filter((result) => result !== null);
+        // Keep results index-aligned with config.jsonFiles: init() destructures this array
+        // positionally, so filtering out a failed fetch would shift every later tab's data
+        // into the wrong slot. A missing file becomes an empty tab instead.
+        const validData = results.map((result) => result ?? {});
 
         console.log("Fetched data:", validData);
 
-        if (validData.length === 0) {
+        if (results.every((result) => result === null)) {
           document.getElementById("gridContainer").innerHTML =
             "<p>No data was loaded. Please check the console for errors.</p>";
           return null;

--- a/docs/s2-tokens-viewer/moon.yml
+++ b/docs/s2-tokens-viewer/moon.yml
@@ -44,6 +44,7 @@ tasks:
       - tokens/**/*.json
     outputs:
       - tokens/resolved.json
+      - tokens/color-component.json
   export:
     command:
       - sh

--- a/docs/s2-tokens-viewer/scripts/resolve.mjs
+++ b/docs/s2-tokens-viewer/scripts/resolve.mjs
@@ -32,6 +32,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 const tokensDir = join(root, 'tokens');
 const outPath = join(tokensDir, 'resolved.json');
+const colorComponentOutPath = join(tokensDir, 'color-component.json');
+
+// The CTR migration (#1330) removed the aggregated color-component.json and reorganized
+// component tokens into per-component files (action-bar.json, avatar.json, ...). The viewer's
+// "Component colors" tab still expects one aggregated file, so this rebuilds it at build time.
+const FOUNDATION_FILES = new Set([
+  'color-palette.json',
+  'color-aliases.json',
+  'semantic-color-palette.json',
+  'icons.json',
+  'layout.json',
+  'layout-component.json',
+  'typography.json',
+]);
 
 // Context key → cascade name-object field mapping (from spike Phase C).
 const CTX_MAP = {
@@ -86,11 +100,80 @@ function loadObjectMap() {
   return { slugs };
 }
 
+/**
+ * True if a resolved value string is a color (hex or rgb/rgba).
+ */
+function isColorValue(value) {
+  return typeof value === 'string' && /^(#[0-9a-f]{3,8}|rgba?\()/i.test(value);
+}
+
+/**
+ * True if any of a token's alias values (flat `value` or per-context `sets.*.value`)
+ * resolve to a color, using the same Dataset the rest of this script already loaded.
+ */
+function resolvesToColor(ds, entry) {
+  const values = entry.sets
+    ? Object.values(entry.sets).map(set => set.value)
+    : [entry.value];
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    if (!value.includes('{')) {
+      if (isColorValue(value)) return true;
+      continue;
+    }
+    for (const ctx of Object.values(CTX_MAP)) {
+      const r = ds.resolveReference(value, ctx);
+      if (r && isColorValue(r.value)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Rebuild the aggregated color-component.json that the CTR migration (#1330) removed, by
+ * scanning the per-component object-map files for color-domain tokens (color-set/opacity
+ * schema, or an alias value that resolves to a color).
+ */
+function buildColorComponentFile(ds) {
+  const aggregated = {};
+  const files = readdirSync(tokensDir)
+    .filter(f => f.endsWith('.json') && f !== 'package.json' && f !== 'resolved.json'
+      && f !== 'color-component.json' && !FOUNDATION_FILES.has(f))
+    .sort(); // deterministic order
+
+  for (const file of files) {
+    let data;
+    try {
+      data = JSON.parse(readFileSync(join(tokensDir, file), 'utf-8'));
+    } catch {
+      continue; // already warned about unparseable files in loadObjectMap()
+    }
+    if (Array.isArray(data)) continue; // cascade format — skip
+
+    for (const [name, entry] of Object.entries(data)) {
+      if (!isTokenRecord(entry) || !entry.component) continue;
+      const schema = entry.$schema || '';
+      const isColorDomain = schema.endsWith('color-set.json') || schema.endsWith('opacity.json')
+        || resolvesToColor(ds, entry);
+      if (isColorDomain) aggregated[name] = entry;
+    }
+  }
+
+  const output = {
+    $schema: 'https://opensource.adobe.com/spectrum-design-data/schemas/token-file.json',
+    ...aggregated,
+  };
+  writeFileSync(colorComponentOutPath, JSON.stringify(output, null, 2));
+  console.log(`[resolve] Wrote ${colorComponentOutPath} (${Object.keys(aggregated).length} tokens)`);
+}
+
 async function main() {
   // Load wasm — node build is synchronous; no init() call needed.
   const wasm = await import('@adobe/design-data-wasm');
   const ds = wasm.Dataset.embedded();
   const datasetTokenCount = ds.tokenCount();
+
+  buildColorComponentFile(ds);
 
   const { slugs } = loadObjectMap();
   console.log(`[resolve] ${slugs.size} slugs, ${datasetTokenCount} tokens in embedded dataset`);

--- a/docs/s2-tokens-viewer/scripts/resolve.mjs
+++ b/docs/s2-tokens-viewer/scripts/resolve.mjs
@@ -73,7 +73,7 @@ function isTokenRecord(obj) {
 function loadObjectMap() {
   const slugs = new Map();
   const files = readdirSync(tokensDir)
-    .filter(f => f.endsWith('.json') && f !== 'package.json' && f !== 'resolved.json')
+    .filter(f => f.endsWith('.json') && f !== 'package.json' && f !== 'resolved.json' && f !== 'color-component.json')
     .sort(); // deterministic order
 
   for (const file of files) {
@@ -159,11 +159,7 @@ function buildColorComponentFile(ds) {
     }
   }
 
-  const output = {
-    $schema: 'https://opensource.adobe.com/spectrum-design-data/schemas/token-file.json',
-    ...aggregated,
-  };
-  writeFileSync(colorComponentOutPath, JSON.stringify(output, null, 2));
+  writeFileSync(colorComponentOutPath, JSON.stringify(aggregated, null, 2));
   console.log(`[resolve] Wrote ${colorComponentOutPath} (${Object.keys(aggregated).length} tokens)`);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the S2 Tokens Viewer (docs/s2-tokens-viewer), which was showing broken/empty
data across most of its tabs.

**Root cause (two parts):**
1. The CTR migration (#1330) intentionally removed the aggregated
   `packages/tokens/src/color-component.json`, reorganizing component tokens into
   ~90 per-component files. The viewer still fetched the old aggregate, which now 404s.
2. `fetchAndValidateData()` in `index.html` filtered `null` results out of the fetch
   array before `init()` destructured it *positionally* into 8 named variables. One
   missing file shifted every later variable by one slot, corrupting 5 of 8 tabs
   (not just the intended "Component colors" one).

**Fix:**
- `index.html`: keep the results array index-aligned (`result ?? {}` instead of
  filtering), so a missing file degrades to one empty tab instead of a cascade.
- `scripts/resolve.mjs`: regenerate `tokens/color-component.json` at build time by
  scanning the per-component CTR-authored token files for color-domain tokens
  (schema match or resolves-to-a-color-via-wasm), restoring the Component colors tab.
- `moon.yml` / `.gitignore`: wire the new generated file into the `resolve` task's
  outputs.

## Related Issue

Reported by Matt Davey: the deployed viewer at
https://opensource.adobe.com/spectrum-design-data/s2-tokens-viewer/ wasn't working.

## Motivation and Context

Restores a broken public tool without reversing the intentional upstream CTR
migration, and keeps the Component colors tab CTR-derived going forward (build-time
regeneration from the per-component files rather than a hand-maintained aggregate).

## How Has This Been Tested?

- `moon run viewer:resolve` and `moon run viewer:export` run clean end-to-end.
- Verified the generated `color-component.json` (82 tokens, all with a `component`
  field, keys like `action-bar-border-color` / `avatar-border-color` present).
- Served the exported site locally and inspected it live via browser automation:
  - All 8 tabs render (Color palette, Semantic colors, Color aliases, Component
    colors, Icons, Layout, Component layout, Typography).
  - Component colors tab populates with 80+ rows, resolved light/dark hex values,
    and resolution chains.
  - Typography tab (previously `undefined` due to the cascade) renders correctly.
  - No console errors on a clean load.
- Regression guard: renamed `typography.json` to force a 404 and reloaded — only
  the Typography tab went empty (header row, no data rows); every other tab still
  rendered correctly, proving the cascade is gone. Console showed a caught 404, not
  a thrown error. Restored the file afterward.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Screenshots (if appropriate):

N/A (before/after not captured as images; described in testing notes above).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
