### PR TITLE
fix(tui): normalize version string in all header-rendering snapshots

### DIFF
--- a/sdk/tui/tests/snapshots.rs
+++ b/sdk/tui/tests/snapshots.rs
@@ -43,6 +43,18 @@ fn buffer_to_string(buf: &Buffer) -> String {
         .join("\n")
 }
 
+/// `insta::assert_snapshot!`, normalizing the compiled-in crate version first so
+/// a version bump alone doesn't break every snapshot that renders the header bar.
+macro_rules! assert_snapshot_version_normalized {
+    ($name:expr, $rendered:expr) => {
+        insta::with_settings!({
+            filters => vec![(r"v\d+\.\d+\.\d+", "v[VERSION]")],
+        }, {
+            insta::assert_snapshot!($name, $rendered);
+        });
+    };
+}
+
 // ── Home / empty view ─────────────────────────────────────────────────────────
 
 /// The initial home screen (no query, no modal).
@@ -51,12 +63,7 @@ fn snapshot_home_view() {
     let mut model = Model::new();
     let buf = render_to_buffer(&mut model, 80, 24);
     let rendered = buffer_to_string(&buf);
-    insta::with_settings!({
-        // Normalize the compiled-in crate version so version bumps don't break this snapshot.
-        filters => vec![(r"v\d+\.\d+\.\d+", "v[VERSION]")],
-    }, {
-        insta::assert_snapshot!("home_view_80x24", rendered);
-    });
+    assert_snapshot_version_normalized!("home_view_80x24", rendered);
 }
 
 // ── Query results view ────────────────────────────────────────────────────────
@@ -101,7 +108,7 @@ fn snapshot_palette_open() {
     );
     let buf = render_to_buffer(&mut model, 80, 24);
     let rendered = buffer_to_string(&buf);
-    insta::assert_snapshot!("palette_open_80x24", rendered);
+    assert_snapshot_version_normalized!("palette_open_80x24", rendered);
 }
 
 // ── Wizard (new token modal) ──────────────────────────────────────────────────
@@ -119,5 +126,5 @@ fn snapshot_wizard_screen1() {
     );
     let buf = render_to_buffer(&mut model, 80, 24);
     let rendered = buffer_to_string(&buf);
-    insta::assert_snapshot!("wizard_screen1_80x24", rendered);
+    assert_snapshot_version_normalized!("wizard_screen1_80x24", rendered);
 }

--- a/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.7.1
+  Spectrum Design Data  v[VERSION]
   ↑↓ history/list · Tab complete · Enter run · Esc back · Ctrl+C quit
   ──────────────────────────────────────────────────────────────────────────────
   > :

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.7.1
+  Spectrum Design Data  v[VERSION]
   ↑↓ hi┌ Step 1 of 4 — Intent ──────────────────────────────────────────┐
   ─────│Intent: background-color                                        │───────
   >    │  These tokens already exist for similar intents.               │


### PR DESCRIPTION
## Description

`snapshot_palette_open` and `snapshot_wizard_screen1` (in `sdk/tui/tests/snapshots.rs`) render the TUI's header bar, which includes the compiled-in crate version. Unlike `snapshot_home_view` — which already normalizes the version via an insta filter (`v\d+\.\d+\.\d+` → `v[VERSION]`) — these two hardcoded the literal version string in their `.snap` files.

Result: every changesets "Version Packages" PR that bumps `design-data-tui`'s version breaks these two snapshots, requiring a manual `cargo insta --accept` fix each time (most recently on #1361).

This extracts the existing filter into a small `assert_snapshot_version_normalized!` macro and applies it to all three header-rendering snapshot tests, so future version bumps won't touch them at all.

## Related Issue

Closes spectrum-design-data-uqjq.

## Motivation and Context

Stop the recurring CI breakage on every release PR.

## How Has This Been Tested?

- `moon run sdk:test` — 1301/1301 passed
- `moon run sdk:lint` — clean
- `cargo fmt --all -- --check` — clean
- Regenerated the two affected `.snap` files via `cargo insta test -p design-data-tui --accept`; diffed to confirm only the version string changed (`v0.7.1` → `v[VERSION]`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
