### PR TITLE
docs: support batch token-change requests in the issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/token-change-request.yml
+++ b/.github/ISSUE_TEMPLATE/token-change-request.yml
@@ -1,5 +1,5 @@
 name: Token change request
-description: Request a create/edit/rename/deprecate on a design token (Figma + code).
+description: Request a create/edit/rename/deprecate on one or more design tokens (Figma + code).
 title: "[Token] "
 labels:
   - token-request
@@ -16,79 +16,37 @@ body:
         Figma file — by property, component, variant, and state. Use that file to find
         the exact current name of a token.
 
+        Requesting a batch of related changes? List every token in the table below —
+        one row per token — instead of filing separate issues.
+
         Want to remove a token entirely? Request **Deprecate** below — the design-data
         team removes it later, once nothing else depends on it.
 
         For proposals bigger than a single token (new taxonomy, schema changes), use the
         "Propose an RFC" link in the issue chooser instead.
 
-  - type: dropdown
-    id: change-type
-    attributes:
-      label: Change type
-      description: What do you want to do?
-      options:
-        - "Create — add a token that doesn't exist yet"
-        - "Edit — change a token's value, or what it inherits from"
-        - "Rename — creates a token with the new name and deprecates the old name (anything using the old name keeps working, pointed at the new one)"
-        - "Deprecate — mark a token as no longer recommended"
-    validations:
-      required: true
-
-  - type: input
-    id: token-name-current
-    attributes:
-      label: Token name
-      description: >-
-        For Edit / Rename / Deprecate: the exact current name, as shown in the S2 Token
-        specs (e.g. `component-property-variant-state`). For Create: the name the new
-        token should have.
-      placeholder: e.g. swatch-border-color
-    validations:
-      required: true
-
-  - type: input
-    id: token-name-new
-    attributes:
-      label: New token name — Rename only
-      description: The name the token should have after the rename. Leave blank for all other change types.
-      placeholder: e.g. swatch-border-color-hover
-
   - type: textarea
-    id: value-or-alias
+    id: token-changes
     attributes:
-      label: Value, or token to inherit from — Create / Edit only
+      label: Token changes
       description: >-
-        A literal value (e.g. `12px`, `0.42`, `#FF0000`), OR the name of another token
-        this one should inherit its value from (e.g. `gray-1000`). Give exactly one, not
-        both. Leave blank for Rename / Deprecate.
-      placeholder: e.g. "#FF0000" OR gray-1000
-
-  - type: input
-    id: replacement
-    attributes:
-      label: Replacement token — Deprecate / Rename, if there is one
-      description: The token designers/consumers should use instead, by name.
-      placeholder: e.g. gray-1000
-
-  - type: checkboxes
-    id: modes
-    attributes:
-      label: Modes / themes affected
-      description: Which light/dark, wireframe, or desktop/mobile variants does this apply to?
-      options:
-        - label: Light
-        - label: Dark
-        - label: Wireframe
-        - label: Desktop
-        - label: Mobile
-        - label: All / not sure
+        One row per token. Change type: Create / Edit / Rename / Deprecate. "New name /
+        value / replacement" holds whichever applies: the new name (Rename), a literal
+        value or the name of another token to inherit from (Create / Edit), or a
+        replacement token (Deprecate). Modes/themes: Light, Dark, Wireframe, Desktop,
+        Mobile, or All.
+      value: |
+        | Change type | Token name | New name / value / replacement | Modes / themes |
+        | --- | --- | --- | --- |
+        | Create | swatch-border-color-hover | gray-1000 | Light, Dark |
+    validations:
+      required: true
 
   - type: checkboxes
     id: platforms
     attributes:
       label: Platform target
-      description: Where does this token need to show up?
+      description: Where do these tokens need to show up?
       options:
         - label: S2 Web
         - label: iOS
@@ -107,26 +65,28 @@ body:
     id: migration-note
     attributes:
       label: Migration guidance — Deprecate / Rename
-      description: What should someone using the old token do instead? This gets carried into the deprecation notice.
+      description: >-
+        What should someone using an old token do instead? Note which token this applies
+        to if it's not all of them. This gets carried into the deprecation notice.
 
   - type: textarea
     id: known-consumers
     attributes:
       label: Known consuming components
       description: >-
-        Components that reference this token today (or should reference it after a
+        Components that reference these tokens today (or should reference them after a
         rename/deprecate). Dangling references after a token change are the most common
-        cause of breakage — list what you know, even if incomplete, so reviewers can
-        check the rest.
+        cause of breakage — list what you know per token, even if incomplete, so
+        reviewers can check the rest.
       placeholder: e.g. badge, tag — or "none known, please check"
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: figma-reference
     attributes:
-      label: Link or screenshot from the S2 Token specs
-      description: Optional, but helps reviewers confirm exactly which token/appearance you mean.
+      label: Links or screenshots from the S2 Token specs
+      description: Optional, but helps reviewers confirm exactly which tokens/appearance you mean. One per line if there's more than one.
       placeholder: e.g. https://www.figma.com/design/eoZHKJH9a3LJkHYCGt60Vb/S2-Token-specs?node-id=...
 
   - type: input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds batch support to the token-change-request issue form: the per-token fields
(change type, current/new name, value or replacement, modes) are folded into a single
"Token changes" table where each row is one token, so a designer can request several
related token changes in one issue instead of filing one per token. GitHub issue forms
can't repeat a field group, so a pre-filled markdown table is the practical way to do
this. Fields that genuinely apply to the whole request (platforms, motivation, migration
guidance, known consumers, Figma references) stay as single fields, reworded to cover
multiple tokens.

## Related Issue

Follow-up to the token-change-request intake work (#1342, and the follow-up rewrite
landed directly on `main` at f52453b8).

## Motivation and Context

Designers requesting a set of related token changes (e.g. renaming several tokens as
part of one redesign) previously had to file one issue per token. This lets one issue
cover the whole batch.

## How Has This Been Tested?

Parsed the YAML with `js-yaml` to confirm it's well-formed and every `dropdown`/`checkboxes`
field still has `options`. GitHub issue-form rendering can only be confirmed once this is on
the default branch or the PR branch is selected via the `template` query param, so also did a
manual read-through of the rendered field order and wording.

## Screenshots (if appropriate):

N/A — form YAML, not previewable outside GitHub's own new-issue renderer for this branch.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
