### PR TITLE
feat(ci): add reusable design-data validation composite action

### DIFF
--- a/.github/actions/validate/README.md
+++ b/.github/actions/validate/README.md
@@ -1,0 +1,49 @@
+# Validate design-data
+
+Reusable composite Action for platform-manifest repos. Installs the
+`design-data` CLI, validates the dataset and platform manifest, and checks for
+foundation drift (the pinned `foundationVersion` vs. the foundation's latest
+tag).
+
+## Usage
+
+```yaml
+name: Validate
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: adobe/spectrum-design-data/.github/actions/validate@main
+        with:
+          dataset-path: .
+          manifest: manifest.json
+```
+
+## Inputs
+
+| Input                   | Default                      | Description                                            |
+| ----------------------- | ---------------------------- | ------------------------------------------------------ |
+| `dataset-path`          | `.`                          | Path passed to `validate-dataset`/`validate-manifest`  |
+| `manifest`              | `manifest.json`              | Platform manifest file                                 |
+| `cli-version`           | `latest`                     | `design-data-cli` release version to install           |
+| `install-method`        | `release`                    | `release` (direct binary download) or `homebrew`       |
+| `foundation-repo`       | `adobe/spectrum-design-data` | Repo checked for foundation drift                      |
+| `foundation-tag-prefix` | `@adobe/spectrum-tokens@`    | Tag prefix identifying foundation release tags         |
+| `drift-mode`            | `warn`                       | `warn` (annotate) or `fail` (block the PR) on drift    |
+| `open-issue`            | `false`                      | Open a "foundation moved" issue when drift is detected |
+| `github-token`          | `${{ github.token }}`        | Used for release/tag lookups and issue creation        |
+
+## Outputs
+
+| Output                      | Description                                           |
+| --------------------------- | ----------------------------------------------------- |
+| `dataset-valid`             | `validate-dataset` result (`true`/`false`)            |
+| `manifest-valid`            | `validate-manifest` result (`true`/`false`)           |
+| `foundation-drift`          | Whether the pinned version is behind (`true`/`false`) |
+| `pinned-foundation-version` | `foundationVersion` from the manifest                 |
+| `latest-foundation-version` | Latest matching tag in `foundation-repo`              |

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -1,0 +1,185 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+name: Validate design-data
+description: >
+  Installs the design-data CLI and validates a platform repo's dataset and
+  manifest against the Spectrum foundation, including a foundation-drift
+  check against the foundation's latest tag.
+
+inputs:
+  dataset-path:
+    description: "Path to the dataset root passed to validate-dataset/validate-manifest"
+    required: false
+    default: "."
+  manifest:
+    description: "Path to the platform manifest.json"
+    required: false
+    default: "manifest.json"
+  cli-version:
+    description: "design-data-cli release version to install, or 'latest'"
+    required: false
+    default: "latest"
+  install-method:
+    description: "How to install the CLI: 'release' (direct binary download) or 'homebrew'"
+    required: false
+    default: "release"
+  foundation-repo:
+    description: "owner/repo of the Spectrum foundation to check for drift"
+    required: false
+    default: "adobe/spectrum-design-data"
+  foundation-tag-prefix:
+    description: "Tag prefix identifying foundation release tags in foundation-repo"
+    required: false
+    default: "@adobe/spectrum-tokens@"
+  drift-mode:
+    description: "'warn' (annotate only) or 'fail' (block the PR) on foundation drift"
+    required: false
+    default: "warn"
+  open-issue:
+    description: "Open a 'foundation moved' issue when drift is detected"
+    required: false
+    default: "false"
+  github-token:
+    description: "GitHub token for release lookups, tag lookups, and issue creation"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  dataset-valid:
+    description: "Whether validate-dataset passed (true/false)"
+    value: ${{ steps.validate-dataset.outputs.valid }}
+  manifest-valid:
+    description: "Whether validate-manifest passed (true/false)"
+    value: ${{ steps.validate-manifest.outputs.valid }}
+  foundation-drift:
+    description: "Whether the pinned foundationVersion is behind the foundation's latest tag"
+    value: ${{ steps.drift.outputs.drift }}
+  pinned-foundation-version:
+    description: "foundationVersion pinned in the manifest"
+    value: ${{ steps.drift.outputs.pinned }}
+  latest-foundation-version:
+    description: "Latest foundation version found in foundation-repo"
+    value: ${{ steps.drift.outputs.latest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install design-data CLI (release binary)
+      if: inputs.install-method == 'release'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        version="${{ inputs.cli-version }}"
+        if [[ "$version" == "latest" ]]; then
+          version=$(gh release list --repo adobe/spectrum-design-data \
+            --limit 50 --json tagName \
+            --jq '.[].tagName | select(startswith("design-data-cli@"))' \
+            | sed 's/^design-data-cli@//' | sort -V | tail -1)
+        fi
+        tag="design-data-cli@${version}"
+        mkdir -p "$RUNNER_TEMP/design-data-cli"
+        curl -fsSL \
+          "https://github.com/adobe/spectrum-design-data/releases/download/${tag//@/%40}/design-data-linux-x64" \
+          -o "$RUNNER_TEMP/design-data-cli/design-data"
+        chmod +x "$RUNNER_TEMP/design-data-cli/design-data"
+        echo "$RUNNER_TEMP/design-data-cli" >> "$GITHUB_PATH"
+
+    - name: Install design-data CLI (Homebrew)
+      if: inputs.install-method == 'homebrew'
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew tap adobe/spectrum-design-data https://github.com/adobe/spectrum-design-data
+        brew install adobe/spectrum-design-data/design-data
+
+    - name: Validate dataset
+      id: validate-dataset
+      shell: bash
+      run: |
+        set +e
+        design-data validate-dataset "${{ inputs.dataset-path }}" --strict --format json \
+          | tee /tmp/validate-dataset.json
+        code=$?
+        set -e
+        echo "valid=$([[ $code -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        exit $code
+
+    - name: Validate manifest
+      id: validate-manifest
+      shell: bash
+      run: |
+        set +e
+        design-data validate-manifest "${{ inputs.dataset-path }}" \
+          --manifest "${{ inputs.manifest }}" --format json \
+          | tee /tmp/validate-manifest.json
+        code=$?
+        set -e
+        echo "valid=$([[ $code -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        exit $code
+
+    - name: Check foundation drift
+      id: drift
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        pinned=$(jq -r '.foundationVersion' "${{ inputs.manifest }}")
+        prefix="${{ inputs.foundation-tag-prefix }}"
+        latest=$(gh api "repos/${{ inputs.foundation-repo }}/tags" --paginate \
+          --jq '.[].name | select(startswith("'"$prefix"'"))' \
+          | sed "s|^${prefix}||" | sort -V | tail -1)
+
+        echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+        echo "latest=$latest" >> "$GITHUB_OUTPUT"
+
+        if [[ -z "$latest" || "$pinned" == "$latest" ]]; then
+          echo "drift=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "drift=true" >> "$GITHUB_OUTPUT"
+        message="Foundation moved: manifest pins ${prefix}${pinned}, latest is ${prefix}${latest}"
+        if [[ "${{ inputs.drift-mode }}" == "fail" ]]; then
+          echo "::error::${message}"
+          exit 1
+        else
+          echo "::warning::${message}"
+        fi
+
+    - name: Open foundation-moved issue
+      if: inputs.open-issue == 'true' && steps.drift.outputs.drift == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        title="Foundation moved: ${{ steps.drift.outputs.pinned }} → ${{ steps.drift.outputs.latest }}"
+        existing=$(gh issue list --search "in:title \"${title}\"" --state open --json title \
+          --jq 'length')
+        if [[ "$existing" -gt 0 ]]; then
+          echo "Issue already open for this drift, skipping."
+          exit 0
+        fi
+        gh issue create --title "$title" --body "$(cat <<EOF
+        The foundation dataset (\`${{ inputs.foundation-repo }}\`) has moved past the
+        version pinned in \`${{ inputs.manifest }}\`.
+
+        - Pinned: \`${{ steps.drift.outputs.pinned }}\`
+        - Latest: \`${{ steps.drift.outputs.latest }}\`
+
+        Review the foundation changelog and update \`foundationVersion\` in
+        \`${{ inputs.manifest }}\` once the platform overrides have been checked
+        against the new release.
+        EOF
+        )"

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -99,8 +99,18 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        version="${{ inputs.cli-version }}"
         brew tap adobe/spectrum-design-data https://github.com/adobe/spectrum-design-data
-        brew install adobe/spectrum-design-data/design-data
+        if [[ "$version" == "latest" ]]; then
+          brew install adobe/spectrum-design-data/design-data
+        else
+          # brew extract walks the tap's git history (rewritten on every release
+          # by the auto-bump step in release.yml) to reconstruct the formula as
+          # it was at the pinned version.
+          brew tap-new --no-git homebrew/local || true
+          brew extract --version="$version" adobe/spectrum-design-data/design-data homebrew/local
+          brew install "homebrew/local/design-data@${version}"
+        fi
 
     - name: Validate dataset
       id: validate-dataset
@@ -109,7 +119,7 @@ runs:
         set +e
         design-data validate-dataset "${{ inputs.dataset-path }}" --strict --format json \
           | tee /tmp/validate-dataset.json
-        code=$?
+        code=${PIPESTATUS[0]}
         set -e
         echo "valid=$([[ $code -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
         exit $code
@@ -122,7 +132,7 @@ runs:
         design-data validate-manifest "${{ inputs.dataset-path }}" \
           --manifest "${{ inputs.manifest }}" --format json \
           | tee /tmp/validate-manifest.json
-        code=$?
+        code=${PIPESTATUS[0]}
         set -e
         echo "valid=$([[ $code -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
         exit $code


### PR DESCRIPTION
## Description

Adds a reusable composite GitHub Action at `.github/actions/validate` that platform-manifest repos can drop into their PR-gating workflows via:

```yaml
uses: adobe/spectrum-design-data/.github/actions/validate@main
```

It:
- Installs the `design-data` CLI (direct release binary by default, or Homebrew via `install-method: homebrew`)
- Runs `design-data validate-dataset --strict --format json`
- Runs `design-data validate-manifest --format json`
- Checks the manifest's pinned `foundationVersion` against the foundation repo's latest matching tag, `warn`ing (default) or `fail`ing the PR on drift
- Optionally opens a de-duped "foundation moved" issue when drift is detected (`open-issue: true`, off by default)

This is the capstone of WS2 in `SPECTRUM_MULTIPLATFORM_SDK_STRATEGY.md` — the CLI is now distributed (Homebrew tap, release binaries — #1370) and `validate-manifest` exists as a standalone subcommand (#1367); this action wires both into a turnkey validation gate for platform repos.

## Related Issue

Closes bead `spectrum-design-data-h890.6` (epic `spectrum-design-data-h890`, initiative `DNA-1741`).

## Motivation and Context

Platform teams adopting the manifest-repo model need CI that machine-checks manifest correctness and flags foundation drift, rather than relying on manual review.

## How Has This Been Tested?

- Parsed `action.yml` with `js-yaml` to confirm valid composite-action syntax.
- Ran `design-data validate-dataset`/`validate-manifest` locally (debug build) against real dataset/manifest fixtures to confirm the JSON shapes and exit codes (0/1/2) the action's `set +e; ...; exit $code` steps rely on.
- Dry-ran the foundation-drift `sed`/`sort -V` version-comparison logic against sample tag lists — caught and fixed a `sed` delimiter bug (`/` in `@adobe/spectrum-tokens@` collided with the default `/` delimiter; switched to `|`).
- No `moon run test` impact — pure YAML/shell, no tracked package changed.

## Screenshots (if appropriate):

N/A — CI Action, no UI.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation (added `.github/actions/validate/README.md`)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes (composite action; verified via manual local dry-run against CLI fixtures, see above)
- [x] All new and existing tests passed