### PR TITLE
fix(docs): restore s2-tokens-viewer search and value resolution

### DIFF
--- a/.changeset/restore-s2-tokens-viewer.md
+++ b/.changeset/restore-s2-tokens-viewer.md
@@ -12,3 +12,7 @@ Restore search/resolution for component tokens broken by the CTR migration (#133
   component-token aliases resolve to real values instead of showing raw `{ref}` strings.
 - **moon.yml**: add a `convert` task (`design-data-cli migrate convert`) that produces the
   cascade files `resolve` now consumes.
+- **scripts/resolve.mjs**: `buildLayoutComponentFile()` now seeds from the pristine
+  `node_modules/@adobe/spectrum-tokens/src/layout-component.json` instead of its own prior
+  output, so re-running `resolve.mjs` drops tokens renamed/removed upstream instead of
+  accumulating them forever.

--- a/.changeset/restore-s2-tokens-viewer.md
+++ b/.changeset/restore-s2-tokens-viewer.md
@@ -1,0 +1,14 @@
+---
+"s2-tokens-viewer": patch
+---
+
+Restore search/resolution for component tokens broken by the CTR migration (#1330).
+
+- **scripts/resolve.mjs**: add `buildLayoutComponentFile()` (mirrors `buildColorComponentFile()`)
+  so non-color component tokens land in `tokens/layout-component.json` again — they're rendered
+  and searchable, not just the color subset #1335 already fixed.
+- **scripts/resolve.mjs**: build the wasm `Dataset` from the viewer's own cascade-converted
+  source via `Dataset.fromTokens()` instead of the stale `Dataset.embedded()` snapshot, so
+  component-token aliases resolve to real values instead of showing raw `{ref}` strings.
+- **moon.yml**: add a `convert` task (`design-data-cli migrate convert`) that produces the
+  cascade files `resolve` now consumes.

--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -66,6 +66,7 @@
     "token-naming-audit:lint",
     "tokens:build",
     "viewer:clean",
+    "viewer:convert",
     "viewer:export",
     "viewer:prepare",
     "viewer:resolve",

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ temp-*
 
 # auto-generated token files (copied by prepare scripts)
 docs/s2-tokens-viewer/tokens/
+docs/s2-tokens-viewer/cascade/
 
 # tool output directories (graphify, ferrograph)
 graphify-out/

--- a/docs/s2-tokens-viewer/.gitignore
+++ b/docs/s2-tokens-viewer/.gitignore
@@ -1,2 +1,3 @@
 tokens/resolved.json
 tokens/color-component.json
+cascade/

--- a/docs/s2-tokens-viewer/moon.yml
+++ b/docs/s2-tokens-viewer/moon.yml
@@ -32,6 +32,29 @@ tasks:
       - node_modules/@adobe/spectrum-tokens/package.json
     outputs:
       - tokens/
+  # Convert the object-map token source (tokens/) to cascade-format .json files (cascade/) so
+  # resolve.mjs can build a Dataset.fromTokens() dataset that actually contains every token —
+  # Dataset.embedded() is a snapshot of packages/design-data/tokens, which post-CTR no longer
+  # carries component tokens as resolvable entries (see #1330).
+  convert:
+    command: bash
+    args:
+      - -c
+      - >-
+        cargo run --manifest-path "$MOON_WORKSPACE_ROOT/sdk/Cargo.toml" -p design-data-cli --
+        migrate convert "$MOON_WORKSPACE_ROOT/docs/s2-tokens-viewer/tokens"
+        --output "$MOON_WORKSPACE_ROOT/docs/s2-tokens-viewer/cascade"
+        --names-dir "$MOON_WORKSPACE_ROOT/packages/token-names/names"
+        --exceptions "$MOON_WORKSPACE_ROOT/packages/tokens/naming-exceptions.json"
+    inputs:
+      - tokens/**/*.json
+      - "/packages/token-names/names/**/*.json"
+      - "/packages/tokens/naming-exceptions.json"
+    outputs:
+      - cascade/
+    deps:
+      - ~:prepare
+    toolchain: "system"
   resolve:
     command:
       - node
@@ -39,12 +62,15 @@ tasks:
     deps:
       - sdk-wasm:build
       - ~:prepare
+      - ~:convert
     inputs:
       - scripts/resolve.mjs
       - tokens/**/*.json
+      - cascade/**/*.json
     outputs:
       - tokens/resolved.json
       - tokens/color-component.json
+      - tokens/layout-component.json
   export:
     command:
       - sh

--- a/docs/s2-tokens-viewer/scripts/resolve.mjs
+++ b/docs/s2-tokens-viewer/scripts/resolve.mjs
@@ -31,8 +31,10 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 const tokensDir = join(root, 'tokens');
+const cascadeDir = join(root, 'cascade');
 const outPath = join(tokensDir, 'resolved.json');
 const colorComponentOutPath = join(tokensDir, 'color-component.json');
+const layoutComponentOutPath = join(tokensDir, 'layout-component.json');
 
 // The CTR migration (#1330) removed the aggregated color-component.json and reorganized
 // component tokens into per-component files (action-bar.json, avatar.json, ...). The viewer's
@@ -163,16 +165,76 @@ function buildColorComponentFile(ds) {
   console.log(`[resolve] Wrote ${colorComponentOutPath} (${Object.keys(aggregated).length} tokens)`);
 }
 
+/**
+ * Merge every NON-color component token into the source-shipped `layout-component.json`
+ * (which, post-CTR, only retains a handful of leftover icon-size tokens — the rest moved to
+ * per-component files). Mirrors buildColorComponentFile()'s scan but takes the opposite side
+ * of the same color-domain test, so every component token lands in exactly one aggregate.
+ */
+function buildLayoutComponentFile(ds) {
+  const aggregated = JSON.parse(readFileSync(join(tokensDir, 'layout-component.json'), 'utf-8'));
+  const files = readdirSync(tokensDir)
+    .filter(f => f.endsWith('.json') && f !== 'package.json' && f !== 'resolved.json'
+      && f !== 'color-component.json' && !FOUNDATION_FILES.has(f))
+    .sort(); // deterministic order
+
+  for (const file of files) {
+    let data;
+    try {
+      data = JSON.parse(readFileSync(join(tokensDir, file), 'utf-8'));
+    } catch {
+      continue; // already warned about unparseable files in loadObjectMap()
+    }
+    if (Array.isArray(data)) continue; // cascade format — skip
+
+    for (const [name, entry] of Object.entries(data)) {
+      if (!isTokenRecord(entry) || !entry.component) continue;
+      const schema = entry.$schema || '';
+      const isColorDomain = schema.endsWith('color-set.json') || schema.endsWith('opacity.json')
+        || resolvesToColor(ds, entry);
+      if (!isColorDomain) aggregated[name] = entry;
+    }
+  }
+
+  writeFileSync(layoutComponentOutPath, JSON.stringify(aggregated, null, 2));
+  console.log(`[resolve] Wrote ${layoutComponentOutPath} (${Object.keys(aggregated).length} tokens)`);
+}
+
+/**
+ * Load every cascade-format .json file from cascadeDir (produced by
+ * `moon run viewer:convert` via `design-data migrate convert`) into one flat token array
+ * suitable for Dataset.fromTokens(). Each file is a top-level array of cascade token objects.
+ */
+function loadCascadeTokens() {
+  const tokens = [];
+  for (const file of readdirSync(cascadeDir).filter(f => f.endsWith('.json')).sort()) {
+    let data;
+    try {
+      data = JSON.parse(readFileSync(join(cascadeDir, file), 'utf-8'));
+    } catch (e) {
+      console.warn(`[resolve] Skipping unparseable cascade file: ${file} — ${e.message}`);
+      continue;
+    }
+    if (Array.isArray(data)) tokens.push(...data);
+  }
+  return tokens;
+}
+
 async function main() {
   // Load wasm — node build is synchronous; no init() call needed.
   const wasm = await import('@adobe/design-data-wasm');
-  const ds = wasm.Dataset.embedded();
+  // Build the dataset from the viewer's own cascade-converted source (not Dataset.embedded(),
+  // a packages/design-data/tokens snapshot that post-CTR no longer carries component tokens
+  // as resolvable entries — see #1330) so every token, including component tokens, resolves.
+  const cascadeTokens = loadCascadeTokens();
+  const ds = wasm.Dataset.fromTokens(cascadeTokens);
   const datasetTokenCount = ds.tokenCount();
 
   buildColorComponentFile(ds);
+  buildLayoutComponentFile(ds);
 
   const { slugs } = loadObjectMap();
-  console.log(`[resolve] ${slugs.size} slugs, ${datasetTokenCount} tokens in embedded dataset`);
+  console.log(`[resolve] ${slugs.size} slugs, ${datasetTokenCount} tokens in cascade dataset`);
 
   const resolved = {};
   let wasmCount = 0;

--- a/docs/s2-tokens-viewer/scripts/resolve.mjs
+++ b/docs/s2-tokens-viewer/scripts/resolve.mjs
@@ -35,6 +35,7 @@ const cascadeDir = join(root, 'cascade');
 const outPath = join(tokensDir, 'resolved.json');
 const colorComponentOutPath = join(tokensDir, 'color-component.json');
 const layoutComponentOutPath = join(tokensDir, 'layout-component.json');
+const layoutComponentSrcPath = join(root, 'node_modules/@adobe/spectrum-tokens/src/layout-component.json');
 
 // The CTR migration (#1330) removed the aggregated color-component.json and reorganized
 // component tokens into per-component files (action-bar.json, avatar.json, ...). The viewer's
@@ -170,9 +171,13 @@ function buildColorComponentFile(ds) {
  * (which, post-CTR, only retains a handful of leftover icon-size tokens — the rest moved to
  * per-component files). Mirrors buildColorComponentFile()'s scan but takes the opposite side
  * of the same color-domain test, so every component token lands in exactly one aggregate.
+ *
+ * Seeds from the pristine copy in node_modules (not tokens/layout-component.json, which this
+ * function overwrites) so re-running the script never re-reads its own prior output — a token
+ * renamed or removed from a per-component source file is dropped, not carried forward forever.
  */
 function buildLayoutComponentFile(ds) {
-  const aggregated = JSON.parse(readFileSync(join(tokensDir, 'layout-component.json'), 'utf-8'));
+  const aggregated = JSON.parse(readFileSync(layoutComponentSrcPath, 'utf-8'));
   const files = readdirSync(tokensDir)
     .filter(f => f.endsWith('.json') && f !== 'package.json' && f !== 'resolved.json'
       && f !== 'color-component.json' && !FOUNDATION_FILES.has(f))


### PR DESCRIPTION
## Description

Restores two regressions in the Spectrum 2 Tokens Viewer (`docs/s2-tokens-viewer/`) caused by the CTR migration (#1330):

1. **Missing search results.** #1330 split component tokens out of aggregated files into 84 per-component files, none of which are in the viewer's fixed fetch list. Only color tokens were rebuilt at build time (#1335); ~1250 non-color component tokens (dimensions, aliases, multipliers) had no row to render, so searching for them — e.g. `accordion-minimum-width` — returned nothing.
2. **Incomplete value resolution.** `resolve.mjs` resolved values against `Dataset.embedded()`, a snapshot baked from `packages/design-data/tokens` that, post-CTR, no longer models component tokens as resolvable entries. 1287 of 2469 slugs were unresolvable and would display raw `{ref}` strings.

### Fix

- `scripts/resolve.mjs`: added `buildLayoutComponentFile()` — mirrors the existing `buildColorComponentFile()` but merges every non-color component token into `layout-component.json`, restoring the missing rows.
- `scripts/resolve.mjs`: replaced `Dataset.embedded()` with `Dataset.fromTokens()` built from the viewer's own token source, converted to cascade format via a new `moon.yml` `convert` task (`design-data-cli migrate convert`). This fixes value resolution for every token, not just the reported one.
- No changes to `index.html`, the SDK, or wasm bindings — the fix lives entirely in the viewer's build pipeline.

## Related Issue

Reported by Matt Davey in Slack: searching `accordion-minimum-width` in the deployed viewer returned no results.

## Motivation and Context

Restore the viewer to its pre-#1330 functionality — every token should be findable and show its correct resolved value.

## How Has This Been Tested?

- Ran the full build pipeline (`moon run viewer:convert`, `node scripts/resolve.mjs`, `moon run viewer:export`) and inspected the generated JSON directly against the exported build:
  - `resolved.json._meta.missingCount`: 1287 → **0**.
  - `layout-component.json`: 63 → 1267 tokens, includes `accordion-minimum-width` (non-deprecated, resolves to `200px`/`250px`).
  - Previously-unresolvable alias chains (e.g. `accordion-bottom-to-text-regular-large`) now resolve to real px values instead of raw refs.
  - Verified this data would satisfy the viewer's DOM-text search filter for the reported token.
- `moon run :test`: all suites pass except one pre-existing, unrelated failure in `sdk-wasm:test` (`parity.test.js:120`) — confirmed via `git stash` that it fails identically on `main` without this change.
- Confirmed `.github/workflows/deploy-docs.yml` already installs the Rust/wasm toolchain the new `convert` task needs (same `sdk` Cargo workspace as the existing `sdk-wasm:build` dep) — no CI changes required.

## Screenshots (if appropriate):

N/A — no visual/UI changes; verification was done at the data layer against the actual build output (browser automation tooling wasn't available in this environment).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (except the pre-existing unrelated failure noted above).
