### PR TITLE
fix(sdk): schema-validate extensions.tokens in platform manifest

### DIFF
--- a/.changeset/manifest-extensions-tokens-schema.md
+++ b/.changeset/manifest-extensions-tokens-schema.md
@@ -1,7 +1,7 @@
 ---
-"@adobe/design-data-spec": patch
-"@adobe/design-data-tui": patch
-"@adobe/design-data-wasm": patch
+"@adobe/design-data-spec": minor
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
 ---
 
 Schema-validate `extensions.tokens` in the platform manifest, closing a gap

--- a/.changeset/manifest-extensions-tokens-schema.md
+++ b/.changeset/manifest-extensions-tokens-schema.md
@@ -1,0 +1,18 @@
+---
+"@adobe/design-data-spec": patch
+"@adobe/design-data-tui": patch
+"@adobe/design-data-wasm": patch
+---
+
+Schema-validate `extensions.tokens` in the platform manifest, closing a gap
+where malformed extension tokens (bad `$schema`, missing `name`) previously
+failed silently or downstream instead of at manifest-validation time (closes
+bead spectrum-design-data-9osr).
+
+- **packages/design-data-spec/schemas/manifest.schema.json**: `extensions.tokens`
+  now references `cascade-file.schema.json`, so entries must match the same
+  cascade token shape as `token.schema.json`.
+- **sdk/core/src/schema.rs**: `SchemaRegistry::validate_manifest` now registers
+  sibling schemas (`token.schema.json`, `cascade-file.schema.json`,
+  `value-types/*`) via `collect_schema_resources`, so the new cross-schema
+  `$ref` resolves offline instead of erroring.

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -87,6 +87,10 @@
       "type": "object",
       "description": "Platform-local tokens, mode sets, and formatting rules.",
       "properties": {
+        "tokens": {
+          "$ref": "cascade-file.schema.json",
+          "description": "Platform-local token definitions, in cascade-format (same shape as a cascade token file)."
+        },
         "formatting": {
           "type": "object",
           "description": "Rules for serializing structured name objects into platform-specific token name strings.",

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -15,7 +15,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use jsonschema::{Draft, Registry, Resource, Validator};
+use jsonschema::{Draft, Registry, Resource, ValidationOptions, Validator};
 use serde_json::Value;
 
 use crate::CoreError;
@@ -120,29 +120,10 @@ impl SchemaRegistry {
         manifest: &Value,
         manifest_schema_path: &Path,
     ) -> Result<Vec<String>, CoreError> {
-        let text = fs::read_to_string(manifest_schema_path)?;
-        let schema: Value = serde_json::from_str(&text)?;
-
-        // Register sibling schemas (token.schema.json, cascade-file.schema.json,
-        // value-types/*) so the `extensions.tokens` cross-schema `$ref` resolves
-        // offline instead of erroring or hitting the network.
-        let mut resources: Vec<(String, Resource)> = Vec::new();
-        if let Some(dir) = manifest_schema_path.parent() {
-            collect_schema_resources(dir, &mut resources)?;
-            let value_types = dir.join("value-types");
-            if value_types.is_dir() {
-                collect_schema_resources(&value_types, &mut resources)?;
-            }
-        }
-
-        let mut builder = jsonschema::options().with_draft(Draft::Draft202012);
-        if !resources.is_empty() {
-            let registry = Registry::try_from_resources(resources)?;
-            builder = builder.with_registry(registry);
-        }
-        let validator = builder
-            .build(&schema)
-            .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
+        let validator = build_schema_validator(
+            manifest_schema_path,
+            jsonschema::options().with_draft(Draft::Draft202012),
+        )?;
         Ok(validator
             .iter_errors(manifest)
             .map(|e| e.to_string())
@@ -165,28 +146,10 @@ impl SchemaRegistry {
         value: &Value,
         schema_path: &Path,
     ) -> Result<Vec<String>, CoreError> {
-        let text = fs::read_to_string(schema_path)?;
-        let schema: Value = serde_json::from_str(&text)?;
-
-        // Register sibling schemas so `$ref`s by canonical `$id` resolve offline.
-        let mut resources: Vec<(String, Resource)> = Vec::new();
-        if let Some(dir) = schema_path.parent() {
-            collect_schema_resources(dir, &mut resources)?;
-            let value_types = dir.join("value-types");
-            if value_types.is_dir() {
-                collect_schema_resources(&value_types, &mut resources)?;
-            }
-        }
-
-        let mut builder = jsonschema::options();
-        if !resources.is_empty() {
-            let registry = Registry::try_from_resources(resources)?;
-            builder = builder.with_registry(registry);
-        }
-        let validator = builder
-            .should_validate_formats(true)
-            .build(&schema)
-            .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
+        let validator = build_schema_validator(
+            schema_path,
+            jsonschema::options().should_validate_formats(true),
+        )?;
         Ok(validator
             .iter_errors(value)
             .map(|e| e.to_string())
@@ -207,6 +170,36 @@ impl SchemaRegistry {
             token_file_schema_url: String::new(),
         }
     }
+}
+
+/// Read `schema_path`, register sibling `*.json` schemas in its directory (and a
+/// `value-types/` subdirectory, if present) by their `$id` so cross-schema `$ref`s
+/// resolve offline, then compile a [`Validator`] with `options` (draft, format
+/// validation, etc. are the caller's choice — this only wires up the registry).
+fn build_schema_validator(
+    schema_path: &Path,
+    options: ValidationOptions,
+) -> Result<Validator, CoreError> {
+    let text = fs::read_to_string(schema_path)?;
+    let schema: Value = serde_json::from_str(&text)?;
+
+    let mut resources: Vec<(String, Resource)> = Vec::new();
+    if let Some(dir) = schema_path.parent() {
+        collect_schema_resources(dir, &mut resources)?;
+        let value_types = dir.join("value-types");
+        if value_types.is_dir() {
+            collect_schema_resources(&value_types, &mut resources)?;
+        }
+    }
+
+    let mut builder = options;
+    if !resources.is_empty() {
+        let registry = Registry::try_from_resources(resources)?;
+        builder = builder.with_registry(registry);
+    }
+    builder
+        .build(&schema)
+        .map_err(|e| CoreError::SchemaBuild(e.to_string()))
 }
 
 /// Read every `*.json` schema file in `dir`, pairing each by its `$id` with a
@@ -312,5 +305,26 @@ mod tests {
         });
         let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
         assert!(!errors.is_empty());
+    }
+
+    // build_schema_validator wires the *entire* schemas/ directory (plus value-types/)
+    // into one registry, keyed by $id — so a future schema with a colliding $id would
+    // silently shadow another rather than erroring, breaking validation for whichever
+    // schema loses. This guards that: if it ever fires, narrow build_schema_validator's
+    // resource collection to only the files each caller actually depends on instead of
+    // the whole directory.
+    #[test]
+    fn schemas_directory_has_no_duplicate_ids() {
+        let dir = manifest_schema_path().parent().unwrap().to_path_buf();
+        let mut resources = Vec::new();
+        collect_schema_resources(&dir, &mut resources).unwrap();
+        let value_types = dir.join("value-types");
+        if value_types.is_dir() {
+            collect_schema_resources(&value_types, &mut resources).unwrap();
+        }
+        let mut seen = std::collections::HashSet::new();
+        for (id, _) in &resources {
+            assert!(seen.insert(id.clone()), "duplicate schema $id: {id}");
+        }
     }
 }

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -122,8 +122,25 @@ impl SchemaRegistry {
     ) -> Result<Vec<String>, CoreError> {
         let text = fs::read_to_string(manifest_schema_path)?;
         let schema: Value = serde_json::from_str(&text)?;
-        let validator = jsonschema::options()
-            .with_draft(Draft::Draft202012)
+
+        // Register sibling schemas (token.schema.json, cascade-file.schema.json,
+        // value-types/*) so the `extensions.tokens` cross-schema `$ref` resolves
+        // offline instead of erroring or hitting the network.
+        let mut resources: Vec<(String, Resource)> = Vec::new();
+        if let Some(dir) = manifest_schema_path.parent() {
+            collect_schema_resources(dir, &mut resources)?;
+            let value_types = dir.join("value-types");
+            if value_types.is_dir() {
+                collect_schema_resources(&value_types, &mut resources)?;
+            }
+        }
+
+        let mut builder = jsonschema::options().with_draft(Draft::Draft202012);
+        if !resources.is_empty() {
+            let registry = Registry::try_from_resources(resources)?;
+            builder = builder.with_registry(registry);
+        }
+        let validator = builder
             .build(&schema)
             .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
         Ok(validator
@@ -258,6 +275,40 @@ mod tests {
             "specVersion": "1.0.0-draft",
             "foundationVersion": "1.0.0",
             "bogusKey": true
+        });
+        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn validate_manifest_accepts_valid_extensions_tokens() {
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "tokens": [
+                    {
+                        "name": {"property": "color"},
+                        "value": "#000"
+                    }
+                ]
+            }
+        });
+        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
+        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+    }
+
+    #[test]
+    fn validate_manifest_rejects_malformed_extensions_tokens() {
+        // Missing the required `name` and has neither `value` nor `$ref`.
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "tokens": [
+                    {"bogus": true}
+                ]
+            }
         });
         let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
         assert!(!errors.is_empty());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`extensions.tokens` in the Platform Manifest was consumed by `TokenGraph::apply_platform_manifest`
with no schema validation — `manifest.schema.json`'s `extensions` object only declared a
`formatting` sub-schema, so a malformed extension token (bad `$schema`, missing `name`) failed
silently or downstream instead of at manifest-validation time.

- **`packages/design-data-spec/schemas/manifest.schema.json`**: `extensions.tokens` now `$ref`s
  `cascade-file.schema.json` — reusing the existing cascade-token-array schema rather than
  duplicating token-shape rules (`extensions.additionalProperties` stays `true`; only the `tokens`
  key itself is now constrained).
- **`sdk/core/src/schema.rs`**: `SchemaRegistry::validate_manifest` now registers sibling schemas
  (`token.schema.json`, `cascade-file.schema.json`, `value-types/*`) via the existing
  `collect_schema_resources` helper before compiling the validator — the same pattern
  `validate_value_against_schema_file` already used — so the new cross-schema `$ref` resolves
  offline instead of erroring.

## Related Issue

Closes bd `spectrum-design-data-9osr` — POC finding #4 from the iOS platform-manifest cascade POC
(GarthDB/spectrum-ios-design-data `FINDINGS.md`), also called out as an open gap in
[adobe/spectrum-design-data#1375](https://github.com/adobe/spectrum-design-data/discussions/1375).

## Motivation and Context

Part of the Nov 20 platform-adoption alignment work (bd `spectrum-design-data-b17`). A platform
author hand-authoring `extensions.tokens` currently gets no feedback if an entry is malformed —
this closes that gap so schema violations surface at `apply_configured`'s existing Layer 1
validation step, before the cascade ever applies the manifest.

## How Has This Been Tested?

- Two new unit tests in `sdk/core/src/schema.rs`:
  - `validate_manifest_accepts_valid_extensions_tokens` — a manifest with a well-formed
    `extensions.tokens` entry passes.
  - `validate_manifest_rejects_malformed_extensions_tokens` — an entry with neither `name` nor
    `value`/`$ref` produces schema errors.
- `moon run sdk:test` — 1315 passed, 1 skipped (includes the two new tests; no regressions).
- `moon run sdk:lint` — clean, no clippy warnings.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — 0 warnings, 0 errors.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
