### PR TITLE
fix(sdk): load query/resolve/legacy-output-cascaded tokens from resolved source

### DIFF
--- a/.changeset/query-resolve-legacy-cascade-source.md
+++ b/.changeset/query-resolve-legacy-cascade-source.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-tui": patch
+"@adobe/design-data-wasm": patch
+---
+
+Load tokens from the resolved `[source]` for `query`/`resolve`/legacy-output-cascaded (h890.19).
+
+- **sdk/cli/src/main.rs**: `run_query`, `run_resolve`, and
+  `run_migrate_legacy_output_cascaded` now load the dataset from
+  `resolved.tokens_root` (an explicit PATH argument still wins) instead of always
+  reading the raw CWD, so a `.design-data.toml` `[source]` block actually takes
+  effect — matching the pattern already used by `run_primer`/`run_cache_build`.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -587,7 +587,7 @@ fn run_dump_legacy_keys(path: &Path) -> miette::Result<ExitCode> {
 
 fn run_resolve(
     property: &str,
-    path: &Path,
+    explicit_path: Option<&Path>,
     mode_sets_path: Option<PathBuf>,
     color_scheme: Option<String>,
     scale: Option<String>,
@@ -611,11 +611,13 @@ fn run_resolve(
     let resolved = data_source::resolve(
         &cwd,
         &CliPathOverrides {
+            tokens_root: explicit_path.map(Path::to_path_buf),
             mode_sets: mode_sets_path,
             ..Default::default()
         },
     )
     .into_diagnostic()?;
+    let path = &resolved.tokens_root;
 
     // Load token graph (via the embedded-database cache when fresh).
     let mut graph = TokenGraph::open_cached_with_catalogs(
@@ -919,9 +921,20 @@ fn run_migrate_legacy_output(input: &Path, output: &Path) -> miette::Result<Exit
     Ok(ExitCode::SUCCESS)
 }
 
-fn run_migrate_legacy_output_cascaded(path: &Path, output: &Path) -> miette::Result<ExitCode> {
+fn run_migrate_legacy_output_cascaded(
+    explicit_path: Option<&Path>,
+    output: &Path,
+) -> miette::Result<ExitCode> {
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            tokens_root: explicit_path.map(Path::to_path_buf),
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
+    let path = &resolved.tokens_root;
 
     let (mut graph, _index) = TokenGraph::open_cached_with_index_with_catalogs(
         path,
@@ -1204,13 +1217,21 @@ fn run_diff(
 }
 
 fn run_query(
-    path: &Path,
+    explicit_path: Option<&Path>,
     filter_expr: &str,
     format: OutputFormat,
     count_only: bool,
 ) -> miette::Result<ExitCode> {
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            tokens_root: explicit_path.map(Path::to_path_buf),
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
+    let path = &resolved.tokens_root;
 
     let (mut graph, mut index) = TokenGraph::open_cached_with_index_with_catalogs(
         path,
@@ -1941,18 +1962,15 @@ fn main() -> ExitCode {
             scale,
             contrast,
             format,
-        } => {
-            let target = path.unwrap_or_else(|| PathBuf::from("."));
-            run_resolve(
-                &property,
-                &target,
-                mode_sets_path,
-                color_scheme,
-                scale,
-                contrast,
-                format,
-            )
-        }
+        } => run_resolve(
+            &property,
+            path.as_deref(),
+            mode_sets_path,
+            color_scheme,
+            scale,
+            contrast,
+            format,
+        ),
         Commands::DecomposeLegacyName {
             slug,
             component_hint,
@@ -1971,10 +1989,7 @@ fn main() -> ExitCode {
             filter,
             format,
             count,
-        } => {
-            let target = path.unwrap_or_else(|| PathBuf::from("."));
-            run_query(&target, &filter, format, count)
-        }
+        } => run_query(path.as_deref(), &filter, format, count),
         Commands::Migrate { sub } => match sub {
             MigrateSub::Verify {
                 path,
@@ -1998,8 +2013,7 @@ fn main() -> ExitCode {
                 run_migrate_legacy_output(&input, &output)
             }
             MigrateSub::LegacyOutputCascaded { path, output } => {
-                let target = path.unwrap_or_else(|| PathBuf::from("."));
-                run_migrate_legacy_output_cascaded(&target, &output)
+                run_migrate_legacy_output_cascaded(path.as_deref(), &output)
             }
             MigrateSub::AddUuids { dir } => run_migrate_add_uuids(&dir),
             MigrateSub::RoundtripVerify { path } => run_migrate_roundtrip_verify(&path),

--- a/sdk/cli/tests/cli_source.rs
+++ b/sdk/cli/tests/cli_source.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Regression tests for spectrum-design-data-h890.19: `query`, `resolve`, and
+//! `migrate legacy-output-cascaded` must load tokens from `resolved.tokens_root`
+//! (i.e. respect a `.design-data.toml` `[source]` block) when no positional PATH
+//! is given — not always fall back to the raw `.` CWD.
+//!
+//! Unlike `cli_manifest.rs`'s `setup_project`, these tests pass **no** positional
+//! path, which is exactly the case the bug affected.
+
+use std::fs;
+
+use assert_cmd::Command;
+use serde_json::json;
+
+/// Create a standalone dataset root (`packages/design-data/tokens/tokens.json`)
+/// and a project dir whose `.design-data.toml` points a `[source]` `path` at it.
+/// Returns `(source_dir, project_dir)`; both must stay alive for the test.
+fn setup_source_project() -> (tempfile::TempDir, tempfile::TempDir) {
+    let source = tempfile::tempdir().expect("temp source dir");
+    let tokens_dir = source.path().join("packages/design-data/tokens");
+    fs::create_dir_all(&tokens_dir).expect("create tokens dir");
+    fs::write(
+        tokens_dir.join("tokens.json"),
+        json!({
+            "btn-bg": {"name": {"property": "background-color", "component": "button"}, "value": "#aaa", "uuid": "u-btn-bg"},
+            "btn-fg": {"name": {"property": "color", "component": "button"}, "value": "#111", "uuid": "u-btn-fg"},
+            "chk-bg": {"name": {"property": "background-color", "component": "checkbox"}, "value": "#bbb", "uuid": "u-chk-bg"},
+        })
+        .to_string(),
+    )
+    .expect("write tokens.json");
+
+    let project = tempfile::tempdir().expect("temp project dir");
+    let source_root = source.path().canonicalize().expect("canonicalize source");
+    fs::write(
+        project.path().join(".design-data.toml"),
+        format!(
+            "[source]\ntype = \"path\"\nroot = \"{}\"\n",
+            source_root.display().to_string().replace('\\', "\\\\")
+        ),
+    )
+    .expect("write .design-data.toml");
+
+    (source, project)
+}
+
+#[test]
+fn query_with_no_path_arg_loads_configured_source() {
+    let (_source, project) = setup_source_project();
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["query", "--filter", "", "--count"])
+        .assert()
+        .success()
+        .stdout(predicates::str::starts_with("3"));
+}
+
+#[test]
+fn resolve_with_no_path_arg_loads_configured_source() {
+    let (_source, project) = setup_source_project();
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["resolve", "color", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("u-btn-fg"));
+}
+
+#[test]
+fn migrate_legacy_output_cascaded_with_no_path_arg_loads_configured_source() {
+    let (_source, project) = setup_source_project();
+    let output = project.path().join("legacy.json");
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["migrate", "legacy-output-cascaded", "--output"])
+        .arg(&output)
+        .assert()
+        .success();
+
+    let legacy: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&output).expect("read output"))
+            .expect("parse output");
+    assert!(legacy.get("button-background-color").is_some());
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`design-data query`, `design-data resolve`, and `design-data migrate legacy-output-cascaded`
computed catalog paths via `data_source::resolve()` (which honors a `.design-data.toml`
`[source]` block) but then loaded the actual token dataset from the raw CLI `PATH`
argument, which defaults to `.` when omitted. So a configured `[source]` (`path`,
`github`, `npm`, `git`) had **zero effect** on where these three commands actually
read tokens from — they always fell back to the current directory.

This fix threads the optional `PATH` argument through `CliPathOverrides { tokens_root }`
and loads from `resolved.tokens_root` instead (explicit `PATH` still wins), matching
the pattern already used correctly by `run_primer` and `run_cache_build`.

## Related Issue

Fixes bead `spectrum-design-data-h890.19` (no linked GitHub issue).

## Motivation and Context

Discovered while verifying the iOS foundation-pin POC (h890.9) against a real
published `@adobe/spectrum-tokens` tag. This contradicted `sdk/cli/README.md`'s
documented behavior (drop a `.design-data.toml` and run `design-data query` with
no path) and was exactly the manual `DESIGN_DATA_PATH` workaround called out in
`SPECTRUM_MULTIPLATFORM_SDK_STRATEGY.md`.

## How Has This Been Tested?

- Added `sdk/cli/tests/cli_source.rs`: three regression tests (one per affected
  command) that configure a `.design-data.toml` `[source] type = "path"` and invoke
  the CLI with **no** positional path argument. Verified all three fail against the
  pre-fix code and pass post-fix.
- `moon run sdk:test` — full workspace suite (1301 tests) passes.
- `moon run sdk:lint` and `moon run sdk:fmt` — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
