### PR TITLE
fix(cli): release 0.12.1 for Homebrew distribution

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/sdk/cli/Cargo.toml
+++ b/sdk/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "design-data-cli"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description

Bumps `design-data-cli` to `0.12.1` to trigger a fresh CLI binary release.

## Related Issue

Part of spectrum-design-data-h890.2 (Homebrew tap + formula for `design-data` CLI).

## Motivation and Context

The live `design-data-cli@0.12.0` GitHub Release predates #1368 (asset-name
collision fix): its binaries are published under the old, clobbered names
(a single shared `design-data` asset for all Unix platforms) with no
`SHA256SUMS` file. A Homebrew formula needs per-platform asset names and
published checksums, which only the post-#1368 `release.yml` path produces.
This bump is a prerequisite — it has no functional code changes, only a
version bump to trigger `release.yml`'s "cliReleaseNeeded" build path.

## How Has This Been Tested?

- `cargo check --package design-data-cli` — builds clean at 0.12.1.
- Will verify the resulting GitHub Release (`design-data-cli@0.12.1`) has
  the 5 expected assets (4 binaries + `SHA256SUMS`) once this merges and
  the release workflow runs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
