### PR TITLE
fix(sdk): sync Cargo.lock's design-data-tui entry in version-sync script

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-tui"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -158,3 +158,4 @@ tasks:
       - "tui/package.json"
     outputs:
       - "tui/Cargo.toml"
+      - "Cargo.lock"

--- a/sdk/scripts/sync-cargo-version.mjs
+++ b/sdk/scripts/sync-cargo-version.mjs
@@ -11,7 +11,9 @@
 /**
  * Syncs the tui Cargo.toml version from tui/package.json after `changeset version`.
  *
- * - For `tui`: reads version from tui/package.json and writes it into tui/Cargo.toml.
+ * - For `tui`: reads version from tui/package.json and writes it into tui/Cargo.toml,
+ *   then patches the matching `design-data-tui` entry in Cargo.lock so the lockfile
+ *   doesn't drift out from under the next `cargo build`/`test`.
  *
  * The `design-data-cli` Rust crate (sdk/cli/Cargo.toml) is versioned independently
  * and released via GitHub Releases — it no longer has a corresponding npm package.
@@ -40,4 +42,22 @@ if (updated === cargo) {
 } else {
   writeFileSync(cargoPath, updated);
   console.log(`Updated sdk/tui/Cargo.toml to ${tuiVersion}`);
+}
+
+// Keep Cargo.lock's design-data-tui entry in sync too, so a plain `cargo build`
+// right after this doesn't rewrite the lockfile as an incidental diff.
+
+const lockPath = resolve(root, 'Cargo.lock');
+const lock = readFileSync(lockPath, 'utf8');
+
+const lockUpdated = lock.replace(
+  /(name = "design-data-tui"\nversion = )"[^"]+"/,
+  `$1"${tuiVersion}"`,
+);
+
+if (lockUpdated === lock) {
+  console.log(`sdk/Cargo.lock already at ${tuiVersion}`);
+} else {
+  writeFileSync(lockPath, lockUpdated);
+  console.log(`Updated sdk/Cargo.lock design-data-tui to ${tuiVersion}`);
 }

--- a/sdk/scripts/sync-cargo-version.mjs
+++ b/sdk/scripts/sync-cargo-version.mjs
@@ -50,14 +50,21 @@ if (updated === cargo) {
 const lockPath = resolve(root, 'Cargo.lock');
 const lock = readFileSync(lockPath, 'utf8');
 
-const lockUpdated = lock.replace(
-  /(name = "design-data-tui"\nversion = )"[^"]+"/,
-  `$1"${tuiVersion}"`,
-);
+const lockEntry = /name = "design-data-tui"\nversion = "([^"]+)"/.exec(lock);
 
-if (lockUpdated === lock) {
+if (!lockEntry) {
+  throw new Error(
+    `Could not find a "design-data-tui" entry in sdk/Cargo.lock — refusing to skip the sync silently.`,
+  );
+}
+
+if (lockEntry[1] === tuiVersion) {
   console.log(`sdk/Cargo.lock already at ${tuiVersion}`);
 } else {
+  const lockUpdated = lock.replace(
+    /(name = "design-data-tui"\nversion = )"[^"]+"/,
+    `$1"${tuiVersion}"`,
+  );
   writeFileSync(lockPath, lockUpdated);
   console.log(`Updated sdk/Cargo.lock design-data-tui to ${tuiVersion}`);
 }


### PR DESCRIPTION
## Description

`sdk/scripts/sync-cargo-version.mjs` synced `tui/package.json`'s version into
`sdk/tui/Cargo.toml`, but never refreshed `sdk/Cargo.lock`'s matching
`design-data-tui` entry. The next `cargo build`/`test` on a fresh checkout
would then silently rewrite `Cargo.lock` as an incidental diff. This PR makes
the script patch both files, and declares `Cargo.lock` as an output of
`sdk:version` in `moon.yml`.

## Related Issue

Tracked internally as beads issue `spectrum-design-data-m5jl` (no GitHub issue
— this is an internal tooling fix, not user-facing).

## Motivation and Context

Recurring lockfile churn across PRs #1360–#1363 — `git checkout --
sdk/Cargo.lock` was needed before nearly every commit to avoid bundling an
unrelated version bump. Root cause: the version-sync script only wrote
`Cargo.toml`.

## How Has This Been Tested?

- Confirmed the pre-existing real drift (`Cargo.lock` said `0.7.0` while
  `Cargo.toml`/`package.json` were already at `0.7.1`) and that running the
  script now corrects it.
- Temporarily bumped `tui/package.json` to a fake version, ran the script,
  confirmed only `tui/Cargo.toml` and `Cargo.lock`'s `design-data-tui` entry
  changed (no other lockfile entries touched), then reverted.
- `moon run sdk:build` — `Cargo.lock` stays untouched afterward.
- `moon run sdk:test` — 1303 passed, 1 skipped.
- `moon run sdk:lint` — clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
