### PR TITLE
fix(ci): install lld in the Deploy Docs job too

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
         with:
           targets: wasm32-unknown-unknown
+      # sdk/.cargo/config.toml forces the lld linker for all Linux builds, and
+      # viewer:resolve → sdk-wasm:build transitively builds the SDK — install it
+      # here too, mirroring ci.yml.
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
       # Persist the Cargo build cache across deploys so the viewer's wasm
       # build is incremental rather than recompiling from scratch each time.
       - name: Cache Cargo build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an "Install lld" step to `.github/workflows/deploy-docs.yml`'s `deploy` job, mirroring the fix already applied to `ci.yml` in 2efc638b.

## Related Issue

Root cause behind the s2-tokens-viewer showing "Error loading data. Please try again later." at https://opensource.adobe.com/spectrum-design-data/s2-tokens-viewer/ — no issue filed yet.

## Motivation and Context

`sdk/.cargo/config.toml` forces the `lld` linker for all Linux builds (#1332). `deploy-docs.yml` transitively builds the SDK via `viewer:export` → `viewer:resolve` → `sdk-wasm:build` → `sdk:build`, but never installs `lld`, so every Deploy Docs run since `2026-08-17T22:16Z` has failed with:

```
collect2: fatal error: cannot find 'ld'
error: could not compile `serde_core` (build script)
```

Because every deploy has been failing, the site has been stuck serving stale build output — including the pre-fix `s2-tokens-viewer` `index.html` (still has the `results.filter(...)` cascade bug) and a missing `tokens/color-component.json` (404, since it's generated at build time and gitignored). The combination throws inside `init()` and produces the "Error loading data" banner on every tab. The viewer-side fix (#1335, commit 39c90de5) is already correct on `main` — it just has never been deployed.

This same broken pipeline is also stranding `site:export`, `visualizer:build`, `s2-visualizer:build`, and `release-timeline:build`, which run in the same job.

## How Has This Been Tested?

- Confirmed the failure via `gh run list --workflow=deploy-docs.yml` (all recent runs fail) and `gh run view --log-failed` (linker error at `sdk:build`).
- Confirmed the fix pattern matches `ci.yml`'s working `Install lld` step from 2efc638b.
- Local YAML validation (`ruby -ryaml`) confirms the file is still well-formed.
- Full verification requires this PR to merge and a Deploy Docs run to succeed — will confirm the run is green and re-check the live site after merge.

## Screenshots (if appropriate)

N/A — CI workflow change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (Will confirm once Deploy Docs runs on this branch.)
