### PR TITLE
docs(cli): document Homebrew/cargo/release install methods

### DIFF
--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -18,6 +18,9 @@ You are a designer or engineer on a product team. Spectrum is your design system
 
 ### Common tasks
 
+> Don't have the CLI yet? See [installing `design-data`](../sdk/cli/README.md#install)
+> — Homebrew (macOS), `cargo install design-data-cli`, or a GitHub Release download.
+
 **See what a component declares:**
 
 ```bash

--- a/packages/design-data-spec/spec/agent-surface.md
+++ b/packages/design-data-spec/spec/agent-surface.md
@@ -66,7 +66,7 @@ An agent loop benefits from a small, structural overview at session start so tha
 
 ### CLI
 
-The reference CLI is `design-data` (see [`sdk/cli/`](../../../sdk/cli/)). RFC-C extends the existing subcommands (`validate`, `resolve`, `diff`, `query`) with:
+The reference CLI is `design-data` (see [`sdk/cli/`](../../../sdk/cli/)). Install it via Homebrew (macOS), `cargo install design-data-cli`, or a [GitHub Release download](https://github.com/adobe/spectrum-design-data/releases) — see the [`sdk/cli/` README](../../../sdk/cli/README.md#install). RFC-C extends the existing subcommands (`validate`, `resolve`, `diff`, `query`) with:
 
 * `design-data primer [PATH]` — emit the [Session primer](#session-primer) payload.
 * `design-data suggest "<intent>" [--property <hint>]` — invoke `suggest_token`.

--- a/sdk/cli/README.md
+++ b/sdk/cli/README.md
@@ -4,13 +4,27 @@ CLI tool for working with [Adobe Spectrum](https://spectrum.adobe.com) design to
 
 ## Install
 
+**Homebrew (macOS):**
+
 ```sh
-npm install -g @adobe/design-data
-# or use without installing:
-npx @adobe/design-data <command>
+brew tap adobe/spectrum-design-data https://github.com/adobe/spectrum-design-data
+brew install adobe/spectrum-design-data/design-data
 ```
 
-Requires Node.js ≥ 20.12. No Rust toolchain needed — the CLI binary is included via platform-specific optional dependencies.
+**Cargo (any platform with a Rust toolchain):**
+
+```sh
+cargo install design-data-cli
+```
+
+**Manual download (Linux/Windows, or any platform):**
+
+Grab the binary for your platform from the latest
+[`design-data-cli@*` GitHub Release](https://github.com/adobe/spectrum-design-data/releases),
+`chmod +x` it (Unix), and put it on your `PATH`. Checksums are in `SHA256SUMS`.
+
+> The `@adobe/design-data` npm package is JS/wasm library glue, not the CLI —
+> `npm install -g @adobe/design-data` does **not** install the `design-data` command.
 
 ## Usage
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Documents the new `design-data` CLI install methods — Homebrew, `cargo install`, and
GitHub Release download — and clarifies that the npm `@adobe/design-data` package is
JS/wasm library glue, not the CLI itself.

- **sdk/cli/README.md**: replace the npm-only install block with Homebrew tap,
  `cargo install design-data-cli`, and manual release-binary download instructions.
- **docs/scenarios.md**: add a callout linking to the install instructions.
- **packages/design-data-spec/spec/agent-surface.md**: update the CLI reference to
  point at the new install methods.

## Related Issue

Follow-up to #1370, which shipped the Homebrew formula and release workflow but did
not update the install docs.

## Motivation and Context

#1370 merged the Homebrew formula and auto-bump release workflow, so `design-data`
is now installable without Node.js. The docs still only mentioned `npm install -g`,
which is misleading — that package is the JS/wasm glue, not the CLI binary.

## How Has This Been Tested?

- Verified the `#install` anchor referenced from `docs/scenarios.md` and
  `agent-surface.md` resolves in `sdk/cli/README.md`.
- Docs-only change; no changeset needed.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
