### PR TITLE
fix(sdk): ship spec schemas in tarball so manifest validation runs

### DIFF
--- a/.changeset/ship-spec-schemas-tarball.md
+++ b/.changeset/ship-spec-schemas-tarball.md
@@ -11,3 +11,6 @@ Ship spec schemas in the GitHub tarball so manifest Layer-1 validation runs (clo
 - **sdk/core/src/manifest.rs**: `apply_configured` now errors when a platform
   manifest is configured but `manifest.schema.json` cannot be located, instead of
   silently skipping Layer 1 validation.
+- **sdk/core/src/data_source/embedded.rs**: the embedded fallback snapshot (used
+  outside a monorepo checkout, with no fetched or local source) now also bakes in
+  `manifest.schema.json`, so the new guard above doesn't newly break that path.

--- a/.changeset/ship-spec-schemas-tarball.md
+++ b/.changeset/ship-spec-schemas-tarball.md
@@ -1,0 +1,13 @@
+---
+"@adobe/design-data-tui": patch
+"@adobe/design-data-wasm": patch
+---
+
+Ship spec schemas in the GitHub tarball so manifest Layer-1 validation runs (closes bead h890.4).
+
+- **sdk/core/src/data_source/fetch.rs**: `should_extract` now retains
+  `packages/design-data-spec/schemas/**`, which was previously dropped during
+  tarball extraction of a fetched foundation.
+- **sdk/core/src/manifest.rs**: `apply_configured` now errors when a platform
+  manifest is configured but `manifest.schema.json` cannot be located, instead of
+  silently skipping Layer 1 validation.

--- a/sdk/core/src/data_source/embedded.rs
+++ b/sdk/core/src/data_source/embedded.rs
@@ -11,9 +11,10 @@
 //! Compile-time embedded Spectrum design-data snapshot.
 //!
 //! The design-data binary carries a pinned copy of `@adobe/spectrum-design-data` (the
-//! canonical cascade-format token corpus) and the matching `@adobe/design-data-spec`
-//! catalog baked in at build time via [`include_dir!`].  On first use outside a monorepo
-//! checkout, [`materialize`] writes the snapshot to a version-namespaced directory under
+//! canonical cascade-format token corpus), its `packages/tokens/schemas` JSON Schemas, and
+//! the single `packages/design-data-spec/schemas/manifest.schema.json` Layer 1 schema, all
+//! baked in at build time via [`include_dir!`] / `include_str!`.  On first use outside a
+//! monorepo checkout, [`materialize`] writes the snapshot to a version-namespaced directory under
 //! the OS cache dir so the disk-based loaders in `graph.rs`, `schema.rs`, and
 //! `discovery.rs` can read it as normal.
 //!
@@ -33,6 +34,9 @@
 //!       schemas/        ← JSON Schema files (+ token-types/ subdir)
 //!       naming-exceptions.json
 //!       manifest.json
+//!     design-data-spec/
+//!       schemas/
+//!         manifest.schema.json  ← Layer 1 platform-manifest schema (only file embedded)
 //!   .complete           ← written last; signals a complete extraction
 //! ```
 //!
@@ -82,6 +86,15 @@ static NAMING_EXCEPTIONS: &str = include_str!(concat!(
 static TOKENS_MANIFEST: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../packages/tokens/manifest.json"
+));
+
+/// Layer 1 platform-manifest JSON Schema, used by `manifest::apply_configured` to
+/// validate a configured platform manifest (`packages/design-data-spec/schemas/manifest.schema.json`).
+/// Embedded as a single file (it has no `$ref`s to sibling schemas) rather than the whole
+/// `design-data-spec` catalog, which is source-authoring tooling not needed at runtime.
+static MANIFEST_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../packages/design-data-spec/schemas/manifest.schema.json"
 ));
 
 // ---------------------------------------------------------------------------
@@ -217,6 +230,10 @@ pub fn materialize_to(root: &Path) -> io::Result<()> {
         &tmp.join("packages/tokens/manifest.json"),
         TOKENS_MANIFEST.as_bytes(),
     )?;
+    write_file(
+        &tmp.join("packages/design-data-spec/schemas/manifest.schema.json"),
+        MANIFEST_SCHEMA.as_bytes(),
+    )?;
 
     // Rename tmp → root.  Atomic on POSIX (same filesystem); non-atomic on Windows
     // cross-device, but the sentinel guarantees correctness regardless.
@@ -327,6 +344,18 @@ mod tests {
             fs::read_to_string(&sentinel).unwrap(),
             "DIRTY",
             "second call should not have overwritten the sentinel"
+        );
+    }
+
+    #[test]
+    fn materialize_writes_manifest_schema() {
+        let (_tmp, root) = temp_root();
+        let schema_path = root.join("packages/design-data-spec/schemas/manifest.schema.json");
+        assert!(schema_path.is_file());
+        let schemas_root = root.join("packages/tokens/schemas");
+        assert_eq!(
+            crate::manifest::locate_manifest_schema(&schemas_root),
+            Some(schema_path)
         );
     }
 

--- a/sdk/core/src/data_source/fetch.rs
+++ b/sdk/core/src/data_source/fetch.rs
@@ -443,6 +443,14 @@ fn should_extract(rel: &Path) -> bool {
                 Some("tokens") | Some("components") | Some("fields") | Some("mode-sets")
             )
         }
+        (Some("packages"), Some("design-data-spec")) => {
+            // schemas/ — Layer-1 spec schemas (manifest.schema.json et al.) used to
+            // validate a fetched foundation. Other subdirs (docs, audits, scripts…) are not needed.
+            let third = components
+                .next()
+                .map(|c| c.as_os_str().to_string_lossy().into_owned());
+            matches!(third.as_deref(), Some("schemas"))
+        }
         _ => false,
     }
 }
@@ -531,13 +539,30 @@ mod tests {
     }
 
     #[test]
-    fn should_not_extract_other_spec_dirs() {
-        assert!(!should_extract(Path::new(
+    fn should_extract_spec_schemas() {
+        assert!(should_extract(Path::new(
+            "packages/design-data-spec/schemas/manifest.schema.json"
+        )));
+        assert!(should_extract(Path::new(
             "packages/design-data-spec/schemas/token.schema.json"
         )));
+        assert!(should_extract(Path::new(
+            "packages/design-data-spec/schemas/value-types/color.schema.json"
+        )));
+        // Other design-data-spec dirs are NOT extracted.
         assert!(!should_extract(Path::new(
             "packages/design-data-spec/rules/rules.yaml"
         )));
+        assert!(!should_extract(Path::new(
+            "packages/design-data-spec/docs/README.md"
+        )));
+        assert!(!should_extract(Path::new(
+            "packages/design-data-spec/package.json"
+        )));
+    }
+
+    #[test]
+    fn should_not_extract_other_spec_dirs() {
         assert!(!should_extract(Path::new(
             "packages/component-schemas/index.js"
         )));

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -59,15 +59,21 @@ pub fn apply_configured(
         ))
     })?;
 
-    if let Some(schema_path) = locate_manifest_schema(&resolved.schemas_root) {
-        let errors = SchemaRegistry::validate_manifest(&manifest, &schema_path)?;
-        if !errors.is_empty() {
-            return Err(CoreError::ParseError(format!(
-                "platform manifest {} failed Layer 1 schema validation:\n  {}",
-                manifest_path.display(),
-                errors.join("\n  ")
-            )));
-        }
+    let schema_path = locate_manifest_schema(&resolved.schemas_root).ok_or_else(|| {
+        CoreError::ParseError(format!(
+            "platform manifest {} is configured but manifest.schema.json could not be \
+             located under {} — Layer 1 validation cannot run",
+            manifest_path.display(),
+            resolved.schemas_root.display()
+        ))
+    })?;
+    let errors = SchemaRegistry::validate_manifest(&manifest, &schema_path)?;
+    if !errors.is_empty() {
+        return Err(CoreError::ParseError(format!(
+            "platform manifest {} failed Layer 1 schema validation:\n  {}",
+            manifest_path.display(),
+            errors.join("\n  ")
+        )));
     }
 
     let outcome = graph.apply_platform_manifest(&manifest)?;
@@ -81,6 +87,13 @@ mod tests {
     use crate::graph::TokenGraph;
     use serde_json::json;
     use std::path::PathBuf;
+
+    /// The real `packages/tokens/schemas` dir, whose ancestry contains
+    /// `packages/design-data-spec/schemas/manifest.schema.json` — mirrors the
+    /// default `schemas_root` an in-repo `ResolvedData` carries.
+    fn repo_schemas_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/schemas")
+    }
 
     fn resolved_with_manifest(manifest_path: PathBuf, schemas_root: PathBuf) -> ResolvedData {
         ResolvedData {
@@ -167,7 +180,7 @@ mod tests {
         .unwrap();
 
         let mut graph = make_graph();
-        let resolved = resolved_with_manifest(manifest_path, dir.path().to_path_buf());
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
         let restrictions = apply_configured(&mut graph, &resolved).unwrap();
         assert!(restrictions.is_empty());
         assert_eq!(graph.tokens.len(), 2);
@@ -192,8 +205,29 @@ mod tests {
         .unwrap();
 
         let mut graph = make_graph();
-        let resolved = resolved_with_manifest(manifest_path, dir.path().to_path_buf());
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
         let err = apply_configured(&mut graph, &resolved).unwrap_err();
         assert!(err.to_string().contains("query parse error"));
+    }
+
+    #[test]
+    fn missing_schema_is_an_error_not_a_silent_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        // schemas_root has no ancestor containing manifest.schema.json.
+        let resolved = resolved_with_manifest(manifest_path, dir.path().to_path_buf());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("could not be located"));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For a **fetched** (remote/CI) foundation, `should_extract` in
`sdk/core/src/data_source/fetch.rs` allowlisted only `packages/tokens/**` and a
few `packages/design-data/**` subdirs when unpacking the GitHub tarball —
`packages/design-data-spec/schemas/**` matched neither branch, so the spec
schemas (including `manifest.schema.json`) were silently dropped during
extraction.

`manifest::apply_configured` is supposed to run Layer-1 manifest schema
validation against that file, but it only did so inside an
`if let Some(schema_path) = locate_manifest_schema(...)` — when the schema
couldn't be located (because extraction dropped it), the whole validation
block was silently skipped and processing continued straight to applying the
manifest. So for any fetched foundation with a configured platform manifest,
Layer-1 validation silently no-op'd.

Two changes:

- **`sdk/core/src/data_source/fetch.rs`**: `should_extract` now retains
  `packages/design-data-spec/schemas/**` (mirroring the existing
  `packages/design-data/**` arm's structure). Other `design-data-spec`
  subdirs (`docs/`, `audits/`, `rules/`, `scripts/`, `spec/`, `node_modules/`)
  are still excluded.
- **`sdk/core/src/manifest.rs`**: `apply_configured` now treats a missing
  `manifest.schema.json` as an error (when a platform manifest is actually
  configured) instead of silently skipping validation. This closes the
  no-op gap directly, independent of extraction — defense in depth.

## Related Issue

Closes bead `spectrum-design-data-h890.4`. Related (not folded in):
`spectrum-design-data-9osr` (schema-validating `extensions.tokens` — a
separate schema-authoring gap).

## Motivation and Context

Layer-1 manifest validation existed but never actually ran against any
fetched/CI foundation, so a malformed or non-conforming platform manifest
could pass through CI undetected.

## How Has This Been Tested?

- Added `should_extract_spec_schemas` in `fetch.rs` asserting the new arm
  extracts `manifest.schema.json` and nested `schemas/**` paths, while sibling
  dirs (`docs/`, `package.json`) are still excluded. Updated the existing
  `should_not_extract_other_spec_dirs` test, which previously asserted the
  buggy (schema-dropping) behavior.
- Added `missing_schema_is_an_error_not_a_silent_skip` in `manifest.rs`
  asserting `apply_configured` now returns an `Err` instead of silently
  proceeding when the schema can't be located.
- Updated two existing `manifest.rs` tests (`include_filter_reduces_token_set`,
  invalid-query test) to point `schemas_root` at the real repo schema dir,
  since they previously relied on schema lookup silently failing.
- `moon run sdk:test` — full workspace passes (1307 tests).
- `moon run sdk:lint` — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Note: the new `apply_configured` guard can newly *reject* a foundation that
configures a platform manifest but has no locatable `manifest.schema.json` —
previously this passed through silently. This is the intended fix.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
