### PR TITLE
fix(ci): give each release binary a distinct asset name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,13 +356,18 @@ jobs:
             --title "design-data CLI ${CLI_VERSION}" \
             --notes "Native CLI binary for \`design-data\` v${CLI_VERSION}. Install via \`cargo install design-data-cli\` or download below." \
             || true
+          # Each platform's artifact directory contains a same-named
+          # `design-data` binary (matrix.platform disambiguates the dir, not
+          # the file) — stage into a separate upload/ dir with distinct,
+          # per-platform names before uploading. Uploading straight from the
+          # download dirs with a shared asset name previously clobbered all
+          # three Unix binaries onto one `design-data` asset.
+          mkdir -p upload
           for platform in darwin-arm64 darwin-x64 linux-x64; do
-            gh release upload "${TAG}" \
-              "design-data-${platform}/design-data" \
-              --clobber
+            cp "design-data-${platform}/design-data" "upload/design-data-${platform}"
           done
-          gh release upload "${TAG}" \
-            "design-data-win32-x64/design-data.exe" \
-            --clobber
+          cp "design-data-win32-x64/design-data.exe" "upload/design-data-win32-x64.exe"
+          ( cd upload && sha256sum * > SHA256SUMS )
+          gh release upload "${TAG}" upload/* --clobber
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Description

The `release` job's "Attach binaries to GitHub Release" step uploaded all
three Unix binaries (`darwin-arm64`, `darwin-x64`, `linux-x64`) to the same
`design-data` asset name with `--clobber`, so each matrix leg silently
overwrote the previous upload — only the last-built arch survived on the
release.

Verified live: `design-data-cli@0.12.0`'s `design-data` asset is a Linux ELF
binary (`file` output), not macOS. Anyone downloading `design-data` on macOS
today gets an unrunnable binary. Windows was unaffected (already had a
distinct `design-data.exe` filename).

Fix: stage each platform's binary into a separate `upload/` directory under
a distinct, per-platform name before uploading, and publish a `SHA256SUMS`
file alongside them.

## Related Issue

Fixes bead `spectrum-design-data-h890.1` (internal beads tracker, not a
GitHub issue). Originally scoped as "evaluate cargo-dist for macOS release
binaries" on the stale premise that no release binaries existed yet — that
work already shipped; this PR fixes the asset-collision bug discovered while
re-scoping it. Unblocks `h890.2` (Homebrew tap), which needs predictable
per-platform asset names + checksums to pin a formula.

## Motivation and Context

Considered migrating to cargo-dist instead of hand-fixing the loop. Rejected:
the existing pipeline's matrix build, per-target Cargo caching, and the
OIDC/proto npm-publish isolation (documented inline in the workflow) all work
correctly — only the upload step was buggy. A cargo-dist migration would
replace a working pipeline to fix a 5-line bug. cargo-dist's main advantages
(SHA256SUMS, install script) are covered here by adding SHA256SUMS directly;
an install script is unnecessary since Homebrew (h890.2) is the intended
macOS install path.

## How Has This Been Tested?

- Confirmed the bug live: `gh release view design-data-cli@0.12.0 --json
  assets --jq '.assets[].name'` returns only `design-data` and
  `design-data.exe` (should be 4 platform binaries).
- Reviewed the edited step for correctness: each `cp` target is distinct, and
  `upload/` is a separate directory from the per-platform download dirs
  (`design-data-<platform>/`) to avoid `cp` copying into an existing
  same-named directory.
- Confirmed `changeset-lint.yml` only triggers on `.changeset/*.md` PR
  changes — this workflow-only change needs no changeset, and
  `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes
  with the existing changesets unaffected.
- Full end-to-end verification requires a real release (next CLI version
  bump): expect 5 assets (4 binaries + SHA256SUMS), and `file
  design-data-darwin-arm64` should report Mach-O arm64, not ELF.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (workflow-only change; verified via live release inspection and manual review, no automated test)
