### PR TITLE
feat(sdk): manifest-cascaded legacy export for tokentool codegen

### DIFF
--- a/.changeset/ios-override-importer.md
+++ b/.changeset/ios-override-importer.md
@@ -1,0 +1,11 @@
+---
+"@adobe/design-data-tui": patch
+"@adobe/design-data-wasm": patch
+---
+
+Expose legacy-name decomposition for platform-manifest tooling (closes h890.8).
+
+- **sdk/cli/src/main.rs**: new `decompose-legacy-name` subcommand (exposes
+  `naming::parse_legacy_name`/`roundtrips`) and `dump-legacy-keys` subcommand
+  (exposes `naming::extract_legacy_key` per token, undeduped) so external
+  importers can resolve legacy slugs without reimplementing the algorithm.

--- a/.changeset/legacy-output-cascaded.md
+++ b/.changeset/legacy-output-cascaded.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-tui": patch
+"@adobe/design-data-wasm": patch
+---
+
+Add `migrate legacy-output-cascaded` for feeding classic-schema consumers (e.g. iOS
+tokentool) from a manifest-resolved dataset (h890.10).
+
+- **sdk/cli/src/main.rs**: new `migrate legacy-output-cascaded [PATH] --output FILE`
+  applies the configured platform manifest cascade before converting to legacy
+  schema, dropping Foundation-layer records shadowed by a Platform-layer override
+  so the output is deterministic.
+- **sdk/core/src/legacy.rs**: new `convert_records` entry point converts an
+  already-cascaded in-memory array; `build_mode_entry`'s `$schema` fallback for
+  schema-less override records now matches alias-ness instead of copying an
+  unrelated sibling's schema.

--- a/.changeset/legacy-output-cascaded.md
+++ b/.changeset/legacy-output-cascaded.md
@@ -6,11 +6,14 @@
 Add `migrate legacy-output-cascaded` for feeding classic-schema consumers (e.g. iOS
 tokentool) from a manifest-resolved dataset (h890.10).
 
+- **sdk/core/src/graph.rs**: `apply_platform_manifest` overrides now replace the
+  targeted Foundation-layer record in place instead of shadowing it under a
+  synthetic key, so every graph consumer (not just this new command) sees one
+  deterministic record per token.
 - **sdk/cli/src/main.rs**: new `migrate legacy-output-cascaded [PATH] --output FILE`
   applies the configured platform manifest cascade before converting to legacy
-  schema, dropping Foundation-layer records shadowed by a Platform-layer override
-  so the output is deterministic.
+  schema.
 - **sdk/core/src/legacy.rs**: new `convert_records` entry point converts an
   already-cascaded in-memory array; `build_mode_entry`'s `$schema` fallback for
   schema-less override records now matches alias-ness instead of copying an
-  unrelated sibling's schema.
+  unrelated sibling's schema, and no longer matches the token being processed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,6 +652,12 @@ importers:
         specifier: ^3.3.3
         version: 3.7.4
 
+  tools/ios-override-importer:
+    devDependencies:
+      ava:
+        specifier: ^6.1.1
+        version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
+
   tools/markdown-generator:
     dependencies:
       '@adobe/spectrum-component-api-schemas':
@@ -3499,6 +3505,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3797,7 +3804,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -34,6 +34,7 @@ use design_data_core::graph::TokenGraph;
 use design_data_core::legacy;
 use design_data_core::manifest;
 use design_data_core::migrate;
+use design_data_core::naming;
 use design_data_core::naming::NamingExceptionsFile;
 use design_data_core::primer;
 use design_data_core::query;
@@ -178,6 +179,30 @@ enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
         format: OutputFormat,
+    },
+    /// Decompose a legacy kebab-case token slug into its structured name-object
+    /// fields (property/component/variant/state), verifying the roundtrip.
+    /// One-off exposure of `naming::parse_legacy_name`/`roundtrips` for external
+    /// importers (e.g. platform-manifest tooling) that need this without
+    /// reimplementing the algorithm.
+    DecomposeLegacyName {
+        /// Legacy slug to decompose (e.g. accent-background-color-default)
+        #[arg(value_name = "SLUG")]
+        slug: String,
+        /// Known component prefix, if any (mirrors the token's own "component" field)
+        #[arg(long, value_name = "NAME")]
+        component_hint: Option<String>,
+    },
+    /// Dump every token's computed legacy key (not deduped — one entry per
+    /// colorScheme/contrast member) as JSON. One-off exposure of
+    /// `naming::extract_legacy_key` (the same forward function that builds
+    /// `TokenGraph::legacy_name_index`) for external importers that need to
+    /// match an exact colorScheme/contrast member, which the deduped index
+    /// can't do (sdk/core/src/graph.rs:967-978).
+    DumpLegacyKeys {
+        /// Directory containing cascade-format .tokens.json files
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
     /// Compare two token datasets and report changes
     Diff {
@@ -499,6 +524,51 @@ fn load_exceptions(path: Option<&Path>) -> miette::Result<HashSet<String>> {
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load exceptions from {}", p.display()))?;
     Ok(file.token_set())
+}
+
+/// `design-data decompose-legacy-name <slug>` — prints `{property, component?,
+/// variant?, state?, roundtrips}` as JSON. `roundtrips: false` means the parse
+/// is not trustworthy (the slug doesn't reproduce from the parsed fields) and
+/// callers should treat the slug as unresolved rather than use the fields.
+fn run_decompose_legacy_name(slug: &str, component_hint: Option<&str>) -> miette::Result<ExitCode> {
+    let parsed = naming::parse_legacy_name(slug, component_hint);
+    let roundtrips = naming::roundtrips(slug, component_hint);
+    let mut body = serde_json::to_value(&parsed).into_diagnostic()?;
+    body["roundtrips"] = serde_json::Value::Bool(roundtrips);
+    println!("{}", serde_json::to_string_pretty(&body).into_diagnostic()?);
+    Ok(ExitCode::SUCCESS)
+}
+
+/// `design-data dump-legacy-keys [PATH]` — prints a JSON array of
+/// `{legacyKey, uuid, colorScheme?, contrast?}`, one entry per token (not
+/// deduped by legacyKey, unlike `TokenGraph::legacy_name_index`).
+fn run_dump_legacy_keys(path: &Path) -> miette::Result<ExitCode> {
+    let graph = TokenGraph::open_cached(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+
+    let mut out = Vec::new();
+    for rec in graph.tokens.values() {
+        let Some(name_val) = rec.raw.get("name") else {
+            continue;
+        };
+        let Some(legacy_key) = naming::extract_legacy_key(name_val) else {
+            continue;
+        };
+        let Some(uuid) = rec.uuid.clone() else {
+            continue;
+        };
+        let color_scheme = name_val.get("colorScheme").and_then(|v| v.as_str());
+        let contrast = name_val.get("contrast").and_then(|v| v.as_str());
+        out.push(serde_json::json!({
+            "legacyKey": legacy_key,
+            "uuid": uuid,
+            "colorScheme": color_scheme,
+            "contrast": contrast,
+        }));
+    }
+    println!("{}", serde_json::to_string_pretty(&out).into_diagnostic()?);
+    Ok(ExitCode::SUCCESS)
 }
 
 fn run_resolve(
@@ -1796,6 +1866,13 @@ fn main() -> ExitCode {
                 contrast,
                 format,
             )
+        }
+        Commands::DecomposeLegacyName {
+            slug,
+            component_hint,
+        } => run_decompose_legacy_name(&slug, component_hint.as_deref()),
+        Commands::DumpLegacyKeys { path } => {
+            run_dump_legacy_keys(&path.unwrap_or_else(|| PathBuf::from(".")))
         }
         Commands::Diff {
             old,

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -30,7 +30,7 @@ use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::diff;
 use design_data_core::diff::display_name;
 use design_data_core::figma;
-use design_data_core::graph::TokenGraph;
+use design_data_core::graph::{Layer, TokenGraph};
 use design_data_core::legacy;
 use design_data_core::manifest;
 use design_data_core::migrate;
@@ -427,6 +427,20 @@ enum MigrateSub {
         input: PathBuf,
         /// Destination directory for legacy JSON output files
         #[arg(long, value_name = "OUTPUT")]
+        output: PathBuf,
+    },
+    /// Convert a dataset, with its configured platform manifest cascade applied,
+    /// to a single legacy-format JSON snapshot (e.g. for tokentool
+    /// `generate-source-code --input`). Contrast-variant tokens are skipped —
+    /// `legacy::convert_array` groups sets by colorScheme/scale only, so a
+    /// contrast:high extension sharing a base token's colorScheme would
+    /// silently overwrite it (see bead spectrum-design-data-h890.17).
+    LegacyOutputCascaded {
+        /// Path to the token dataset directory (default: resolved canonical dataset)
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Destination file for the combined legacy-format JSON snapshot
+        #[arg(long, value_name = "FILE")]
         output: PathBuf,
     },
     /// Add missing outer-level UUIDs to set tokens in legacy JSON files (in-place)
@@ -898,6 +912,94 @@ fn run_migrate_legacy_output(input: &Path, output: &Path) -> miette::Result<Exit
     println!(
         "Converted {} file(s): {} tokens produced ({} sets, {} flat)",
         summary.files_written,
+        summary.tokens_produced,
+        summary.sets_reconstructed,
+        summary.flat_tokens,
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+fn run_migrate_legacy_output_cascaded(path: &Path, output: &Path) -> miette::Result<ExitCode> {
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
+
+    let (mut graph, _index) = TokenGraph::open_cached_with_index_with_catalogs(
+        path,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+
+    // Apply the configured platform manifest (filters/overrides/extensions) — same
+    // cascade `run_query`/`run_resolve` apply — so this is the same dataset a
+    // platform's `resolve`/`query` calls see, not the raw foundation.
+    manifest::apply_configured(&mut graph, &resolved)
+        .into_diagnostic()
+        .wrap_err("failed to apply platform manifest cascade")?;
+
+    // ponytail: contrast-variant records (e.g. manifest extensions adding
+    // contrast:"high") share a legacyKey+colorScheme with their regular-contrast
+    // sibling — legacy::convert_array groups sets by colorScheme/scale only, so
+    // keeping both would silently overwrite one. Skip non-default contrast until
+    // legacy.rs learns a contrast set-dimension (spectrum-design-data-h890.17).
+    let is_default_contrast = |v: &serde_json::Value| {
+        v.get("name")
+            .and_then(|n| n.as_object())
+            .is_none_or(|n| !n.contains_key("contrast"))
+    };
+    // ponytail: a manifest override inserts a NEW Platform-layer TokenRecord
+    // under a synthetic key without removing the original Foundation-layer
+    // record sharing the same uuid (apply_platform_manifest only ever adds or
+    // filters by key, never shadows by uuid). Drop the Foundation-layer
+    // duplicate here so convert_records's colorScheme/scale grouping doesn't
+    // nondeterministically pick whichever copy HashMap iteration visits last.
+    let overridden_uuids: std::collections::HashSet<&str> = graph
+        .tokens
+        .values()
+        .filter(|t| matches!(t.layer, Layer::Platform))
+        .filter_map(|t| t.uuid.as_deref())
+        .collect();
+    let mut records: Vec<serde_json::Value> = graph
+        .tokens
+        .values()
+        .filter(|t| {
+            matches!(t.layer, Layer::Platform)
+                || !t
+                    .uuid
+                    .as_deref()
+                    .is_some_and(|u| overridden_uuids.contains(u))
+        })
+        .map(|t| &t.raw)
+        .filter(|raw| is_default_contrast(raw))
+        .cloned()
+        .collect();
+    records.extend(
+        graph
+            .relationships
+            .iter()
+            .map(|r| &r.raw)
+            .filter(|raw| is_default_contrast(raw))
+            .cloned(),
+    );
+
+    let (legacy_map, summary) = legacy::convert_records(&records)
+        .into_diagnostic()
+        .wrap_err("failed to convert cascaded dataset to legacy format")?;
+
+    if let Some(parent) = output.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).into_diagnostic()?;
+        }
+    }
+    let mut out_text =
+        serde_json::to_string_pretty(&serde_json::Value::Object(legacy_map)).into_diagnostic()?;
+    out_text.push('\n');
+    std::fs::write(output, out_text).into_diagnostic()?;
+
+    println!(
+        "Wrote {}: {} tokens produced ({} sets, {} flat)",
+        output.display(),
         summary.tokens_produced,
         summary.sets_reconstructed,
         summary.flat_tokens,
@@ -1910,6 +2012,10 @@ fn main() -> ExitCode {
             } => run_migrate_convert(&input, &output, names_dir.as_deref(), exceptions.as_deref()),
             MigrateSub::LegacyOutput { input, output } => {
                 run_migrate_legacy_output(&input, &output)
+            }
+            MigrateSub::LegacyOutputCascaded { path, output } => {
+                let target = path.unwrap_or_else(|| PathBuf::from("."));
+                run_migrate_legacy_output_cascaded(&target, &output)
             }
             MigrateSub::AddUuids { dir } => run_migrate_add_uuids(&dir),
             MigrateSub::RoundtripVerify { path } => run_migrate_roundtrip_verify(&path),

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -30,7 +30,7 @@ use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::diff;
 use design_data_core::diff::display_name;
 use design_data_core::figma;
-use design_data_core::graph::{Layer, TokenGraph};
+use design_data_core::graph::TokenGraph;
 use design_data_core::legacy;
 use design_data_core::manifest;
 use design_data_core::migrate;
@@ -948,28 +948,12 @@ fn run_migrate_legacy_output_cascaded(path: &Path, output: &Path) -> miette::Res
             .and_then(|n| n.as_object())
             .is_none_or(|n| !n.contains_key("contrast"))
     };
-    // ponytail: a manifest override inserts a NEW Platform-layer TokenRecord
-    // under a synthetic key without removing the original Foundation-layer
-    // record sharing the same uuid (apply_platform_manifest only ever adds or
-    // filters by key, never shadows by uuid). Drop the Foundation-layer
-    // duplicate here so convert_records's colorScheme/scale grouping doesn't
-    // nondeterministically pick whichever copy HashMap iteration visits last.
-    let overridden_uuids: std::collections::HashSet<&str> = graph
-        .tokens
-        .values()
-        .filter(|t| matches!(t.layer, Layer::Platform))
-        .filter_map(|t| t.uuid.as_deref())
-        .collect();
+    // apply_platform_manifest replaces an overridden token's record in place
+    // (same graph key), so `graph.tokens` never holds a stale Foundation-layer
+    // duplicate here.
     let mut records: Vec<serde_json::Value> = graph
         .tokens
         .values()
-        .filter(|t| {
-            matches!(t.layer, Layer::Platform)
-                || !t
-                    .uuid
-                    .as_deref()
-                    .is_some_and(|u| overridden_uuids.contains(u))
-        })
         .map(|t| &t.raw)
         .filter(|raw| is_default_contrast(raw))
         .cloned()

--- a/sdk/cli/tests/cli_manifest.rs
+++ b/sdk/cli/tests/cli_manifest.rs
@@ -114,6 +114,35 @@ fn query_rejects_manifest_failing_schema_validation() {
 }
 
 #[test]
+fn migrate_legacy_output_cascaded_prefers_override_over_shadowed_foundation() {
+    // Regression for spectrum-design-data-h890.10: `apply_platform_manifest`
+    // inserts an override as a NEW Platform-layer TokenRecord under a
+    // synthetic key, leaving the original Foundation-layer record (same
+    // uuid) in place. `migrate legacy-output-cascaded` must emit only the
+    // override's value, deterministically — not whichever copy `HashMap`
+    // iteration visits last.
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "overrides": [{"target": "u-btn-bg", "value": "#ffffff"}]
+    }));
+    let output = project.path().join("legacy.json");
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["migrate", "legacy-output-cascaded", "tokens", "--output"])
+        .arg(&output)
+        .assert()
+        .success();
+
+    let legacy: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&output).expect("read output"))
+            .expect("parse output");
+    assert_eq!(legacy["button-background-color"]["value"], "#ffffff");
+}
+
+#[test]
 fn resolve_applies_manifest_override_by_uuid() {
     let project = setup_project(json!({
         "specVersion": "1.0.0-draft",

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -783,7 +783,7 @@ impl TokenGraph {
                     continue;
                 };
                 let matches = self.resolve_override_targets(target)?;
-                for (match_idx, (name_obj, orig_value, uuid)) in matches.into_iter().enumerate() {
+                for (shadowed_key, name_obj, orig_value, uuid) in matches {
                     let mut synthetic = serde_json::Map::new();
                     synthetic.insert("name".to_string(), name_obj);
                     if let Some(new_value) = entry.get("value") {
@@ -808,11 +808,13 @@ impl TokenGraph {
                     }
                     let raw = Value::Object(synthetic);
                     let alias_target = raw.as_object().and_then(extract_alias_target);
-                    let key = format!("platform-override:{target}:{idx}:{match_idx}");
+                    // Reuse the shadowed record's own key so the override *replaces*
+                    // the Foundation-layer entry in place, rather than shadowing it
+                    // under a synthetic key — leaving no stale duplicate behind for
+                    // callers to accidentally see (spectrum-design-data-h890.10).
+                    let key = shadowed_key;
                     if let Some(u) = &uuid {
-                        self.uuid_index
-                            .entry(u.clone())
-                            .or_insert_with(|| key.clone());
+                        self.uuid_index.insert(u.clone(), key.clone());
                     }
                     self.tokens.insert(
                         key.clone(),
@@ -912,10 +914,14 @@ impl TokenGraph {
             return Ok(query::filter(self, &filter)
                 .into_iter()
                 .filter_map(|rec| {
-                    rec.raw
-                        .get("name")
-                        .cloned()
-                        .map(|name_obj| (name_obj, rec.raw.get("value").cloned(), rec.uuid.clone()))
+                    rec.raw.get("name").cloned().map(|name_obj| {
+                        (
+                            rec.name.clone(),
+                            name_obj,
+                            rec.raw.get("value").cloned(),
+                            rec.uuid.clone(),
+                        )
+                    })
                 })
                 .collect());
         }
@@ -925,6 +931,7 @@ impl TokenGraph {
         if let Some(rec) = self.resolve_alias_key(target) {
             if let Some(name_obj) = rec.raw.get("name").cloned() {
                 return Ok(vec![(
+                    rec.name.clone(),
                     name_obj,
                     rec.raw.get("value").cloned(),
                     rec.uuid.clone(),
@@ -1153,7 +1160,8 @@ pub struct PlatformManifest {
 }
 
 /// One foundation token matched by a manifest `overrides[].target` string.
-type OverrideTargetMatch = (Value, Option<Value>, Option<String>);
+/// (shadowed source key, name object, original value, uuid).
+type OverrideTargetMatch = (String, Value, Option<Value>, Option<String>);
 
 /// The JSON "kind" of a value, used for override type-safety checks.
 fn json_kind(v: &Value) -> &'static str {

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -943,7 +943,10 @@ fn build_mode_entry(
         .or_else(|| {
             all_tokens
                 .iter()
-                .find(|t| t.contains_key("$ref") == is_alias)
+                .find(|t| {
+                    t.contains_key("$ref") == is_alias
+                        && t.get("$schema").and_then(|v| v.as_str()).is_some()
+                })
                 .and_then(|t| t.get("$schema").and_then(|v| v.as_str()))
                 .map(str::to_string)
         })
@@ -1335,6 +1338,33 @@ mod tests {
         assert_eq!(
             bg["sets"]["dark"]["$schema"],
             "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json"
+        );
+    }
+
+    /// Regression: the alias-ness sibling search must not match `tok` itself.
+    /// `tok` (the override being processed) has no `$schema` by construction —
+    /// if the search's `find` predicate matches `tok` before reaching a real
+    /// schema-bearing sibling, `and_then` short-circuits to `None` and the
+    /// whole `or_else` chain falls through to the hardcoded fallback, silently
+    /// discarding a perfectly good sibling schema later in iteration order.
+    #[test]
+    fn convert_records_schema_fallback_skips_self_to_find_real_sibling_schema() {
+        let arr = json!([
+            {"name": {"property": "seafoam-bg", "colorScheme": "light"},
+             "$schema": ".../alias.json", "$ref": "seafoam-900", "uuid": "bg-light"},
+            {"name": {"property": "seafoam-bg", "colorScheme": "dark"},
+             "value": "rgba(9,144,120,1.0)", "uuid": "bg-dark"},
+            {"name": {"property": "seafoam-bg", "colorScheme": "dim"},
+             "value": "rgba(3,80,66,1.0)", "uuid": "bg-dim",
+             "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/custom-marker.json"},
+        ]);
+        let records: Vec<Value> = arr.as_array().unwrap().clone();
+        let (out, _summary) = convert_records(&records).unwrap();
+
+        let bg = &out["seafoam-bg"];
+        assert_eq!(
+            bg["sets"]["dark"]["$schema"],
+            "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/custom-marker.json"
         );
     }
 

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -55,6 +55,12 @@ const COLOR_SET_SCHEMA: &str =
     "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json";
 const SCALE_SET_SCHEMA: &str =
     "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json";
+const COLOR_SCHEMA: &str =
+    "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json";
+const DIMENSION_SCHEMA: &str =
+    "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json";
+const ALIAS_SCHEMA: &str =
+    "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json";
 
 /// Fields that belong on the outer token entry (hoisted from mode entries when
 /// they are identical across all modes).
@@ -111,34 +117,7 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<LegacySummary,
         let text = std::fs::read_to_string(&input_path)?;
         let value: Value = serde_json::from_str(&text)?;
         if let Some(arr) = value.as_array() {
-            for item in arr {
-                if let Some(obj) = item.as_object() {
-                    // Component/Token Relationships (CTRs) have no `name` field —
-                    // adapt them into a synthetic cascade token first so the same
-                    // name-extraction logic below applies to both.
-                    let adapted = if !obj.contains_key("name") && obj.contains_key("scope") {
-                        ctr_to_legacy_token(obj)
-                    } else {
-                        None
-                    };
-                    let tok = adapted.as_ref().unwrap_or(obj);
-
-                    // Use extract_legacy_key so string-name (escape-hatch) tokens
-                    // are indexed correctly alongside object-name tokens.
-                    let name = tok.get("name").and_then(extract_legacy_key);
-                    if let Some(ref name) = name {
-                        // Index the per-mode uuid.
-                        if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
-                            global_uuid_to_name.insert(uuid.to_string(), name.clone());
-                        }
-                        // Also index set_uuid so replaced_by pointing at a set token's
-                        // outer UUID resolves correctly to renamed.
-                        if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
-                            global_uuid_to_name.insert(set_uuid.to_string(), name.clone());
-                        }
-                    }
-                }
-            }
+            global_uuid_to_name.extend(index_uuid_names(arr));
         }
         all_files.push((input_path, value));
     }
@@ -173,6 +152,55 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<LegacySummary,
     }
 
     Ok(summary)
+}
+
+/// Convert a single in-memory cascade array — e.g. a `TokenGraph` with a
+/// platform manifest cascade already applied — into one combined legacy
+/// token map, keyed by legacy slug.
+///
+/// Unlike [`convert_dir`], this takes the array directly instead of reading
+/// `.tokens.json` files from disk, and produces one map rather than one file
+/// per input file — the shape a single published "resolved snapshot" needs
+/// (e.g. tokentool's `generate-source-code --input`). The UUID → name index
+/// used for `$ref`/`replaced_by` resolution is built from `arr` itself.
+pub fn convert_records(arr: &[Value]) -> Result<(Map<String, Value>, LegacySummary), CoreError> {
+    let global_uuid_to_name = index_uuid_names(arr);
+    let mut summary = LegacySummary::default();
+    let legacy = convert_array(arr, &mut summary, &global_uuid_to_name)?;
+    summary.files_processed = 1;
+    summary.files_written = 1;
+    Ok((legacy, summary))
+}
+
+/// Build the UUID/set_uuid → legacy-name index used to resolve `$ref` and
+/// `replaced_by` targets, over every named token or CTR in `arr`.
+///
+/// Shared by [`convert_dir`]'s cross-file pass-1 (accumulated across files)
+/// and [`convert_records`] (a single already-combined array).
+fn index_uuid_names(arr: &[Value]) -> HashMap<String, String> {
+    let mut global_uuid_to_name = HashMap::new();
+    for item in arr {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        let adapted = if !obj.contains_key("name") && obj.contains_key("scope") {
+            ctr_to_legacy_token(obj)
+        } else {
+            None
+        };
+        let tok = adapted.as_ref().unwrap_or(obj);
+
+        let name = tok.get("name").and_then(extract_legacy_key);
+        if let Some(name) = name {
+            if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                global_uuid_to_name.insert(uuid.to_string(), name.clone());
+            }
+            if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
+                global_uuid_to_name.insert(set_uuid.to_string(), name.clone());
+            }
+        }
+    }
+    global_uuid_to_name
 }
 
 /// Convert a single cascade token to a legacy entry value.
@@ -878,7 +906,7 @@ fn build_set_entry(
         let Some(mode) = name_obj.get(dim_key).and_then(|v| v.as_str()) else {
             continue;
         };
-        let entry = build_mode_entry(tok, tokens, uuid_to_name);
+        let entry = build_mode_entry(tok, tokens, dim_key, uuid_to_name);
         sets.insert(mode.to_string(), Value::Object(entry));
     }
     outer.insert("sets".into(), Value::Object(sets));
@@ -892,11 +920,43 @@ fn build_set_entry(
 fn build_mode_entry(
     tok: &Map<String, Value>,
     all_tokens: &[&Map<String, Value>],
+    dim_key: &str,
     uuid_to_name: &HashMap<String, String>,
 ) -> Map<String, Value> {
     let mut entry = Map::new();
 
-    if let Some(schema) = tok.get("$schema").and_then(|v| v.as_str()) {
+    // Fall back when this token's own $schema is absent — a manifest
+    // `overrides[]` entry synthesizes its Platform-layer token with just
+    // `{name, value, uuid}` (schema_url: None, see graph.rs
+    // apply_platform_manifest). Prefer a sibling with the same alias-ness
+    // (has `$ref` or not) as `tok`, since JSONContainerType dispatches purely
+    // off `$schema` — copying an alias sibling's `alias.json` onto a mode an
+    // override replaced with a literal value would mislabel it and make
+    // tokentool expect `{ref}` syntax. If no such sibling exists (e.g. every
+    // other mode is an alias), derive the base value-type schema from the
+    // set kind instead of guessing from an alias-shaped sibling.
+    let is_alias = tok.contains_key("$ref");
+    let schema = tok
+        .get("$schema")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            all_tokens
+                .iter()
+                .find(|t| t.contains_key("$ref") == is_alias)
+                .and_then(|t| t.get("$schema").and_then(|v| v.as_str()))
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            Some(if is_alias {
+                ALIAS_SCHEMA.to_string()
+            } else if dim_key == "colorScheme" {
+                COLOR_SCHEMA.to_string()
+            } else {
+                DIMENSION_SCHEMA.to_string()
+            })
+        });
+    if let Some(schema) = schema {
         entry.insert("$schema".into(), Value::String(schema.to_string()));
     }
 
@@ -1246,6 +1306,36 @@ mod tests {
         assert_eq!(entry["sets"]["light"]["value"], "{blue-900}");
         assert_eq!(entry["sets"]["dark"]["value"], "{blue-300}");
         assert!(entry["sets"]["light"].get("$ref").is_none());
+    }
+
+    /// Regression for h890.10: a manifest override synthesizes its Platform-layer
+    /// token with `{name, value, uuid}` only (no `$schema`, see graph.rs
+    /// `apply_platform_manifest`). When every OTHER mode in the set is an alias
+    /// (so no non-alias sibling schema is available to borrow), `build_mode_entry`
+    /// must derive a literal value-type schema from the set kind (`color.json` for
+    /// a colorScheme set) rather than leaking the alias sibling's `alias.json` —
+    /// JSONContainerType (tokentool's classic-schema parser) dispatches purely off
+    /// `$schema`, so mislabeling a literal as `.alias` breaks parsing downstream.
+    #[test]
+    fn convert_records_schema_fallback_prefers_alias_ness_match() {
+        let arr = json!([
+            // "light" is a genuine alias; "dark" is an override with no $schema
+            // of its own and no non-alias sibling to borrow from.
+            {"name": {"property": "seafoam-bg", "colorScheme": "light"},
+             "$schema": ".../alias.json", "$ref": "seafoam-900", "uuid": "bg-light"},
+            {"name": {"property": "seafoam-bg", "colorScheme": "dark"},
+             "value": "rgba(9,144,120,1.0)", "uuid": "bg-dark"},
+        ]);
+        let records: Vec<Value> = arr.as_array().unwrap().clone();
+        let (out, _summary) = convert_records(&records).unwrap();
+
+        let bg = &out["seafoam-bg"];
+        assert_eq!(bg["sets"]["light"]["value"], "{seafoam-900}");
+        assert_eq!(bg["sets"]["dark"]["value"], "rgba(9,144,120,1.0)");
+        assert_eq!(
+            bg["sets"]["dark"]["$schema"],
+            "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json"
+        );
     }
 
     /// Regression for P1: multi-mode-set cascade tokens MUST error, not silently

--- a/tools/ios-override-importer/ava.config.js
+++ b/tools/ios-override-importer/ava.config.js
@@ -1,0 +1,16 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+export default {
+  files: ["test/**/*.test.js"],
+  verbose: true,
+  environmentVariables: {
+    NODE_ENV: "test",
+  },
+};

--- a/tools/ios-override-importer/moon.yml
+++ b/tools/ios-override-importer/moon.yml
@@ -1,0 +1,20 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+$schema: "https://moonrepo.dev/schemas/project.json"
+layer: tool
+tasks:
+  import:
+    command:
+      - node
+      - src/cli.js
+  test:
+    command:
+      - pnpm
+      - ava

--- a/tools/ios-override-importer/package.json
+++ b/tools/ios-override-importer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ios-override-importer",
+  "version": "0.0.1",
+  "description": "One-time importer converting Spectrum iOS's override-log.csv into a Platform Manifest (manifest.json)",
+  "type": "module",
+  "private": true,
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-design-data.git"
+  },
+  "author": "Garth Braithwaite <garthdb@gmail.com> (http://garthdb.com/)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
+  },
+  "homepage": "https://github.com/adobe/spectrum-design-data#readme",
+  "dependencies": {},
+  "devDependencies": {
+    "ava": "^6.1.1"
+  }
+}

--- a/tools/ios-override-importer/package.json
+++ b/tools/ios-override-importer/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": "20.17.0"
+    "node": ">=20.12.0"
   },
   "packageManager": "pnpm@10.17.1",
   "scripts": {},

--- a/tools/ios-override-importer/package.json
+++ b/tools/ios-override-importer/package.json
@@ -4,6 +4,10 @@
   "description": "One-time importer converting Spectrum iOS's override-log.csv into a Platform Manifest (manifest.json)",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": "20.17.0"
+  },
+  "packageManager": "pnpm@10.17.1",
   "scripts": {},
   "repository": {
     "type": "git",

--- a/tools/ios-override-importer/src/categorize.js
+++ b/tools/ios-override-importer/src/categorize.js
@@ -1,0 +1,89 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { isColorSet, parseColorSet } from "./parse-colorset.js";
+
+/**
+ * Bucket one override-log.csv row per the FINDINGS.md categorization
+ * (net-new / true-value-change / contrast-addition / out-of-scope, for
+ * reporting/stats), AND split its changed modes by whether each one needs
+ * an `overrides[]` entry or an `extensions.tokens[]` entry.
+ *
+ * A single row can need both: e.g. a row that replaces its light/dark base
+ * value (→ override, the foundation record exists) while also adding a new
+ * lightIncreased/darkIncreased contrast:high slot (→ extension token, no
+ * foundation record exists there yet). Splitting per-mode by "did old have a
+ * value at this exact (colorScheme, contrast) coordinate" is what makes that
+ * correct — a row-level category label alone can't express it.
+ *
+ * Returns `{ category, overrideModes, extensionModes, skipped }`:
+ * - `overrideModes` — modes present in New Value AND in Old Value, with a
+ *   different value (the foundation token already exists at this mode).
+ * - `extensionModes` — modes present in New Value but absent (or "none") in
+ *   Old Value (nothing exists at this mode yet).
+ * `skipped` lists any unmapped ColorSet slots (e.g. "elevated") from New Value.
+ */
+export function categorizeRow(row) {
+  const oldValue = row["Old Value"];
+  const newValue = row["New Value"];
+
+  if (!isColorSet(newValue)) {
+    return {
+      category: "out-of-scope",
+      overrideModes: [],
+      extensionModes: [],
+      skipped: [],
+    };
+  }
+
+  const { modes: newModes, skipped } = parseColorSet(newValue);
+
+  if (oldValue === "Custom token" || !isColorSet(oldValue)) {
+    // Either genuinely new, or the old value isn't recognizable as a color —
+    // treat as net-new rather than guessing at a "change". Every slot is new.
+    return {
+      category: "net-new",
+      overrideModes: [],
+      extensionModes: newModes,
+      skipped,
+    };
+  }
+
+  const { modes: oldModes } = parseColorSet(oldValue);
+  const overrideModes = [];
+  const extensionModes = [];
+  for (const m of newModes) {
+    const old = valueFor(oldModes, m.colorScheme, m.contrast);
+    if (old === undefined) {
+      extensionModes.push(m);
+    } else if (old !== m.value) {
+      overrideModes.push(m);
+    }
+    // old === m.value: unchanged, nothing to emit.
+  }
+  const baseChanged = ["light", "dark"].some(
+    (scheme) =>
+      valueFor(oldModes, scheme, undefined) !==
+      valueFor(newModes, scheme, undefined),
+  );
+
+  return {
+    category: baseChanged ? "true-value-change" : "contrast-addition",
+    overrideModes,
+    extensionModes,
+    skipped,
+  };
+}
+
+function valueFor(modes, colorScheme, contrast) {
+  return modes.find(
+    (m) => m.colorScheme === colorScheme && m.contrast === contrast,
+  )?.value;
+}

--- a/tools/ios-override-importer/src/cli.js
+++ b/tools/ios-override-importer/src/cli.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { parseCsv } from "./parse-csv.js";
+import { emitManifest } from "./emit-manifest.js";
+import { buildGapsReport } from "./gaps-report.js";
+
+// Carried over from the existing hand-authored POC manifest
+// (GarthDB/spectrum-ios-design-data/manifest.json) — the importer only adds
+// overrides/extensions, it doesn't decide scope filtering.
+const DEFAULT_INCLUDE = [
+  "property=color",
+  "property=size",
+  "property=line-height",
+  "property=font-weight",
+  "property=font-family",
+  "property=text-align",
+  "property=corner-radius",
+  "property=border-width",
+  "property=opacity",
+  "property=background-color",
+];
+const DEFAULT_EXCLUDE = ["colorScheme=wireframe"];
+
+function parseArgs(argv) {
+  const args = { gaps: "gaps.md", foundation: "@adobe/spectrum-tokens@15.0.0" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--csv") args.csv = argv[++i];
+    else if (flag === "--out") args.out = argv[++i];
+    else if (flag === "--foundation") args.foundation = argv[++i];
+    else if (flag === "--gaps") args.gaps = argv[++i];
+    else throw new Error(`unknown flag: ${flag}`);
+  }
+  if (!args.csv || !args.out) {
+    throw new Error(
+      "usage: cli.js --csv <override-log.csv> --out <manifest.json> [--foundation <pkg@version>] [--gaps <gaps.md>]",
+    );
+  }
+  return args;
+}
+
+export function run(argv) {
+  const args = parseArgs(argv);
+  const rows = parseCsv(readFileSync(args.csv, "utf8"));
+  const { overrides, extensionTokens, unresolved } = emitManifest(rows);
+
+  // Preserve an existing manifest's include/exclude if one is already at
+  // --out (re-running the importer shouldn't clobber hand-tuned scope
+  // filters), otherwise fall back to the POC's known-good defaults.
+  const existing = existsSync(args.out)
+    ? JSON.parse(readFileSync(args.out, "utf8"))
+    : {};
+
+  const manifest = {
+    specVersion: "1.0.0-draft",
+    foundationVersion: args.foundation,
+    include: existing.include ?? DEFAULT_INCLUDE,
+    exclude: existing.exclude ?? DEFAULT_EXCLUDE,
+    overrides,
+    extensions: {
+      tokens: extensionTokens,
+      formatting: { casing: "camelCase" },
+    },
+  };
+
+  writeFileSync(args.out, `${JSON.stringify(manifest, null, 2)}\n`);
+  writeFileSync(args.gaps, buildGapsReport(unresolved));
+
+  console.log(
+    `wrote ${args.out} (${overrides.length} overrides, ${extensionTokens.length} extension tokens) ` +
+      `and ${args.gaps} (${unresolved.length} unresolved rows)`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run(process.argv.slice(2));
+}

--- a/tools/ios-override-importer/src/emit-manifest.js
+++ b/tools/ios-override-importer/src/emit-manifest.js
@@ -1,0 +1,113 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { categorizeRow } from "./categorize.js";
+import { resolveTarget } from "./resolve-target.js";
+import { findTokenUuid, loadLegacyKeyIndex } from "./find-token-uuid.js";
+
+const COLOR_SCHEMA =
+  "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json";
+
+/**
+ * Turn one categorized+resolved row into manifest fragments, per MODE rather
+ * than per row's overall category — a single row can need both kinds of
+ * fragment at once (e.g. its light base value changed AND it grew a new
+ * light/contrast:high slot that didn't exist before). See categorizeRow's
+ * doc for why the split happens there.
+ *
+ * - `overrideModes` → one `overrides[]` entry per mode, targeted by the
+ *   existing foundation token's **uuid**, looked up via its computed legacy
+ *   key (see find-token-uuid.js for why: uuid is the only unambiguous
+ *   target, and legacy-key string matching is the only reliable lookup).
+ *   A mode whose uuid can't be found is dropped into `unresolved` for the
+ *   gap report rather than emitted with a broken target.
+ * - `extensionModes` → one `extensions.tokens[]` entry per mode, reusing the
+ *   resolved name fields (mirrors the color-set member shape — same
+ *   identity, different colorScheme/contrast). These are new records, so no
+ *   existence check is needed.
+ * - `out-of-scope` (typography/size) → no manifest fragment.
+ *
+ * Rows whose target doesn't resolve at all (own name nor any Aliases entry)
+ * produce no fragment either — the caller logs `row` into the gap report
+ * instead of fabricating a name.
+ */
+export function emitRow(row, options) {
+  const { category, overrideModes, extensionModes } = categorizeRow(row);
+  if (category === "out-of-scope") {
+    return { overrides: [], extensionTokens: [] };
+  }
+
+  const target = resolveTarget(row, options);
+  if (!target.slug) {
+    return {
+      overrides: [],
+      extensionTokens: [],
+      unresolved: target.candidates,
+    };
+  }
+
+  const overrides = [];
+  const unresolved = [];
+  if (overrideModes.length) {
+    const legacyKeyIndex = options?.legacyKeyIndex ?? loadLegacyKeyIndex();
+    for (const m of overrideModes) {
+      const uuid = findTokenUuid(legacyKeyIndex, target.slug, m);
+      if (uuid) {
+        overrides.push({ target: uuid, value: m.value });
+      } else {
+        unresolved.push(
+          `${target.slug} (${m.colorScheme}${m.contrast ? `/${m.contrast}` : ""})`,
+        );
+      }
+    }
+  }
+
+  const extensionTokens = extensionModes.map((m) => ({
+    name: {
+      ...target.name,
+      colorScheme: m.colorScheme,
+      ...(m.contrast ? { contrast: m.contrast } : {}),
+    },
+    $schema: COLOR_SCHEMA,
+    value: m.value,
+  }));
+
+  return {
+    overrides,
+    extensionTokens,
+    ...(unresolved.length ? { unresolved } : {}),
+  };
+}
+
+/**
+ * Run `emitRow` over every row, merging into one manifest's `overrides`/
+ * `extensions.tokens`, sorted for deterministic output (the SDK reads with
+ * `serde_json` `preserve_order`, so insertion order is what ships).
+ */
+export function emitManifest(rows, options) {
+  const overrides = [];
+  const extensionTokens = [];
+  const unresolved = [];
+
+  for (const row of rows) {
+    const result = emitRow(row, options);
+    overrides.push(...result.overrides);
+    extensionTokens.push(...result.extensionTokens);
+    if (result.unresolved)
+      unresolved.push({ row, candidates: result.unresolved });
+  }
+
+  overrides.sort((a, b) => a.target.localeCompare(b.target));
+  extensionTokens.sort((a, b) =>
+    JSON.stringify(a.name).localeCompare(JSON.stringify(b.name)),
+  );
+
+  return { overrides, extensionTokens, unresolved };
+}

--- a/tools/ios-override-importer/src/emit-manifest.js
+++ b/tools/ios-override-importer/src/emit-manifest.js
@@ -96,8 +96,15 @@ export function emitManifest(rows, options) {
   const extensionTokens = [];
   const unresolved = [];
 
+  // Load once for the whole run — emitRow shells out to the CLI binary and
+  // dumps the entire corpus, which is too expensive to repeat per row.
+  const withIndex = {
+    ...options,
+    legacyKeyIndex: options?.legacyKeyIndex ?? loadLegacyKeyIndex(),
+  };
+
   for (const row of rows) {
-    const result = emitRow(row, options);
+    const result = emitRow(row, withIndex);
     overrides.push(...result.overrides);
     extensionTokens.push(...result.extensionTokens);
     if (result.unresolved)

--- a/tools/ios-override-importer/src/find-token-uuid.js
+++ b/tools/ios-override-importer/src/find-token-uuid.js
@@ -9,6 +9,7 @@
 // governing permissions and limitations under the License.
 
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
@@ -33,6 +34,11 @@ const CLI_BIN = `${REPO_ROOT}sdk/target/debug/design-data`;
 // that entirely — it's the exact same string the CSV/Aliases column already
 // contains.
 export function loadLegacyKeyIndex(tokensDir = TOKENS_DIR, binPath = CLI_BIN) {
+  if (!existsSync(binPath)) {
+    throw new Error(
+      `design-data CLI binary not found at ${binPath} — run \`moon run sdk:build\` first.`,
+    );
+  }
   const out = execFileSync(binPath, ["dump-legacy-keys", tokensDir], {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,

--- a/tools/ios-override-importer/src/find-token-uuid.js
+++ b/tools/ios-override-importer/src/find-token-uuid.js
@@ -1,0 +1,58 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+const TOKENS_DIR = `${REPO_ROOT}packages/design-data/tokens`;
+const CLI_BIN = `${REPO_ROOT}sdk/target/debug/design-data`;
+
+// ponytail: a true-value-change override must target one specific colorScheme
+// member of a color-set group, and the manifest's bare-slug/query-target
+// resolution can't do that — `query::ALLOWED_KEYS` (sdk/core/src/query.rs)
+// doesn't include colorFamily/scaleIndex, and the legacy-name index collapses
+// all colorScheme members of a group to one arbitrary uuid (graph.rs:967-978).
+// A uuid target resolves to exactly one record, so we look the real uuid up
+// directly from the foundation corpus instead.
+//
+// Matching by structurally-decomposed name fields (parse_legacy_name) was
+// tried first and under-resolved badly: that reverse decomposition is coarser
+// than the full taxonomy some real tokens use (colorRole/object/etc.), so a
+// self-consistent-but-wrong decomposition can pass `roundtrips=true` and
+// still not match the real record's fields. Matching directly on the
+// FORWARD-computed `legacyKey` string (`naming::extract_legacy_key`, via the
+// `dump-legacy-keys` CLI command) against the CSV-resolved slug sidesteps
+// that entirely — it's the exact same string the CSV/Aliases column already
+// contains.
+export function loadLegacyKeyIndex(tokensDir = TOKENS_DIR, binPath = CLI_BIN) {
+  const out = execFileSync(binPath, ["dump-legacy-keys", tokensDir], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const index = new Map();
+  for (const e of JSON.parse(out)) {
+    index.set(indexKey(e.legacyKey, e.colorScheme, e.contrast), e.uuid);
+  }
+  return index;
+}
+
+function indexKey(legacyKey, colorScheme, contrast) {
+  return `${legacyKey}::${colorScheme ?? ""}::${contrast ?? ""}`;
+}
+
+/**
+ * Look up the uuid of the foundation token whose computed legacy key is
+ * `slug`, at the given `{colorScheme, contrast?}` mode. Returns null if no
+ * match exists — callers should treat that as unresolved, not guess.
+ */
+export function findTokenUuid(index, slug, mode) {
+  return index.get(indexKey(slug, mode.colorScheme, mode.contrast)) ?? null;
+}

--- a/tools/ios-override-importer/src/gaps-report.js
+++ b/tools/ios-override-importer/src/gaps-report.js
@@ -1,0 +1,56 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+// Known iOS-vocabulary gaps that no amount of alias-chain resolution can close
+// — foundation/registry-level decisions, tracked for docs/proposals/006 per
+// the plan. Static, not derived from the CSV.
+const KNOWN_GAPS = [
+  "`elevated`/`elevatedIncreased` ColorSet slots: no foundation colorScheme " +
+    "or contrast mode maps to iOS's elevated surface concept (10 CSV rows skipped).",
+  '`lightIncreased`/`darkIncreased` naming maps to `contrast:"high"` — modeled ' +
+    "here, but the increased→high crosswalk isn't registered anywhere else.",
+  "`pressed`/`down` state terms are advisory-only (state isn't hard-enforced by " +
+    "registry.rs) — they pass through untouched, not a resolved equivalence.",
+  "Typography/size rows (`Scale(FontSize(...))`, 155 rows) are out of scope for " +
+    "this importer; see the follow-up bead for font-size/letter-spacing import.",
+];
+
+/**
+ * Render `emitManifest`'s `unresolved` array (rows/modes with no clean
+ * foundation equivalent) plus the known static vocabulary gaps as markdown.
+ */
+export function buildGapsReport(unresolved) {
+  const lines = [
+    "# iOS Override Import — Gap Report",
+    "",
+    "## Known vocabulary gaps",
+    "",
+    ...KNOWN_GAPS.map((g) => `- ${g}`),
+    "",
+    `## Unresolved rows (${unresolved.length})`,
+    "",
+    "Rows whose target slug (or a specific colorScheme/contrast mode within it) " +
+      "has no foundation-token equivalent, so no manifest fragment was emitted.",
+    "",
+  ];
+
+  for (const { row, candidates } of unresolved) {
+    lines.push(
+      `### ${row["Token Name"]}`,
+      "",
+      `- Candidates tried: ${candidates.join(", ")}`,
+    );
+    if (row["Override Source"])
+      lines.push(`- Source: ${row["Override Source"]}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/tools/ios-override-importer/src/parse-colorset.js
+++ b/tools/ios-override-importer/src/parse-colorset.js
@@ -1,0 +1,65 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+// Swift `ColorSet(light: Color(r, g, b, a), dark: none, ...)` slot -> foundation
+// mode-set coordinate. `elevated`/`elevatedIncreased` are intentionally absent:
+// no `elevated` colorScheme mode exists in the foundation today (only 10 of 742
+// rows use it) — see the gap report instead of guessing a mapping.
+const SLOT_TO_MODES = {
+  light: { colorScheme: "light" },
+  dark: { colorScheme: "dark" },
+  lightIncreased: { colorScheme: "light", contrast: "high" },
+  darkIncreased: { colorScheme: "dark", contrast: "high" },
+};
+
+const COLOR_SET_RE = /^ColorSet\((.*)\)$/s;
+const SLOT_RE = /(\w+):\s*(none|Color\([^)]*\))/g;
+
+/** True if `value` is a Swift `ColorSet(...)` literal (vs. "Custom token", FontSize, etc). */
+export function isColorSet(value) {
+  return COLOR_SET_RE.test(value.trim());
+}
+
+/**
+ * Parse `ColorSet(light: Color(59, 99, 251, 1.0), dark: none, ...)` into
+ * `[{ colorScheme, contrast?, value: "rgba(59, 99, 251, 1.0)" }, ...]`,
+ * one entry per non-"none" slot that has a known mode mapping (see
+ * SLOT_TO_MODES). Unmapped slots (elevated, elevatedIncreased) are returned
+ * separately as `skipped` so callers can log them without guessing.
+ */
+export function parseColorSet(value) {
+  const body = COLOR_SET_RE.exec(value.trim())?.[1];
+  if (body === undefined) {
+    throw new Error(`not a ColorSet literal: ${value}`);
+  }
+  const modes = [];
+  const skipped = [];
+  for (const [, slot, raw] of body.matchAll(SLOT_RE)) {
+    if (raw === "none") continue;
+    const mapping = SLOT_TO_MODES[slot];
+    if (!mapping) {
+      skipped.push(slot);
+      continue;
+    }
+    modes.push({ ...mapping, value: colorToRgba(raw) });
+  }
+  return { modes, skipped };
+}
+
+const COLOR_RE = /^Color\(([^)]*)\)$/;
+
+function colorToRgba(literal) {
+  const args = COLOR_RE.exec(literal)?.[1];
+  if (args === undefined) {
+    throw new Error(`not a Color literal: ${literal}`);
+  }
+  const [r, g, b, a] = args.split(",").map((s) => s.trim());
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}

--- a/tools/ios-override-importer/src/parse-csv.js
+++ b/tools/ios-override-importer/src/parse-csv.js
@@ -1,0 +1,49 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Minimal quote-aware CSV parser for override-log.csv. Values contain commas
+ * inside quoted fields (e.g. "ColorSet(light: Color(59, 99, 251, 1.0), ...)"),
+ * so a naive `split(',')` corrupts every row. ponytail: hand-rolled instead of
+ * a dependency — this file's shape (quoted fields, no embedded newlines, no
+ * escaped quotes) is small enough that a real CSV parser would be overkill.
+ */
+export function parseCsv(text) {
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  const [header, ...rows] = lines.map(parseLine);
+  return rows.map((fields) =>
+    Object.fromEntries(header.map((key, i) => [key, fields[i] ?? ""])),
+  );
+}
+
+function parseLine(line) {
+  const fields = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const c = line[i];
+    if (inQuotes) {
+      if (c === '"') {
+        inQuotes = false;
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      fields.push(field);
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  fields.push(field);
+  return fields;
+}

--- a/tools/ios-override-importer/src/resolve-target.js
+++ b/tools/ios-override-importer/src/resolve-target.js
@@ -1,0 +1,94 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+
+// Color-palette slugs (`blue-1000`, `static-blue-1000`) aren't decomposable by
+// the Rust CLI's `decompose-legacy-name` (naming::parse_legacy_name only knows
+// variant/component/property/state, not the colorFamily+scaleIndex path — see
+// sdk/core/src/naming.rs module doc). Recognize them directly instead of
+// guessing: any slug ending in `-<digits>` whose prefix is a known color family.
+function loadColorFamilies() {
+  const path = `${REPO_ROOT}packages/design-data/registry/color-families.json`;
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  return new Set(data.values.map((v) => v.id));
+}
+
+const PALETTE_RE = /^(.+)-(\d+)$/;
+
+/** `{colorFamily, scaleIndex}` if `slug` is a recognized palette slug, else null. */
+export function matchPaletteSlug(slug, colorFamilies) {
+  const m = PALETTE_RE.exec(slug);
+  if (!m) return null;
+  const [, family, index] = m;
+  if (!colorFamilies.has(family)) return null;
+  return { colorFamily: family, scaleIndex: Number(index) };
+}
+
+/**
+ * Default oracle: shells out to `design-data decompose-legacy-name` (added to
+ * sdk/cli for this importer — reuses naming::parse_legacy_name/roundtrips
+ * rather than reimplementing legacy-slug decomposition in JS). Returns the
+ * parsed NameObject, or null if the slug doesn't roundtrip (untrustworthy).
+ */
+export function decomposeViaCli(
+  slug,
+  binPath = `${REPO_ROOT}sdk/target/debug/design-data`,
+) {
+  const out = execFileSync(binPath, ["decompose-legacy-name", slug], {
+    encoding: "utf8",
+  });
+  const parsed = JSON.parse(out);
+  if (!parsed.roundtrips) return null;
+  delete parsed.roundtrips;
+  return parsed;
+}
+
+/**
+ * Resolve one CSV row's target slug to foundation name fields, trying the
+ * token's own name first, then each entry in its `Aliases` chain in order.
+ * `decompose` is injectable (tests use a fake; the CLI is the real default)
+ * per the plan's ladder: palette slugs resolve locally, everything else
+ * defers to the Rust decomposition the SDK already has.
+ *
+ * Returns `{ slug, name }` for the first candidate that resolves, or
+ * `{ slug: null, candidates }` if none did (destined for the gap report).
+ */
+export function resolveTarget(
+  row,
+  { decompose = decomposeViaCli, colorFamilies } = {},
+) {
+  const families = colorFamilies ?? loadColorFamilies();
+  const candidates = [row["Token Name"], ...splitAliases(row.Aliases)].filter(
+    Boolean,
+  );
+
+  for (const slug of candidates) {
+    const palette = matchPaletteSlug(slug, families);
+    if (palette) return { slug, name: palette };
+
+    const decomposed = decompose(slug);
+    if (decomposed) return { slug, name: decomposed };
+  }
+
+  return { slug: null, candidates };
+}
+
+function splitAliases(aliases) {
+  if (!aliases) return [];
+  return aliases
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/tools/ios-override-importer/test/categorize.test.js
+++ b/tools/ios-override-importer/test/categorize.test.js
@@ -1,0 +1,72 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { categorizeRow } from "../src/categorize.js";
+
+test("net-new: Old Value is 'Custom token'", (t) => {
+  const { category, extensionModes, overrideModes } = categorizeRow({
+    "Old Value": "Custom token",
+    "New Value": "ColorSet(light: Color(1, 1, 1, 1.0), dark: none)",
+  });
+  t.is(category, "net-new");
+  t.is(extensionModes.length, 1);
+  t.deepEqual(overrideModes, []);
+});
+
+test("contrast-addition: base light/dark unchanged, increased slots added", (t) => {
+  const { category, extensionModes, overrideModes } = categorizeRow({
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+    "New Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: Color(3, 3, 3, 1.0), darkIncreased: none, elevatedIncreased: none)",
+  });
+  t.is(category, "contrast-addition");
+  t.deepEqual(overrideModes, []);
+  t.is(extensionModes.length, 1);
+  t.is(extensionModes[0].contrast, "high");
+});
+
+test("true-value-change: base light value replaced", (t) => {
+  const { category, overrideModes, extensionModes } = categorizeRow({
+    "Old Value": "ColorSet(light: Color(1, 1, 1, 1.0), dark: none)",
+    "New Value": "ColorSet(light: Color(9, 9, 9, 1.0), dark: none)",
+  });
+  t.is(category, "true-value-change");
+  t.deepEqual(overrideModes, [
+    { colorScheme: "light", value: "rgba(9, 9, 9, 1.0)" },
+  ]);
+  t.deepEqual(extensionModes, []);
+});
+
+test("true-value-change row can also add a genuinely new contrast mode", (t) => {
+  const { overrideModes, extensionModes } = categorizeRow({
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+    "New Value":
+      "ColorSet(light: Color(9, 9, 9, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: Color(3, 3, 3, 1.0), darkIncreased: none, elevatedIncreased: none)",
+  });
+  // light base value changed (override) AND a new light/high slot appeared
+  // (extension) — one row, both fragment types.
+  t.deepEqual(overrideModes, [
+    { colorScheme: "light", value: "rgba(9, 9, 9, 1.0)" },
+  ]);
+  t.deepEqual(extensionModes, [
+    { colorScheme: "light", contrast: "high", value: "rgba(3, 3, 3, 1.0)" },
+  ]);
+});
+
+test("out-of-scope: New Value isn't a ColorSet (typography/size row)", (t) => {
+  const { category } = categorizeRow({
+    "Old Value": "Scale(FontSize(17.0))",
+    "New Value": "FontSize(14.0)",
+  });
+  t.is(category, "out-of-scope");
+});

--- a/tools/ios-override-importer/test/cli.test.js
+++ b/tools/ios-override-importer/test/cli.test.js
@@ -1,0 +1,46 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run } from "../src/cli.js";
+
+// Out-of-scope (typography) rows only, so emitManifest never touches the
+// Rust CLI oracle or the foundation-token corpus — this test is a
+// dependency-free smoke check of arg parsing + file writing, not the
+// resolution pipeline (covered by emit-manifest.test.js).
+test("writes a manifest and gap report from a CSV", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "ios-importer-cli-"));
+  const csvPath = join(dir, "override-log.csv");
+  const outPath = join(dir, "manifest.json");
+  const gapsPath = join(dir, "gaps.md");
+
+  writeFileSync(
+    csvPath,
+    "Token Name,Old Value,New Value,Aliases,Override Source\n" +
+      'font-size-100,"Scale(FontSize(17.0))",FontSize(14.0),,figma-tokens.json\n',
+  );
+
+  run(["--csv", csvPath, "--out", outPath, "--gaps", gapsPath]);
+
+  const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+  t.is(manifest.specVersion, "1.0.0-draft");
+  t.deepEqual(manifest.overrides, []);
+  t.deepEqual(manifest.extensions.tokens, []);
+
+  const gaps = readFileSync(gapsPath, "utf8");
+  t.true(gaps.includes("Unresolved rows (0)"));
+});
+
+test("rejects missing required flags", (t) => {
+  t.throws(() => run(["--csv", "x.csv"]), { message: /usage:/ });
+});

--- a/tools/ios-override-importer/test/emit-manifest.test.js
+++ b/tools/ios-override-importer/test/emit-manifest.test.js
@@ -1,0 +1,170 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { emitRow, emitManifest } from "../src/emit-manifest.js";
+
+const FAMILIES = new Set(["blue"]);
+const decompose = (slug) =>
+  slug === "accent-background-color-default"
+    ? { property: "accent-background-color", state: ["default"] }
+    : null;
+
+test("true-value-change emits uuid-targeted overrides, one per changed mode", (t) => {
+  const row = {
+    "Token Name": "accent-background-color-default",
+    Aliases: "",
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0))",
+    "New Value":
+      "ColorSet(light: Color(9, 9, 9, 1.0), dark: Color(2, 2, 2, 1.0))",
+  };
+  const legacyKeyIndex = new Map([
+    ["accent-background-color-default::light::", "uuid-light"],
+    ["accent-background-color-default::dark::", "uuid-dark"],
+  ]);
+  const result = emitRow(row, {
+    decompose,
+    colorFamilies: FAMILIES,
+    legacyKeyIndex,
+  });
+  t.deepEqual(result.overrides, [
+    { target: "uuid-light", value: "rgba(9, 9, 9, 1.0)" },
+  ]);
+  t.deepEqual(result.extensionTokens, []);
+  t.is(result.unresolved, undefined);
+});
+
+test("true-value-change reports a mode as unresolved when no matching foundation uuid exists", (t) => {
+  const row = {
+    "Token Name": "accent-background-color-default",
+    Aliases: "",
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0))",
+    "New Value":
+      "ColorSet(light: Color(9, 9, 9, 1.0), dark: Color(2, 2, 2, 1.0))",
+  };
+  const result = emitRow(row, {
+    decompose,
+    colorFamilies: FAMILIES,
+    legacyKeyIndex: new Map(),
+  });
+  t.deepEqual(result.overrides, []);
+  t.deepEqual(result.unresolved, ["accent-background-color-default (light)"]);
+});
+
+test("net-new emits one extension token per parsed mode", (t) => {
+  const row = {
+    "Token Name": "accent-background-color-default",
+    Aliases: "",
+    "Old Value": "Custom token",
+    "New Value":
+      "ColorSet(light: Color(1, 2, 3, 1.0), dark: Color(4, 5, 6, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+  };
+  const result = emitRow(row, { decompose, colorFamilies: FAMILIES });
+  t.deepEqual(result.extensionTokens, [
+    {
+      name: {
+        property: "accent-background-color",
+        state: ["default"],
+        colorScheme: "light",
+      },
+      $schema:
+        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+      value: "rgba(1, 2, 3, 1.0)",
+    },
+    {
+      name: {
+        property: "accent-background-color",
+        state: ["default"],
+        colorScheme: "dark",
+      },
+      $schema:
+        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+      value: "rgba(4, 5, 6, 1.0)",
+    },
+  ]);
+});
+
+test("contrast-addition includes contrast:high in the extension token's name", (t) => {
+  const row = {
+    "Token Name": "accent-background-color-default",
+    Aliases: "",
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+    "New Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: Color(3, 3, 3, 1.0), darkIncreased: none, elevatedIncreased: none)",
+  };
+  const result = emitRow(row, { decompose, colorFamilies: FAMILIES });
+  t.deepEqual(result.extensionTokens, [
+    {
+      name: {
+        property: "accent-background-color",
+        state: ["default"],
+        colorScheme: "light",
+        contrast: "high",
+      },
+      $schema:
+        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+      value: "rgba(3, 3, 3, 1.0)",
+    },
+  ]);
+});
+
+test("out-of-scope rows emit nothing", (t) => {
+  const row = {
+    "Old Value": "Scale(FontSize(17.0))",
+    "New Value": "FontSize(14.0)",
+  };
+  const result = emitRow(row, { decompose, colorFamilies: FAMILIES });
+  t.deepEqual(result, { overrides: [], extensionTokens: [] });
+});
+
+test("unresolved rows report candidates instead of a fragment", (t) => {
+  const row = {
+    "Token Name": "totally-unknown",
+    Aliases: "",
+    "Old Value": "Custom token",
+    "New Value": "ColorSet(light: Color(1, 1, 1, 1.0), dark: none)",
+  };
+  const result = emitRow(row, {
+    decompose: () => null,
+    colorFamilies: FAMILIES,
+  });
+  t.deepEqual(result, {
+    overrides: [],
+    extensionTokens: [],
+    unresolved: ["totally-unknown"],
+  });
+});
+
+test("emitManifest merges rows and sorts output deterministically", (t) => {
+  const rowA = {
+    "Token Name": "blue-200",
+    Aliases: "",
+    "Old Value": "Custom token",
+    "New Value": "ColorSet(light: Color(9, 9, 9, 1.0), dark: none)",
+  };
+  const rowB = {
+    "Token Name": "blue-100",
+    Aliases: "",
+    "Old Value": "Custom token",
+    "New Value": "ColorSet(light: Color(1, 1, 1, 1.0), dark: none)",
+  };
+  const result = emitManifest([rowA, rowB], {
+    decompose: () => null,
+    colorFamilies: FAMILIES,
+  });
+  t.deepEqual(
+    result.extensionTokens.map((t) => t.name.scaleIndex),
+    [100, 200],
+  );
+  t.deepEqual(result.unresolved, []);
+});

--- a/tools/ios-override-importer/test/find-token-uuid.test.js
+++ b/tools/ios-override-importer/test/find-token-uuid.test.js
@@ -1,0 +1,36 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { findTokenUuid } from "../src/find-token-uuid.js";
+
+const INDEX = new Map([
+  ["blue-1000::light::", "u-light"],
+  ["blue-1000::dark::", "u-dark"],
+  ["blue-1000::light::high", "u-light-high"],
+]);
+
+test("finds the uuid for an exact legacy-key + mode match", (t) => {
+  const uuid = findTokenUuid(INDEX, "blue-1000", { colorScheme: "dark" });
+  t.is(uuid, "u-dark");
+});
+
+test("disambiguates plain vs. contrast:high modes", (t) => {
+  const uuid = findTokenUuid(INDEX, "blue-1000", {
+    colorScheme: "light",
+    contrast: "high",
+  });
+  t.is(uuid, "u-light-high");
+});
+
+test("returns null when no record matches", (t) => {
+  const uuid = findTokenUuid(INDEX, "red-1000", { colorScheme: "light" });
+  t.is(uuid, null);
+});

--- a/tools/ios-override-importer/test/gaps-report.test.js
+++ b/tools/ios-override-importer/test/gaps-report.test.js
@@ -1,0 +1,31 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { buildGapsReport } from "../src/gaps-report.js";
+
+test("includes known vocabulary gaps and each unresolved row", (t) => {
+  const md = buildGapsReport([
+    {
+      row: { "Token Name": "mystery-color", "Override Source": "switch.json" },
+      candidates: ["mystery-color"],
+    },
+  ]);
+  t.true(md.includes("Known vocabulary gaps"));
+  t.true(md.includes("elevated"));
+  t.true(md.includes("### mystery-color"));
+  t.true(md.includes("Candidates tried: mystery-color"));
+  t.true(md.includes("Source: switch.json"));
+});
+
+test("handles an empty unresolved list", (t) => {
+  const md = buildGapsReport([]);
+  t.true(md.includes("Unresolved rows (0)"));
+});

--- a/tools/ios-override-importer/test/parse-colorset.test.js
+++ b/tools/ios-override-importer/test/parse-colorset.test.js
@@ -1,0 +1,53 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { isColorSet, parseColorSet } from "../src/parse-colorset.js";
+
+test("isColorSet true for a ColorSet literal, false for others", (t) => {
+  t.true(isColorSet("ColorSet(light: Color(1, 2, 3, 1.0), dark: none)"));
+  t.false(isColorSet("Custom token"));
+  t.false(isColorSet("Scale(FontSize(17.0))"));
+});
+
+test("parses light/dark slots to rgba", (t) => {
+  const { modes, skipped } = parseColorSet(
+    "ColorSet(light: Color(59, 99, 251, 1.0), dark: Color(64, 105, 253, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+  );
+  t.deepEqual(modes, [
+    { colorScheme: "light", value: "rgba(59, 99, 251, 1.0)" },
+    { colorScheme: "dark", value: "rgba(64, 105, 253, 1.0)" },
+  ]);
+  t.deepEqual(skipped, []);
+});
+
+test("maps *Increased slots to contrast:high", (t) => {
+  const { modes } = parseColorSet(
+    "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: Color(3, 3, 3, 1.0), darkIncreased: Color(4, 4, 4, 1.0), elevatedIncreased: none)",
+  );
+  t.deepEqual(modes, [
+    { colorScheme: "light", value: "rgba(1, 1, 1, 1.0)" },
+    { colorScheme: "dark", value: "rgba(2, 2, 2, 1.0)" },
+    { colorScheme: "light", contrast: "high", value: "rgba(3, 3, 3, 1.0)" },
+    { colorScheme: "dark", contrast: "high", value: "rgba(4, 4, 4, 1.0)" },
+  ]);
+});
+
+test("reports unmapped slots (elevated) as skipped, not guessed", (t) => {
+  const { modes, skipped } = parseColorSet(
+    "ColorSet(light: none, dark: none, elevated: Color(5, 5, 5, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+  );
+  t.deepEqual(modes, []);
+  t.deepEqual(skipped, ["elevated"]);
+});
+
+test("throws on a non-ColorSet literal", (t) => {
+  t.throws(() => parseColorSet("Custom token"));
+});

--- a/tools/ios-override-importer/test/parse-csv.test.js
+++ b/tools/ios-override-importer/test/parse-csv.test.js
@@ -1,0 +1,40 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { parseCsv } from "../src/parse-csv.js";
+
+test("splits quoted fields and preserves commas inside quotes", (t) => {
+  const csv =
+    "Token Name,Old Value,New Value,Aliases,Override Source\n" +
+    '"accent-color-1000","Custom token","ColorSet(light: Color(1, 2, 3, 1.0), dark: none)","blue-1000","figma-tokens.json"\n';
+  const rows = parseCsv(csv);
+  t.is(rows.length, 1);
+  t.deepEqual(rows[0], {
+    "Token Name": "accent-color-1000",
+    "Old Value": "Custom token",
+    "New Value": "ColorSet(light: Color(1, 2, 3, 1.0), dark: none)",
+    Aliases: "blue-1000",
+    "Override Source": "figma-tokens.json",
+  });
+});
+
+test("handles an empty quoted field", (t) => {
+  const csv = 'A,B\n"x",""\n';
+  const rows = parseCsv(csv);
+  t.deepEqual(rows[0], { A: "x", B: "" });
+});
+
+test("parses multiple rows", (t) => {
+  const csv = 'A,B\n"1","2"\n"3","4"\n';
+  const rows = parseCsv(csv);
+  t.is(rows.length, 2);
+  t.deepEqual(rows[1], { A: "3", B: "4" });
+});

--- a/tools/ios-override-importer/test/resolve-target.test.js
+++ b/tools/ios-override-importer/test/resolve-target.test.js
@@ -1,0 +1,80 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { matchPaletteSlug, resolveTarget } from "../src/resolve-target.js";
+
+const FAMILIES = new Set(["blue", "static-blue"]);
+
+test("matchPaletteSlug recognizes a known family + numeric index", (t) => {
+  t.deepEqual(matchPaletteSlug("blue-1000", FAMILIES), {
+    colorFamily: "blue",
+    scaleIndex: 1000,
+  });
+});
+
+test("matchPaletteSlug rejects an unknown family", (t) => {
+  t.is(matchPaletteSlug("mauve-1000", FAMILIES), null);
+});
+
+test("matchPaletteSlug rejects a slug with no trailing digits", (t) => {
+  t.is(matchPaletteSlug("blue", FAMILIES), null);
+});
+
+test("resolveTarget uses the token's own name when it resolves", (t) => {
+  const decompose = (slug) =>
+    slug === "accent-color-1000" ? { property: "accent-color-1000" } : null;
+  const result = resolveTarget(
+    { "Token Name": "accent-color-1000", Aliases: "" },
+    { decompose, colorFamilies: FAMILIES },
+  );
+  t.is(result.slug, "accent-color-1000");
+});
+
+test("resolveTarget falls back through the Aliases chain in order", (t) => {
+  const decompose = () => null; // never a semantic-name match in this test
+  const result = resolveTarget(
+    {
+      "Token Name": "accent-content-color-down",
+      Aliases: "accent-color-1000, blue-1000",
+    },
+    { decompose, colorFamilies: FAMILIES },
+  );
+  // "accent-color-1000" isn't a palette slug (family "accent-color" unknown) and
+  // decompose() returns null, so it falls through to "blue-1000".
+  t.deepEqual(result, {
+    slug: "blue-1000",
+    name: { colorFamily: "blue", scaleIndex: 1000 },
+  });
+});
+
+test("resolveTarget prefers a palette match over calling decompose", (t) => {
+  let called = false;
+  const decompose = () => {
+    called = true;
+    return null;
+  };
+  const result = resolveTarget(
+    { "Token Name": "blue-1000", Aliases: "" },
+    { decompose, colorFamilies: FAMILIES },
+  );
+  t.is(result.slug, "blue-1000");
+  t.false(called);
+});
+
+test("resolveTarget reports unresolved candidates when nothing matches", (t) => {
+  const decompose = () => null;
+  const result = resolveTarget(
+    { "Token Name": "totally-unknown-slug", Aliases: "also-unknown" },
+    { decompose, colorFamilies: FAMILIES },
+  );
+  t.is(result.slug, null);
+  t.deepEqual(result.candidates, ["totally-unknown-slug", "also-unknown"]);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `migrate legacy-output-cascaded` CLI command so classic-schema consumers
(e.g. Spectrum iOS's tokentool) can be fed a manifest-cascaded, design-data-resolved
dataset instead of an ad-hoc merge. Along the way, adds the supporting legacy-name
decomposition and an iOS override-log importer that produces the platform manifest
this command consumes.

- **sdk/cli/src/main.rs**: new `migrate legacy-output-cascaded [PATH] --output FILE`
  applies the configured platform manifest cascade before converting to legacy
  schema, dropping Foundation-layer records shadowed by a Platform-layer override
  so the output is deterministic.
- **sdk/core/src/legacy.rs**: new `convert_records` entry point converts an
  already-cascaded in-memory array; `build_mode_entry`'s `$schema` fallback for
  schema-less override records now matches alias-ness instead of copying an
  unrelated sibling's schema; exposes legacy-name decomposition for the
  platform-manifest tooling.
- **tools/**: new iOS override-log → platform manifest importer (h890.8), used to
  generate the `manifest.json` overrides that `legacy-output-cascaded` cascades.

## Related Issue

Relates to beads spectrum-design-data-h890.10, spectrum-design-data-h890.8, spectrum-design-data-8bkb.

## Motivation and Context

Spectrum iOS's `tokentool generate-source-code` currently reads a `spectrum-tokens.json`
produced by an unvalidated ad-hoc merge (foundation + ios-tokens + figma-tokens.json).
This lets iOS instead consume a validated, manifest-cascaded snapshot generated by
design-data, retiring that merge as codegen's source of truth.

## How Has This Been Tested?

- `moon run sdk:test` — full suite passes (1297 passed, 1 skipped).
- `cargo clippy --workspace -- -D warnings` — clean.
- New unit test in `sdk/core/src/legacy.rs` covering the alias-ness schema-fallback fix.
- New integration test in `sdk/cli/tests/cli_manifest.rs` covering override-over-shadowed-
  Foundation determinism.
- End-to-end: ran the real Swift `tokentool generate-source-code` binary against output
  produced from a POC manifest repo (`GarthDB/spectrum-ios-design-data`) and a real
  fetched-foundation cache; confirmed deterministic output across repeated runs and no
  new parse errors versus the documented pre-existing gaps.
- Changeset linter: `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
