### PR TITLE
feat(cli): add validate-manifest subcommand

### DIFF
--- a/.changeset/validate-manifest-subcommand.md
+++ b/.changeset/validate-manifest-subcommand.md
@@ -1,0 +1,13 @@
+---
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
+---
+
+Add a standalone `validate-manifest` CLI subcommand (closes bead spectrum-design-data-h890.5).
+
+- **sdk/cli/src/main.rs**: new `validate-manifest [PATH] [--manifest FILE] [--format]`
+  subcommand — validates a configured Layer 2 platform manifest (Layer 1 schema shape +
+  apply-time cascade checks) with CI-friendly exit codes, without running a query.
+- **sdk/core/src/data_source/mod.rs**: `CliPathOverrides` gains a `platform_manifest`
+  override so the manifest can be supplied on the command line, winning over the
+  `.design-data.toml` `manifest` key.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -156,6 +156,20 @@ enum Commands {
         #[arg(long)]
         strict: bool,
     },
+    /// Validate the configured Layer 2 platform manifest (Foundation→Platform cascade):
+    /// Layer 1 schema-shape check plus apply-time include/exclude and override-target
+    /// resolution — the same validation `query` enforces, without running a query.
+    ValidateManifest {
+        /// Path to the dataset root (or its tokens/ dir). Default: current directory.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Explicit platform manifest.json (overrides the `.design-data.toml` `manifest` key)
+        #[arg(long, value_name = "FILE")]
+        manifest: Option<PathBuf>,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+    },
     /// Resolve a token value for a given mode set context
     Resolve {
         /// Token property name to resolve (e.g. background-color-default)
@@ -866,6 +880,89 @@ fn run_validate_dataset(path: &Path, opts: ValidateDatasetOpts) -> miette::Resul
         return Ok(ExitCode::from(1));
     }
     Ok(ExitCode::SUCCESS)
+}
+
+/// `design-data validate-manifest [PATH] [--manifest FILE] [--format]` — validate the
+/// configured Layer 2 platform manifest directly, without running a query. Loads the
+/// foundation token graph and runs the same cascade `manifest::apply_configured` applies
+/// during `query`/`resolve`/`convert`: Layer 1 schema-shape validation plus apply-time
+/// checks (include/exclude query parse, override-target resolution).
+///
+/// Exit codes: `0` valid; `1` validation failure (schema violation, unlocatable schema,
+/// bad include/exclude query, missing override target); `2` no platform manifest
+/// configured or supplied via `--manifest`.
+fn run_validate_manifest(
+    explicit_path: Option<&Path>,
+    manifest_override: Option<PathBuf>,
+    format: OutputFormat,
+) -> miette::Result<ExitCode> {
+    let resolved = resolve_data_source(CliPathOverrides {
+        tokens_root: explicit_path.map(Path::to_path_buf),
+        platform_manifest: manifest_override,
+        ..Default::default()
+    })?;
+
+    let Some(manifest_path) = resolved.platform_manifest.clone() else {
+        let message = "no platform manifest configured (set the `.design-data.toml` \
+                        top-level `manifest` key, or pass --manifest <FILE>)";
+        match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::json!({"valid": false, "error": message}));
+            }
+            OutputFormat::Pretty => eprintln!("design-data: error: {message}"),
+        }
+        return Ok(ExitCode::from(2));
+    };
+
+    let path = &resolved.tokens_root;
+    let (mut graph, _index) = TokenGraph::open_cached_with_index_with_catalogs(
+        path,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+
+    match manifest::apply_configured(&mut graph, &resolved) {
+        Ok(_) => {
+            match format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "valid": true,
+                            "manifest": manifest_path.display().to_string(),
+                        })
+                    );
+                }
+                OutputFormat::Pretty => {
+                    println!("design-data: {} is valid", manifest_path.display());
+                }
+            }
+            Ok(ExitCode::SUCCESS)
+        }
+        Err(e) => {
+            match format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "valid": false,
+                            "manifest": manifest_path.display().to_string(),
+                            "error": e.to_string(),
+                        })
+                    );
+                }
+                OutputFormat::Pretty => {
+                    eprintln!(
+                        "design-data: error: {} failed validation:\n{e}",
+                        manifest_path.display()
+                    );
+                }
+            }
+            Ok(ExitCode::from(1))
+        }
+    }
 }
 
 fn run_migrate_verify(
@@ -1918,6 +2015,11 @@ fn main() -> ExitCode {
                 },
             )
         }
+        Commands::ValidateManifest {
+            path,
+            manifest,
+            format,
+        } => run_validate_manifest(path.as_deref(), manifest, format),
         Commands::Resolve {
             property,
             path,

--- a/sdk/cli/tests/cli_manifest.rs
+++ b/sdk/cli/tests/cli_manifest.rs
@@ -62,6 +62,105 @@ fn setup_project(manifest: serde_json::Value) -> tempfile::TempDir {
     project
 }
 
+/// Like [`setup_project`], but the `.design-data.toml` has no top-level `manifest`
+/// key — `manifest.json` is still written to the project root so a test can pass it
+/// explicitly via `--manifest`.
+fn setup_project_without_manifest_key(manifest: serde_json::Value) -> tempfile::TempDir {
+    let project = setup_project(manifest);
+    fs::write(
+        project.path().join(".design-data.toml"),
+        format!(
+            "[source]\ntype = \"path\"\nroot = \"{}\"\n",
+            repo_root().display()
+        ),
+    )
+    .expect("rewrite config without manifest key");
+    project
+}
+
+#[test]
+fn validate_manifest_accepts_valid_manifest() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["component=button"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["validate-manifest", "tokens"])
+        .assert()
+        .success()
+        .stdout(contains("valid"));
+}
+
+#[test]
+fn validate_manifest_rejects_schema_violation() {
+    // Missing required `foundationVersion` → Layer 1 schema validation fails.
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "include": ["component=button"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["validate-manifest", "tokens"])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn validate_manifest_rejects_unparseable_query() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["not-a-valid-query"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["validate-manifest", "tokens"])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn validate_manifest_errors_when_none_configured() {
+    let project = setup_project_without_manifest_key(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["component=button"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["validate-manifest", "tokens"])
+        .assert()
+        .code(2)
+        .stderr(contains("no platform manifest"));
+}
+
+#[test]
+fn validate_manifest_honors_explicit_flag() {
+    let project = setup_project_without_manifest_key(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["component=button"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["validate-manifest", "tokens", "--manifest", "manifest.json"])
+        .assert()
+        .success()
+        .stdout(contains("valid"));
+}
+
 #[test]
 fn query_applies_manifest_include_filter() {
     let project = setup_project(json!({

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -155,6 +155,9 @@ pub struct CliPathOverrides {
     pub relationships: Option<PathBuf>,
     /// Naming-exceptions file (`--exceptions-path`).
     pub exceptions: Option<PathBuf>,
+    /// Explicit platform manifest.json (`--manifest`), overriding the
+    /// `.design-data.toml` top-level `manifest` key.
+    pub platform_manifest: Option<PathBuf>,
 }
 
 /// Records how the paths were determined so callers and diagnostics can report it.
@@ -280,6 +283,15 @@ pub fn resolve(cwd: &Path, overrides: &CliPathOverrides) -> Result<ResolvedData,
     // Carry it down to whichever tier actually resolves.
     let mut carried_manifest: Option<PathBuf> = None;
 
+    // `--manifest` always wins over the config `manifest` key (tier 1 override).
+    let override_manifest = overrides.platform_manifest.as_ref().map(|m| {
+        if m.is_absolute() {
+            m.clone()
+        } else {
+            cwd.join(m)
+        }
+    });
+
     // Tier 2: look for `.design-data.toml` walking up from cwd.
     if let Some((config_path, config)) = find_config(cwd)? {
         // Resolve the optional platform manifest relative to the config file's
@@ -309,7 +321,7 @@ pub fn resolve(cwd: &Path, overrides: &CliPathOverrides) -> Result<ResolvedData,
                     let canonical = abs_root.canonicalize().unwrap_or(abs_root);
                     let mut resolved =
                         from_root(&canonical, overrides, Provenance::Config { config_path });
-                    resolved.platform_manifest = platform_manifest;
+                    resolved.platform_manifest = override_manifest.clone().or(platform_manifest);
                     Ok(resolved)
                 }
                 SourceConfig::Npm { .. }
@@ -320,7 +332,7 @@ pub fn resolve(cwd: &Path, overrides: &CliPathOverrides) -> Result<ResolvedData,
                         config.cache.as_ref().and_then(|c| c.dir.as_deref()),
                         overrides,
                     )?;
-                    resolved.platform_manifest = platform_manifest;
+                    resolved.platform_manifest = override_manifest.clone().or(platform_manifest);
                     Ok(resolved)
                 }
             };
@@ -334,7 +346,7 @@ pub fn resolve(cwd: &Path, overrides: &CliPathOverrides) -> Result<ResolvedData,
     // If we are inside a monorepo checkout probe will find everything; return immediately.
     if is_in_repo(cwd) {
         let mut resolved = probe_cwd(cwd, overrides);
-        resolved.platform_manifest = carried_manifest;
+        resolved.platform_manifest = override_manifest.clone().or(carried_manifest);
         return Ok(resolved);
     }
 
@@ -350,7 +362,7 @@ pub fn resolve(cwd: &Path, overrides: &CliPathOverrides) -> Result<ResolvedData,
                     version: embedded::EMBEDDED_DATA_VERSION,
                 },
             );
-            resolved.platform_manifest = carried_manifest;
+            resolved.platform_manifest = override_manifest.clone().or(carried_manifest);
             return Ok(resolved);
         }
         Err(e) => {


### PR DESCRIPTION
## Description

Adds a standalone `design-data validate-manifest [PATH] [--manifest FILE] [--format]`
CLI subcommand. Today Layer-1 platform-manifest validation only runs as a side effect
of `query` (via `manifest::apply_configured`, hardened in #1366 to error instead of
silently no-op when the schema can't be located). This adds a way to validate a
manifest directly, with a clean exit code, without loading/filtering/running a query.

The new subcommand reuses `manifest::apply_configured` as-is against a real
`TokenGraph`, so it validates both Layer 1 schema shape and apply-time concerns
(include/exclude query parse, override-target resolution) — the same checks `query`
already enforces.

Also adds a `--manifest <FILE>` override (threaded through `CliPathOverrides` /
`data_source::resolve`) so CI can point at a manifest.json directly, winning over the
`.design-data.toml` top-level `manifest` key.

Exit codes: `0` valid · `1` validation failure (schema violation, unlocatable schema,
bad include/exclude query, missing override target) · `2` no platform manifest
configured or supplied.

## Related Issue

Closes bead `spectrum-design-data-h890.5`. Blocks `spectrum-design-data-h890.6`
(reusable validation GitHub Action, built in a follow-up).

## Motivation and Context

A platform CI needs to validate its `manifest.json` on its own, with a clear
pass/fail signal, rather than as an incidental side effect of a `query` invocation.

## How Has This Been Tested?

- `moon run sdk:test` — full workspace suite (1313 tests) passes.
- `moon run sdk:lint` — clippy clean.
- New integration tests in `sdk/cli/tests/cli_manifest.rs`:
  - `validate_manifest_accepts_valid_manifest`
  - `validate_manifest_rejects_schema_violation`
  - `validate_manifest_rejects_unparseable_query`
  - `validate_manifest_errors_when_none_configured`
  - `validate_manifest_honors_explicit_flag`
- Changeset linted: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
