### PR TITLE
fix(design-data): resolve SPEC-027 dangling tokenBindings for vpk.1

### DIFF
--- a/.changeset/spec027-vpk1-safe-removes.md
+++ b/.changeset/spec027-vpk1-safe-removes.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": minor
+"@adobe/spectrum-tokens": minor
+---
+
+Resolve SPEC-027 dangling `tokenBindings` via design-owner triage
+(spectrum-design-data-vpk.1).
+
+- **components/cards.json**: drop 4 `card-selection-background-corner-radius-*`
+  bindings — card-selection only has background-size/-color tokens, no
+  corner-radius family exists.
+- **components/menu.json**: drop the `popover-submenu-to-menu-item-position`
+  binding — no "submenu" token exists anywhere in the dataset.
+- **components/alert-dialog.json**: drop the `alert-dialog-top-to-alert-icon`
+  binding — no matching spacing token exists in the live Figma spec.
+- **components/date-picker.json**: drop the 3 `range-border-dash-*` bindings —
+  the live spec documents a solid range fill, not a dashed border.
+- **tokens/token-types/angle.json**: add a new `angle` token type (degrees) for
+  rotation/direction values like gradient angle.
+- **tokens**: define 8 tokens confirmed live in Figma but missing from the
+  corpus — tabs gap/indicator-thickness, `neutral-content-color-selected-*`,
+  date-picker strikethrough thickness/angle and in-field-button gap.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
       # proto/rustup interaction bug. Pre-installing via dtolnay/rust-toolchain
       # ensures proto finds cargo already present and skips its own install.
       - uses: dtolnay/rust-toolchain@1.88.0
+      # sdk/.cargo/config.toml forces the lld linker for all Linux builds, and
+      # some node-list moon tasks transitively depend on sdk:build — install
+      # it here too, mirroring the Rust job below.
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
       - uses: moonrepo/setup-toolchain@v0
         with:
           auto-install: true

--- a/docs/site/public/schemas/token-types/angle.json
+++ b/docs/site/public/schemas/token-types/angle.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/angle.json",
+  "title": "Angle",
+  "description": "An angle in degrees, e.g. for rotation or gradient direction. Positive values rotate clockwise from horizontal.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "token.json"
+    }
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/angle.json"
+    },
+    "value": {
+      "type": "number"
+    },
+    "component": {},
+    "private": {},
+    "deprecated": {},
+    "deprecated_comment": {},
+    "description": {},
+    "uuid": {}
+  }
+}

--- a/packages/design-data/components/alert-dialog.json
+++ b/packages/design-data/components/alert-dialog.json
@@ -103,12 +103,6 @@
   "lifecycle": {
     "introduced": "1.0.0-draft"
   },
-  "tokenBindings": [
-    {
-      "token": "alert-dialog-top-to-alert-icon",
-      "context": "Icon asset (error and warning variants)"
-    }
-  ],
   "accessibility": {
     "role": "dialog",
     "intents": ["dismiss"],

--- a/packages/design-data/components/cards.json
+++ b/packages/design-data/components/cards.json
@@ -97,24 +97,6 @@
   "lifecycle": {
     "introduced": "1.0.0-draft"
   },
-  "tokenBindings": [
-    {
-      "token": "card-selection-background-corner-radius-small",
-      "context": "Selection checkbox "
-    },
-    {
-      "token": "card-selection-background-corner-radius-medium",
-      "context": "Selection checkbox "
-    },
-    {
-      "token": "card-selection-background-corner-radius-large",
-      "context": "Selection checkbox "
-    },
-    {
-      "token": "card-selection-background-corner-radius-extra-large",
-      "context": "Selection checkbox "
-    }
-  ],
   "accessibility": {
     "intents": ["select"],
     "focusable": true,

--- a/packages/design-data/components/date-picker.json
+++ b/packages/design-data/components/date-picker.json
@@ -264,23 +264,7 @@
   },
   "tokenBindings": [
     {
-      "token": "range-border-dash-length",
-      "context": "Range fill stroke padding"
-    },
-    {
-      "token": "range-border-dash-gap",
-      "context": "Range fill stroke padding"
-    },
-    {
-      "token": "range-border-dash-thickness",
-      "context": "Range fill stroke padding"
-    },
-    {
       "token": "strikethrough-day-thickness",
-      "context": "Strikethrough day "
-    },
-    {
-      "token": "strikethrough-day-orientation",
       "context": "Strikethrough day "
     },
     {

--- a/packages/design-data/components/menu.json
+++ b/packages/design-data/components/menu.json
@@ -289,12 +289,6 @@
   "lifecycle": {
     "introduced": "1.0.0-draft"
   },
-  "tokenBindings": [
-    {
-      "token": "popover-submenu-to-menu-item-position",
-      "context": "Sub-menu alignment with menu item"
-    }
-  ],
   "accessibility": {
     "role": "menu",
     "intents": ["select"],

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -3372,6 +3372,39 @@
   {
     "name": {
       "colorRole": "neutral",
+      "property": "content-color",
+      "state": ["selected", "default"],
+      "legacyKey": "neutral-content-color-selected-default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
+    "uuid": "7289003d-78b6-4c61-aada-a3252a7a9bd2"
+  },
+  {
+    "name": {
+      "colorRole": "neutral",
+      "property": "content-color",
+      "state": ["selected", "hover"],
+      "legacyKey": "neutral-content-color-selected-hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
+    "uuid": "018f02b1-2f01-4b48-8161-4a0e9d2eed09"
+  },
+  {
+    "name": {
+      "colorRole": "neutral",
+      "property": "content-color",
+      "state": ["selected", "keyboard-focus"],
+      "legacyKey": "neutral-content-color-selected-key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
+    "uuid": "1b040ae6-315e-49a5-9363-62ba79b139ff"
+  },
+  {
+    "name": {
+      "colorRole": "neutral",
       "variant": "subdued",
       "property": "color",
       "state": ["default"],

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -7192,5 +7192,69 @@
     "uuid": "a659c66d-1e77-4818-95ea-501e65162841",
     "set_uuid": "dd3133de-94a6-4007-a68e-4202762f0eb5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tabs",
+      "property": "gap",
+      "orientation": "horizontal",
+      "density": "compact",
+      "size": "m",
+      "legacyKey": "tab-item-to-tab-item-compact-horizontal-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
+    "uuid": "95593667-9f7c-4e5e-a739-8dd479cd082f",
+    "description": "Spacing between tab items, horizontal, compact density"
+  },
+  {
+    "name": {
+      "component": "tabs",
+      "anatomy": "indicator",
+      "property": "thickness",
+      "legacyKey": "tab-selection-indicator-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "181806e5-0216-4b11-a775-9ed4bb8832fc",
+    "description": "Thickness of the tab selection indicator (underline)"
+  },
+  {
+    "name": {
+      "component": "date-picker",
+      "anatomy": "day",
+      "qualifier": "strikethrough",
+      "property": "thickness",
+      "legacyKey": "strikethrough-day-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "c4e4695b-3838-4bd4-b045-8219c77f6786",
+    "description": "Thickness of the strikethrough line on an unavailable calendar day"
+  },
+  {
+    "name": {
+      "component": "date-picker",
+      "anatomy": "day",
+      "qualifier": "strikethrough",
+      "property": "angle",
+      "legacyKey": "strikethrough-day-orientation"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/angle.json",
+    "value": -25,
+    "uuid": "e9a6e122-49fc-4d40-880d-1d9006d7154e",
+    "description": "Angle of the strikethrough line on an unavailable calendar day, in degrees (negative rotates counter-clockwise from horizontal)"
+  },
+  {
+    "name": {
+      "component": "date-picker",
+      "anatomy": "in-field-button",
+      "property": "gap",
+      "legacyKey": "date-picker-text-to-in-field-button"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "19864654-c28c-4ad9-b35d-c669b33c5b9c",
+    "description": "Spacing between date field value and the in-field calendar button"
   }
 ]

--- a/packages/tokens/naming-exceptions.json
+++ b/packages/tokens/naming-exceptions.json
@@ -1609,6 +1609,30 @@
       "file": "layout.json",
       "category": "state-position",
       "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tab-item-to-tab-item-compact-horizontal-medium",
+      "file": "layout.json",
+      "category": "legacy-preserved",
+      "reason": "legacyKey pinned to the original dangling tokenBindings name (SPEC-027 vpk.1 fix); does not roundtrip through field-order generation"
+    },
+    {
+      "token": "tab-selection-indicator-thickness",
+      "file": "layout.json",
+      "category": "legacy-preserved",
+      "reason": "legacyKey pinned to the original dangling tokenBindings name (SPEC-027 vpk.1 fix); does not roundtrip through field-order generation"
+    },
+    {
+      "token": "strikethrough-day-thickness",
+      "file": "layout.json",
+      "category": "legacy-preserved",
+      "reason": "legacyKey pinned to the original dangling tokenBindings name (SPEC-027 vpk.1 fix); does not roundtrip through field-order generation"
+    },
+    {
+      "token": "strikethrough-day-orientation",
+      "file": "layout.json",
+      "category": "legacy-preserved",
+      "reason": "legacyKey pinned to the original dangling tokenBindings name (SPEC-027 vpk.1 fix); does not roundtrip through field-order generation"
     }
   ]
 }

--- a/packages/tokens/schemas/token-types/angle.json
+++ b/packages/tokens/schemas/token-types/angle.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/angle.json",
+  "title": "Angle",
+  "description": "An angle in degrees, e.g. for rotation or gradient direction. Positive values rotate clockwise from horizontal.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "token.json"
+    }
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/angle.json"
+    },
+    "value": {
+      "type": "number"
+    },
+    "component": {},
+    "private": {},
+    "deprecated": {},
+    "deprecated_comment": {},
+    "description": {},
+    "uuid": {}
+  }
+}

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -1017,6 +1017,34 @@
       "message": "Known naming exception: 'side-focus-indicator' does not match canonical generation rules (tracked in naming-exceptions.json)"
     },
     {
+      "file": "./src/layout.json",
+      "token": "strikethrough-day-orientation",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'strikethrough-day-orientation' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "strikethrough-day-thickness",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'strikethrough-day-thickness' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "tab-item-to-tab-item-compact-horizontal-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-compact-horizontal-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "tab-selection-indicator-thickness",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-selection-indicator-thickness' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
       "file": "./src/menu.json",
       "token": "menu-item-edge-to-content-not-selected-extra-large",
       "rule_id": "SPEC-007",

--- a/packages/tokens/src/color-aliases.json
+++ b/packages/tokens/src/color-aliases.json
@@ -1620,6 +1620,21 @@
     "value": "{gray-900}",
     "uuid": "c2c538e0-6f8d-4586-953a-b98ef40c9eca"
   },
+  "neutral-content-color-selected-default": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{gray-800}",
+    "uuid": "7289003d-78b6-4c61-aada-a3252a7a9bd2"
+  },
+  "neutral-content-color-selected-hover": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{gray-900}",
+    "uuid": "018f02b1-2f01-4b48-8161-4a0e9d2eed09"
+  },
+  "neutral-content-color-selected-key-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{gray-900}",
+    "uuid": "1b040ae6-315e-49a5-9363-62ba79b139ff"
+  },
   "neutral-subdued-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -1819,6 +1819,13 @@
       }
     }
   },
+  "date-picker-text-to-in-field-button": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "date-picker",
+    "value": "20px",
+    "uuid": "19864654-c28c-4ad9-b35d-c669b33c5b9c",
+    "description": "Spacing between date field value and the in-field calendar button"
+  },
   "disclosure-indicator-top-to-disclosure-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
     "uuid": "4c5c2390-1571-4141-9ebd-a3e0b1e58322",
@@ -3308,6 +3315,34 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "80px",
     "uuid": "d04e5d81-0b6e-48e7-9e47-744753dfcff3"
+  },
+  "strikethrough-day-orientation": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/angle.json",
+    "component": "date-picker",
+    "value": -25,
+    "uuid": "e9a6e122-49fc-4d40-880d-1d9006d7154e",
+    "description": "Angle of the strikethrough line on an unavailable calendar day, in degrees (negative rotates counter-clockwise from horizontal)"
+  },
+  "strikethrough-day-thickness": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "date-picker",
+    "value": "2px",
+    "uuid": "c4e4695b-3838-4bd4-b045-8219c77f6786",
+    "description": "Thickness of the strikethrough line on an unavailable calendar day"
+  },
+  "tab-item-to-tab-item-compact-horizontal-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tabs",
+    "value": "{spacing-400}",
+    "uuid": "95593667-9f7c-4e5e-a739-8dd479cd082f",
+    "description": "Spacing between tab items, horizontal, compact density"
+  },
+  "tab-selection-indicator-thickness": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "tabs",
+    "value": "2px",
+    "uuid": "181806e5-0216-4b11-a775-9ed4bb8832fc",
+    "description": "Thickness of the tab selection indicator (underline)"
   },
   "text-gap-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",


### PR DESCRIPTION
## Description

Design-owner triage of the 17 SPEC-027 dangling `tokenBindings[].token`
references escalated in this bead, following a Figma-verified decision matrix
(live Variables, geometry, and spec-annotation screenshots — not just repo
greps).

- **Removed** (no backing token family, or unsupported by the live spec):
  - `cards.json`: 4 `card-selection-background-corner-radius-*` bindings
  - `menu.json`: `popover-submenu-to-menu-item-position`
  - `alert-dialog.json`: `alert-dialog-top-to-alert-icon`
  - `date-picker.json`: 3 `range-border-dash-*` bindings (spec documents a
    solid range fill, not a dashed border)
- **Defined** (confirmed live in Figma, missing from the corpus — first
  modern-schema tokens for the tabs/date-picker/radio-button families):
  - `tab-item-to-tab-item-compact-horizontal-medium`,
    `tab-selection-indicator-thickness`
  - `neutral-content-color-selected-{default,hover,key-focus}`
  - `strikethrough-day-thickness`, `strikethrough-day-orientation`,
    `date-picker-text-to-in-field-button`
- **Added** a new `angle` token type (degrees) to back
  `strikethrough-day-orientation` — a genuinely reusable primitive (also
  useful for gradient direction), not a one-off hack.
- Regenerated legacy `packages/tokens/src` output and the validation golden
  snapshot; added 4 `naming-exceptions.json` entries for legacyKeys pinned
  via the explicit escape hatch.

## Related Issue

Closes spectrum-design-data-vpk.1 (SPEC-027 escalated dangling tokenBindings).

## Motivation and Context

SPEC-027 is an error-level validation rule; these were real validation
failures needing design-owner sign-off before they could be resolved.

## How Has This Been Tested?

- `./sdk/target/debug/design-data validate` — SPEC-027 count dropped 20 → 3
  (remaining 3 belong to `button.json`, out of scope / tracked separately).
- `moon run design-data:validate-dataset design-data:roundtrip-verify design-data:validate-registry` — pass
- `moon run tokens:test tokens:verifyLegacyRoundtrip tokens:verifyLegacyOutput tokens:validateDesignData tokens:verifyDesignDataSnapshot` — pass (27 tests)
- `moon run sdk:codegen-check` — up to date
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
