### PR TITLE
fix(sdk): enforce cascade type-safety on alias-only override targets

### DIFF
--- a/.changeset/cascade-alias-override-type-safety.md
+++ b/.changeset/cascade-alias-override-type-safety.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
+---
+
+Enforce cascade type-safety on manifest overrides targeting alias-only tokens.
+
+- **sdk/core/src/graph.rs**: `resolve_override_targets` now resolves the shadowed
+  token's value through its alias chain (`TokenRecord::resolve_leaf`) instead of
+  only reading a literal `value`, so an override that changes a `$ref`-aliased
+  token's value type (e.g. color → dimension) is rejected like the existing
+  literal-value case, instead of silently applying.

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -918,7 +918,7 @@ impl TokenGraph {
                         (
                             rec.name.clone(),
                             name_obj,
-                            rec.raw.get("value").cloned(),
+                            rec.resolve_leaf(self).raw.get("value").cloned(),
                             rec.uuid.clone(),
                         )
                     })
@@ -933,7 +933,11 @@ impl TokenGraph {
                 return Ok(vec![(
                     rec.name.clone(),
                     name_obj,
-                    rec.raw.get("value").cloned(),
+                    // Resolve through the alias chain so a pure `$ref` target's
+                    // effective type (from its leaf's literal `value`) is available
+                    // to the cascade type-safety guard, not just literal-value
+                    // targets (spectrum-design-data-c3qw).
+                    rec.resolve_leaf(self).raw.get("value").cloned(),
                     rec.uuid.clone(),
                 )]);
             }
@@ -1749,6 +1753,60 @@ mod tests {
             g.apply_platform_manifest(&manifest),
             Err(CoreError::ParseError(_))
         ));
+    }
+
+    /// Foundation graph like [`foundation_graph`] but `btn-bg` is a pure `$ref`
+    /// alias to a separate leaf token, instead of carrying a literal `value`.
+    fn foundation_graph_with_alias_target() -> TokenGraph {
+        TokenGraph::from_pairs(vec![
+            (
+                "btn-bg-leaf".into(),
+                PathBuf::from("palette.json"),
+                json!({"name": {"property": "color", "colorFamily": "blue", "scaleIndex": 100}, "value": "#aaa", "uuid": "u-btn-bg-leaf"}),
+            ),
+            (
+                "btn-bg".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "background-color", "component": "button"}, "$ref": "u-btn-bg-leaf", "uuid": "u-btn-bg"}),
+            ),
+        ])
+    }
+
+    #[test]
+    fn manifest_override_alias_type_change_errors() {
+        // btn-bg is a pure $ref alias (no literal `value`); its leaf's value is a
+        // string. Overriding with a number must still violate type safety instead
+        // of silently applying (spectrum-design-data-c3qw).
+        let mut g = foundation_graph_with_alias_target();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "overrides": [{"target": "u-btn-bg", "value": 42}]
+        });
+        assert!(matches!(
+            g.apply_platform_manifest(&manifest),
+            Err(CoreError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn manifest_override_alias_same_type_succeeds() {
+        // Same setup, but the override keeps the same kind (string) — must apply.
+        let mut g = foundation_graph_with_alias_target();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "overrides": [{"target": "u-btn-bg", "value": "#000000"}]
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        let overridden = g
+            .tokens
+            .get("btn-bg")
+            .expect("override replaces shadowed alias token in place");
+        assert_eq!(
+            overridden.raw.get("value").and_then(|v| v.as_str()),
+            Some("#000000")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`resolve_override_targets` (`sdk/core/src/graph.rs`) read a shadowed Foundation
token's `value` field directly to feed the cascade type-safety guard in
`apply_platform_manifest`. That's `None` for pure `$ref` aliases — the majority
of the color corpus — so an override changing an alias-backed token's value
type (e.g. color → dimension) was applied silently, unlike the literal-value
case which correctly rejects a type mismatch.

Fixes it by resolving the shadowed token's effective value through
`TokenRecord::resolve_leaf` (the existing alias-chain walker) before comparing
`json_kind`, so both literal-value and alias-only targets get the same
type-safety enforcement.

## Related Issue

POC finding #2, `GarthDB/spectrum-ios-design-data` FINDINGS.md. Closes
`spectrum-design-data-c3qw`.

## Motivation and Context

Silent type-unsafe overrides on alias targets could corrupt downstream
consumers (e.g. a numeric dimension value landing where a color string was
expected) with no error surfaced at manifest-apply time.

## How Has This Been Tested?

- Added `manifest_override_alias_type_change_errors` — override targeting a
  `$ref` alias with a value of a different kind now errors
  (`CoreError::ParseError`). Fails before this fix (silently applied), passes
  after.
- Added `manifest_override_alias_same_type_succeeds` — same-kind override on an
  alias target still applies normally.
- `moon run sdk:test` — full workspace suite (1305 tests) passes.
- `moon run sdk:lint` — clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
