### PR TITLE
fix(sdk): load validate/dump-legacy-keys tokens from resolved source

### DIFF
--- a/.changeset/validate-dump-legacy-keys-source.md
+++ b/.changeset/validate-dump-legacy-keys-source.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-tui": patch
+"@adobe/design-data-wasm": patch
+---
+
+Load tokens from the resolved `[source]` for `validate`/`dump-legacy-keys` (h890.20).
+
+- **sdk/cli/src/main.rs**: `run_validate` and `run_dump_legacy_keys` now load the
+  dataset from `resolved.tokens_root` (an explicit PATH argument still wins)
+  instead of always reading the raw CWD, so a `.design-data.toml` `[source]`
+  block actually takes effect — matching the pattern already used by
+  `run_query`/`run_resolve`/`run_migrate_legacy_output_cascaded` (h890.19).

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -556,7 +556,18 @@ fn run_decompose_legacy_name(slug: &str, component_hint: Option<&str>) -> miette
 /// `design-data dump-legacy-keys [PATH]` — prints a JSON array of
 /// `{legacyKey, uuid, colorScheme?, contrast?}`, one entry per token (not
 /// deduped by legacyKey, unlike `TokenGraph::legacy_name_index`).
-fn run_dump_legacy_keys(path: &Path) -> miette::Result<ExitCode> {
+fn run_dump_legacy_keys(explicit_path: Option<&Path>) -> miette::Result<ExitCode> {
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            tokens_root: explicit_path.map(Path::to_path_buf),
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
+    let path = &resolved.tokens_root;
+
     let graph = TokenGraph::open_cached(path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
@@ -690,7 +701,7 @@ struct ValidateOpts {
     strict: bool,
 }
 
-fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
+fn run_validate(explicit_path: Option<&Path>, opts: ValidateOpts) -> miette::Result<ExitCode> {
     if !validate::engine_ready() {
         miette::bail!("validation engine not ready");
     }
@@ -698,6 +709,7 @@ fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
     let resolved = data_source::resolve(
         &cwd,
         &CliPathOverrides {
+            tokens_root: explicit_path.map(Path::to_path_buf),
             schema_root: opts.schema_path,
             exceptions: opts.exceptions_path,
             mode_sets: opts.mode_sets_path,
@@ -707,6 +719,7 @@ fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
         },
     )
     .into_diagnostic()?;
+    let path = &resolved.tokens_root;
 
     let schema_root = resolved.schemas_root;
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root)
@@ -1917,23 +1930,20 @@ fn main() -> ExitCode {
             names_dir,
             components_report_only,
             strict,
-        } => {
-            let target = path.unwrap_or_else(|| PathBuf::from("."));
-            run_validate(
-                &target,
-                ValidateOpts {
-                    format,
-                    schema_path,
-                    exceptions_path,
-                    mode_sets_path,
-                    components_path,
-                    relationships_path,
-                    names_dir,
-                    components_report_only,
-                    strict,
-                },
-            )
-        }
+        } => run_validate(
+            path.as_deref(),
+            ValidateOpts {
+                format,
+                schema_path,
+                exceptions_path,
+                mode_sets_path,
+                components_path,
+                relationships_path,
+                names_dir,
+                components_report_only,
+                strict,
+            },
+        ),
         Commands::ValidateDataset {
             path,
             format,
@@ -1975,9 +1985,7 @@ fn main() -> ExitCode {
             slug,
             component_hint,
         } => run_decompose_legacy_name(&slug, component_hint.as_deref()),
-        Commands::DumpLegacyKeys { path } => {
-            run_dump_legacy_keys(&path.unwrap_or_else(|| PathBuf::from(".")))
-        }
+        Commands::DumpLegacyKeys { path } => run_dump_legacy_keys(path.as_deref()),
         Commands::Diff {
             old,
             new,

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -529,6 +529,14 @@ enum DiffFormat {
     Markdown,
 }
 
+/// Resolve `overrides` against the current working directory. Shared by every
+/// command handler so the config/probing/embedded-snapshot tiers in
+/// [`data_source::resolve`] are applied consistently everywhere.
+fn resolve_data_source(overrides: CliPathOverrides) -> miette::Result<data_source::ResolvedData> {
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    data_source::resolve(&cwd, &overrides).into_diagnostic()
+}
+
 fn load_exceptions(path: Option<&Path>) -> miette::Result<HashSet<String>> {
     let Some(p) = path else {
         // No path provided and not resolved — no exceptions file found.
@@ -557,15 +565,10 @@ fn run_decompose_legacy_name(slug: &str, component_hint: Option<&str>) -> miette
 /// `{legacyKey, uuid, colorScheme?, contrast?}`, one entry per token (not
 /// deduped by legacyKey, unlike `TokenGraph::legacy_name_index`).
 fn run_dump_legacy_keys(explicit_path: Option<&Path>) -> miette::Result<ExitCode> {
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(Path::to_path_buf),
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(Path::to_path_buf),
+        ..Default::default()
+    })?;
     let path = &resolved.tokens_root;
 
     let graph = TokenGraph::open_cached(path)
@@ -618,16 +621,11 @@ fn run_resolve(
     }
 
     // Resolve catalog paths first so the cache can hydrate them on hit.
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(Path::to_path_buf),
-            mode_sets: mode_sets_path,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(Path::to_path_buf),
+        mode_sets: mode_sets_path,
+        ..Default::default()
+    })?;
     let path = &resolved.tokens_root;
 
     // Load token graph (via the embedded-database cache when fresh).
@@ -705,20 +703,15 @@ fn run_validate(explicit_path: Option<&Path>, opts: ValidateOpts) -> miette::Res
     if !validate::engine_ready() {
         miette::bail!("validation engine not ready");
     }
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(Path::to_path_buf),
-            schema_root: opts.schema_path,
-            exceptions: opts.exceptions_path,
-            mode_sets: opts.mode_sets_path,
-            components: opts.components_path,
-            relationships: opts.relationships_path,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(Path::to_path_buf),
+        schema_root: opts.schema_path,
+        exceptions: opts.exceptions_path,
+        mode_sets: opts.mode_sets_path,
+        components: opts.components_path,
+        relationships: opts.relationships_path,
+        ..Default::default()
+    })?;
     let path = &resolved.tokens_root;
 
     let schema_root = resolved.schemas_root;
@@ -813,15 +806,11 @@ fn run_validate_dataset(path: &Path, opts: ValidateDatasetOpts) -> miette::Resul
         miette::bail!("validation engine not ready");
     }
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            schema_root: opts.schema_path,
-            exceptions: opts.exceptions_path,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        schema_root: opts.schema_path,
+        exceptions: opts.exceptions_path,
+        ..Default::default()
+    })?;
 
     let schema_root = resolved.schemas_root;
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root)
@@ -885,16 +874,11 @@ fn run_migrate_verify(
     schema_path: Option<PathBuf>,
     exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            schema_root: schema_path,
-            exceptions: exceptions_path,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        schema_root: schema_path,
+        exceptions: exceptions_path,
+        ..Default::default()
+    })?;
     let registry =
         SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
     let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
@@ -938,15 +922,10 @@ fn run_migrate_legacy_output_cascaded(
     explicit_path: Option<&Path>,
     output: &Path,
 ) -> miette::Result<ExitCode> {
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(Path::to_path_buf),
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(Path::to_path_buf),
+        ..Default::default()
+    })?;
     let path = &resolved.tokens_root;
 
     let (mut graph, _index) = TokenGraph::open_cached_with_index_with_catalogs(
@@ -1146,16 +1125,11 @@ fn run_migrate_snapshot(
     schema_path: Option<PathBuf>,
     exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            schema_root: schema_path,
-            exceptions: exceptions_path,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        schema_root: schema_path,
+        exceptions: exceptions_path,
+        ..Default::default()
+    })?;
     let registry =
         SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
     let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
@@ -1235,15 +1209,10 @@ fn run_query(
     format: OutputFormat,
     count_only: bool,
 ) -> miette::Result<ExitCode> {
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(Path::to_path_buf),
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(Path::to_path_buf),
+        ..Default::default()
+    })?;
     let path = &resolved.tokens_root;
 
     let (mut graph, mut index) = TokenGraph::open_cached_with_index_with_catalogs(
@@ -1515,18 +1484,13 @@ fn run_primer(
     fields_dir: Option<PathBuf>,
     mode_sets_dir: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(|p| p.to_path_buf()),
-            mode_sets: mode_sets_dir,
-            components: components_dir,
-            fields: fields_dir,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(|p| p.to_path_buf()),
+        mode_sets: mode_sets_dir,
+        components: components_dir,
+        fields: fields_dir,
+        ..Default::default()
+    })?;
 
     // Dataset path: explicit arg wins; otherwise use the resolved tokens root (which
     // comes from the config source, embedded snapshot, or in-repo CWD probing).
@@ -1629,15 +1593,10 @@ fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<Ex
         return Ok(ExitCode::from(1));
     }
 
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            components: components_dir,
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        components: components_dir,
+        ..Default::default()
+    })?;
     let dir = resolved
         .components
         .ok_or_else(|| miette::miette!("could not locate components directory"))?;
@@ -1723,18 +1682,13 @@ fn run_cache_build(
     fields_path: Option<&Path>,
 ) -> miette::Result<ExitCode> {
     // Resolve the dataset: explicit arg wins, else the canonical resolved root.
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(
-        &cwd,
-        &CliPathOverrides {
-            tokens_root: explicit_path.map(|p| p.to_path_buf()),
-            mode_sets: mode_sets_path.map(|p| p.to_path_buf()),
-            components: components_path.map(|p| p.to_path_buf()),
-            fields: fields_path.map(|p| p.to_path_buf()),
-            ..Default::default()
-        },
-    )
-    .into_diagnostic()?;
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(|p| p.to_path_buf()),
+        mode_sets: mode_sets_path.map(|p| p.to_path_buf()),
+        components: components_path.map(|p| p.to_path_buf()),
+        fields: fields_path.map(|p| p.to_path_buf()),
+        ..Default::default()
+    })?;
     let tokens_root = resolved.tokens_root;
 
     cache::build_file_with_all_catalogs(

--- a/sdk/cli/tests/cli_source.rs
+++ b/sdk/cli/tests/cli_source.rs
@@ -8,18 +8,31 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! Regression tests for spectrum-design-data-h890.19: `query`, `resolve`, and
-//! `migrate legacy-output-cascaded` must load tokens from `resolved.tokens_root`
-//! (i.e. respect a `.design-data.toml` `[source]` block) when no positional PATH
-//! is given — not always fall back to the raw `.` CWD.
+//! Regression tests for spectrum-design-data-h890.19 and h890.20: `query`, `resolve`,
+//! `migrate legacy-output-cascaded`, `validate`, and `dump-legacy-keys` must load
+//! tokens from `resolved.tokens_root` (i.e. respect a `.design-data.toml` `[source]`
+//! block) when no positional PATH is given — not always fall back to the raw `.` CWD.
 //!
 //! Unlike `cli_manifest.rs`'s `setup_project`, these tests pass **no** positional
 //! path, which is exactly the case the bug affected.
 
 use std::fs;
+use std::path::PathBuf;
 
 use assert_cmd::Command;
 use serde_json::json;
+
+/// Real `packages/tokens/schemas` dir in this checkout, for `--schema-path` —
+/// the fixture source in [`setup_source_project`] has no schemas of its own.
+fn real_schemas_dir() -> PathBuf {
+    let schemas = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/schemas");
+    assert!(
+        schemas.join("token-types").is_dir(),
+        "expected schemas at {}",
+        schemas.display()
+    );
+    schemas
+}
 
 /// Create a standalone dataset root (`packages/design-data/tokens/tokens.json`)
 /// and a project dir whose `.design-data.toml` points a `[source]` `path` at it.
@@ -96,4 +109,60 @@ fn migrate_legacy_output_cascaded_with_no_path_arg_loads_configured_source() {
         serde_json::from_str(&fs::read_to_string(&output).expect("read output"))
             .expect("parse output");
     assert!(legacy.get("button-background-color").is_some());
+}
+
+#[test]
+fn validate_with_no_path_arg_loads_configured_source() {
+    let (source, project) = setup_source_project();
+    let schemas = real_schemas_dir();
+    let source_root = source.path().canonicalize().expect("canonicalize source");
+
+    // The fixture tokens don't pass real schema validation (no `$schema`, made-up
+    // shape) — that's not what's under test here. What matters is that the
+    // dataset loaded from the configured `[source]` at all: the report's `file`
+    // fields point at the source dir's `tokens.json`, not the empty project dir.
+    let output = Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args([
+            "validate",
+            "--format",
+            "json",
+            "--schema-path",
+            schemas.to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("run design-data validate");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected_file = source_root.join("packages/design-data/tokens/tokens.json");
+    assert!(
+        stdout.contains(expected_file.to_str().expect("utf8 path")),
+        "expected report to reference source's tokens.json ({}), got: {stdout}\nstderr: {}",
+        expected_file.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn dump_legacy_keys_with_no_path_arg_loads_configured_source() {
+    let (_source, project) = setup_source_project();
+
+    let output = Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["dump-legacy-keys"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let keys: serde_json::Value = serde_json::from_slice(&output).expect("parse output");
+    let keys = keys.as_array().expect("array of legacy keys");
+    assert_eq!(
+        keys.len(),
+        3,
+        "expected one entry per source token: {keys:?}"
+    );
 }


### PR DESCRIPTION
## Description

`run_validate` and `run_dump_legacy_keys` in `sdk/cli/src/main.rs` loaded their
token dataset from the raw CLI PATH argument (defaulting to `.`) instead of
`resolved.tokens_root`, so a `.design-data.toml` `[source]` block had no effect
on them.

## Related Issue

Fixes spectrum-design-data-h890.20 (follow-up to h890.19 / #1360).

## Motivation and Context

PR #1360 fixed this same bug for `run_query`/`run_resolve`/
`run_migrate_legacy_output_cascaded`. `run_validate` and `run_dump_legacy_keys`
were the two remaining commands still bypassing the resolved source, so a
configured `[source]` was silently ignored for validation and legacy-key
dumps.

## How Has This Been Tested?

- Added `validate_with_no_path_arg_loads_configured_source` and
  `dump_legacy_keys_with_no_path_arg_loads_configured_source` to
  `sdk/cli/tests/cli_source.rs`, reusing the existing `setup_source_project()`
  fixture. Both fail pre-fix and pass post-fix.
- `moon run sdk:test` — 1303 passed, 1 skipped.
- `moon run sdk:lint` — clean.
- `cargo fmt --all -- --check` — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
