### PR TITLE
feat(homebrew): add design-data CLI formula with auto-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,3 +371,55 @@ jobs:
           gh release upload "${TAG}" upload/* --clobber
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      # Bumps Formula/design-data.rb (version + macOS sha256s) to match the
+      # release just published above. main requires a PR (branch protection),
+      # so this opens one from a bot branch and merges it immediately rather
+      # than pushing directly — works regardless of whether GH_TOKEN can
+      # bypass protection, since 0 approvals/required checks are configured.
+      - name: Bump Homebrew formula
+        if: needs.build-binaries.result == 'success'
+        shell: bash
+        run: |
+          CLI_VERSION=$(grep '^version' sdk/cli/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          DARWIN_ARM_SHA=$(awk '/design-data-darwin-arm64$/{print $1}' upload/SHA256SUMS)
+          DARWIN_X64_SHA=$(awk '/design-data-darwin-x64$/{print $1}' upload/SHA256SUMS)
+
+          python3 - "$CLI_VERSION" "$DARWIN_ARM_SHA" "$DARWIN_X64_SHA" <<'PYEOF'
+          import re, sys
+          new_version, arm_sha, x64_sha = sys.argv[1], sys.argv[2], sys.argv[3]
+          path = "Formula/design-data.rb"
+          text = open(path).read()
+
+          text = re.sub(r'version "[^"]+"', f'version "{new_version}"', text, count=1)
+          text = re.sub(r'design-data-cli%40[0-9][^/"]*', f'design-data-cli%40{new_version}', text)
+
+          def replace_sha(text, marker, new_sha):
+              pattern = re.compile(r'(url "[^"]*' + re.escape(marker) + r'"\n\s*sha256 ")[0-9a-f]{64}(")')
+              return pattern.sub(lambda m: m.group(1) + new_sha + m.group(2), text)
+
+          text = replace_sha(text, "design-data-darwin-arm64", arm_sha)
+          text = replace_sha(text, "design-data-darwin-x64", x64_sha)
+          open(path, "w").write(text)
+          PYEOF
+
+          ruby -c Formula/design-data.rb
+
+          if git diff --quiet Formula/design-data.rb; then
+            echo "Formula already up to date — skipping bump PR."
+            exit 0
+          fi
+
+          BRANCH="chore/bump-homebrew-formula-${CLI_VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add Formula/design-data.rb
+          git commit -m "chore(homebrew): bump design-data formula to ${CLI_VERSION}"
+          git push origin "${BRANCH}"
+          gh pr create --title "chore(homebrew): bump design-data formula to ${CLI_VERSION}" \
+            --body "Auto-bumped by release.yml for design-data-cli@${CLI_VERSION}." \
+            --base main --head "${BRANCH}"
+          gh pr merge "${BRANCH}" --squash --delete-branch
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,8 +377,10 @@ jobs:
       # so this opens one from a bot branch and merges it immediately rather
       # than pushing directly — works regardless of whether GH_TOKEN can
       # bypass protection, since 0 approvals/required checks are configured.
+      # Restricted to main: this workflow also runs on beta, and a beta-triggered
+      # run would branch off beta and auto-merge a PR into main with no review gate.
       - name: Bump Homebrew formula
-        if: needs.build-binaries.result == 'success'
+        if: needs.build-binaries.result == 'success' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           CLI_VERSION=$(grep '^version' sdk/cli/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')

--- a/Formula/design-data.rb
+++ b/Formula/design-data.rb
@@ -1,0 +1,35 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+class DesignData < Formula
+  desc "CLI for Adobe Spectrum design data and token tooling"
+  homepage "https://github.com/adobe/spectrum-design-data"
+  version "0.12.1"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/adobe/spectrum-design-data/releases/download/design-data-cli%400.12.1/design-data-darwin-arm64"
+      sha256 "f2709e708c39b1704403dfe81de3403843d4fd0161c3031edfe421b6f48df585"
+    end
+    on_intel do
+      url "https://github.com/adobe/spectrum-design-data/releases/download/design-data-cli%400.12.1/design-data-darwin-x64"
+      sha256 "23a01014092cfb5bdd4dbf38a6d90a6d4f4eb5cf0b077ab2d20f4a1244f984ca"
+    end
+  end
+
+  def install
+    bin.install Dir["design-data-*"].first => "design-data"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/design-data --version")
+  end
+end


### PR DESCRIPTION
## Description

Stands up a Homebrew formula for the `design-data` CLI (macOS only for now)
and wires the formula version/checksums to auto-bump on future CLI releases.

## Related Issue

Closes spectrum-design-data-h890.2 (Homebrew tap + formula for `design-data`
CLI).

## Motivation and Context

Implementation engineers want `brew install`/`brew upgrade` for the native
CLI instead of manually downloading GitHub Release binaries. The formula
lives in this repo (`Formula/design-data.rb`) rather than a separate tap
repo, so users tap via `adobe/spectrum-design-data` directly:

```
brew tap adobe/spectrum-design-data https://github.com/adobe/spectrum-design-data
brew install adobe/spectrum-design-data/design-data
```

The formula targets `design-data-cli@0.12.1` — the first release published
after #1368 fixed the asset-name collision (the prior `0.12.0` release
clobbered all three Unix binaries onto a single `design-data` asset with no
`SHA256SUMS`, so it couldn't back a correct formula).

For the auto-bump mechanism: `design-data-cli` is versioned independently of
changesets (`sdk/scripts/sync-cargo-version.mjs`), so a changeset can't
drive this. Instead, `release.yml`'s existing "Attach binaries to GitHub
Release" step — which already computes `SHA256SUMS` and knows the version —
gets a follow-on step that rewrites the formula and opens+merges a small bot
PR. A PR (rather than a direct push) is used because `main` requires one via
branch protection; opening and immediately squash-merging it works
regardless of whether the release token can bypass that restriction, since
0 approvals and no required status checks are configured.

## How Has This Been Tested?

- `brew style Formula/design-data.rb` — clean, no offenses.
- `brew audit --strict` (via a local `file://` tap) — clean.
- Real end-to-end install: tapped this repo locally, ran
  `brew install adobe/spectrum-design-data/design-data`, confirmed
  `design-data --version` prints `design-data 0.12.1`, and `brew test`
  passed.
- Dry-ran the `release.yml` bump step's Python substitution logic locally
  against a copy of the formula with fake checksums — version, download
  URLs, and both macOS `sha256` values updated correctly; `ruby -c` syntax
  check passes.
- Validated `release.yml` YAML parses (`ruby -ryaml -e 'YAML.load_file(...)'`).
- The real auto-bump path (open+merge a bot PR from within `release.yml`)
  will exercise for real on the next CLI release; will confirm then.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
