### PR TITLE
fix(mcp): set DESIGN_DATA_ROOT for the design-data MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,6 +12,7 @@
       "command": "npx",
       "args": ["-y", "@adobe/design-data-agent-mcp"],
       "env": {
+        "DESIGN_DATA_ROOT": "${PWD}",
         "DESIGN_DATA_BIN": "${PWD}/sdk/target/release/design-data",
         "DESIGN_DATA_PATH": "packages/design-data/tokens",
         "DESIGN_DATA_COMPONENTS": "packages/design-data/components",


### PR DESCRIPTION
## Description

`.mcp.json` launches the `design-data` MCP server via `npx -y @adobe/design-data-agent-mcp` (the published package) with relative `DESIGN_DATA_PATH`/`DESIGN_DATA_COMPONENTS`/`DESIGN_DATA_FIELDS` env vars. Without `DESIGN_DATA_ROOT` set, those relative paths resolve against whatever directory `npx` happens to run from, not the repo root — so `describe_component` (and everything else touching those paths) returned "not found" for every component, blocking the `tpd` epic's work end-to-end.

Adds `"DESIGN_DATA_ROOT": "${PWD}"` alongside the existing `DESIGN_DATA_BIN` entry, which already used the same `${PWD}` pattern.

## Related Issue

Blocking bug found while working the `tpd` epic (design-data MCP integration).

## Motivation and Context

Every `mcp__design-data__*` tool call was silently broken for path-dependent lookups (`describe_component`, etc.) — this unblocks that whole surface.

## How Has This Been Tested?

Verified against local source: `describe_component("button")` now correctly returns 176 CTR relationship entries (previously "not found").

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
