### PR TITLE
feat(ios-override-importer): import font-size override rows

### DIFF
--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -576,8 +576,11 @@ fn run_decompose_legacy_name(slug: &str, component_hint: Option<&str>) -> miette
 }
 
 /// `design-data dump-legacy-keys [PATH]` — prints a JSON array of
-/// `{legacyKey, uuid, colorScheme?, contrast?}`, one entry per token (not
-/// deduped by legacyKey, unlike `TokenGraph::legacy_name_index`).
+/// `{legacyKey, uuid, colorScheme?, contrast?, scale?}`, one entry per token
+/// (not deduped by legacyKey, unlike `TokenGraph::legacy_name_index`).
+/// `scale` disambiguates scale-set members (e.g. `font-size-100` has both a
+/// `mobile` and `desktop` uuid under the same legacy key) — see
+/// spectrum-design-data-h890.15.
 fn run_dump_legacy_keys(explicit_path: Option<&Path>) -> miette::Result<ExitCode> {
     let resolved = resolve_data_source(CliPathOverrides {
         tokens_root: explicit_path.map(Path::to_path_buf),
@@ -602,11 +605,13 @@ fn run_dump_legacy_keys(explicit_path: Option<&Path>) -> miette::Result<ExitCode
         };
         let color_scheme = name_val.get("colorScheme").and_then(|v| v.as_str());
         let contrast = name_val.get("contrast").and_then(|v| v.as_str());
+        let scale = name_val.get("scale").and_then(|v| v.as_str());
         out.push(serde_json::json!({
             "legacyKey": legacy_key,
             "uuid": uuid,
             "colorScheme": color_scheme,
             "contrast": contrast,
+            "scale": scale,
         }));
     }
     println!("{}", serde_json::to_string_pretty(&out).into_diagnostic()?);

--- a/tools/ios-override-importer/src/emit-manifest.js
+++ b/tools/ios-override-importer/src/emit-manifest.js
@@ -9,7 +9,7 @@
 // governing permissions and limitations under the License.
 
 import { categorizeRow } from "./categorize.js";
-import { resolveTarget } from "./resolve-target.js";
+import { resolveTarget, splitAliases } from "./resolve-target.js";
 import { findTokenUuid, loadLegacyKeyIndex } from "./find-token-uuid.js";
 import { isFontSizeValue, parseFontSize } from "./parse-scale.js";
 
@@ -38,14 +38,6 @@ function emitFontSizeRow(row, legacyKeyIndex) {
     }
   }
   return { overrides: [], extensionTokens: [], unresolved: candidates };
-}
-
-function splitAliases(aliases) {
-  if (!aliases) return [];
-  return aliases
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
 }
 
 /**

--- a/tools/ios-override-importer/src/emit-manifest.js
+++ b/tools/ios-override-importer/src/emit-manifest.js
@@ -11,9 +11,42 @@
 import { categorizeRow } from "./categorize.js";
 import { resolveTarget } from "./resolve-target.js";
 import { findTokenUuid, loadLegacyKeyIndex } from "./find-token-uuid.js";
+import { isFontSizeValue, parseFontSize } from "./parse-scale.js";
 
 const COLOR_SCHEMA =
   "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json";
+
+/**
+ * Resolve a font-size row directly by uuid existence at the `mobile` scale
+ * member, scanning `[Token Name, ...Aliases]` in order — NOT via
+ * `resolveTarget`'s structural decompose. A component name like
+ * `action-bar-counter-font-size` roundtrips through `decompose-legacy-name`
+ * just fine (it's a valid property slug), which would resolve to itself and
+ * shadow the real `font-size-100` alias it points to. Existence in the
+ * legacy-key index (built from the same tokens the CSV was generated
+ * against) is the reliable signal here instead.
+ */
+function emitFontSizeRow(row, legacyKeyIndex) {
+  const candidates = [row["Token Name"], ...splitAliases(row.Aliases)].filter(
+    Boolean,
+  );
+  const value = parseFontSize(row["New Value"]);
+  for (const slug of candidates) {
+    const uuid = findTokenUuid(legacyKeyIndex, slug, { scale: "mobile" });
+    if (uuid) {
+      return { overrides: [{ target: uuid, value }], extensionTokens: [] };
+    }
+  }
+  return { overrides: [], extensionTokens: [], unresolved: candidates };
+}
+
+function splitAliases(aliases) {
+  if (!aliases) return [];
+  return aliases
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
 /**
  * Turn one categorized+resolved row into manifest fragments, per MODE rather
@@ -32,13 +65,23 @@ const COLOR_SCHEMA =
  *   resolved name fields (mirrors the color-set member shape — same
  *   identity, different colorScheme/contrast). These are new records, so no
  *   existence check is needed.
- * - `out-of-scope` (typography/size) → no manifest fragment.
+ * - `out-of-scope` (letter-spacing, non-color/font-size sizing) → no manifest
+ *   fragment.
  *
  * Rows whose target doesn't resolve at all (own name nor any Aliases entry)
  * produce no fragment either — the caller logs `row` into the gap report
  * instead of fabricating a name.
+ *
+ * Font-size rows (`FontSize(N)` / `Scale(FontSize(N))`) are handled up front
+ * via `emitFontSizeRow`, bypassing `categorizeRow`/`resolveTarget` entirely —
+ * see that function's doc for why. See spectrum-design-data-h890.15.
  */
 export function emitRow(row, options) {
+  if (isFontSizeValue(row["New Value"])) {
+    const legacyKeyIndex = options?.legacyKeyIndex ?? loadLegacyKeyIndex();
+    return emitFontSizeRow(row, legacyKeyIndex);
+  }
+
   const { category, overrideModes, extensionModes } = categorizeRow(row);
   if (category === "out-of-scope") {
     return { overrides: [], extensionTokens: [] };

--- a/tools/ios-override-importer/src/find-token-uuid.js
+++ b/tools/ios-override-importer/src/find-token-uuid.js
@@ -45,20 +45,30 @@ export function loadLegacyKeyIndex(tokensDir = TOKENS_DIR, binPath = CLI_BIN) {
   });
   const index = new Map();
   for (const e of JSON.parse(out)) {
-    index.set(indexKey(e.legacyKey, e.colorScheme, e.contrast), e.uuid);
+    index.set(
+      indexKey(e.legacyKey, e.colorScheme, e.contrast, e.scale),
+      e.uuid,
+    );
   }
   return index;
 }
 
-function indexKey(legacyKey, colorScheme, contrast) {
-  return `${legacyKey}::${colorScheme ?? ""}::${contrast ?? ""}`;
+function indexKey(legacyKey, colorScheme, contrast, scale) {
+  return `${legacyKey}::${colorScheme ?? ""}::${contrast ?? ""}::${scale ?? ""}`;
 }
 
 /**
  * Look up the uuid of the foundation token whose computed legacy key is
- * `slug`, at the given `{colorScheme, contrast?}` mode. Returns null if no
- * match exists — callers should treat that as unresolved, not guess.
+ * `slug`, at the given `{colorScheme, contrast?, scale?}` mode. `scale`
+ * disambiguates scale-set members that share a legacy key (e.g.
+ * `font-size-100` has both a `mobile` and `desktop` uuid) — color modes
+ * don't set it, so they fall back to matching the null/null scale entry as
+ * before. Returns null if no match exists — callers should treat that as
+ * unresolved, not guess.
  */
 export function findTokenUuid(index, slug, mode) {
-  return index.get(indexKey(slug, mode.colorScheme, mode.contrast)) ?? null;
+  return (
+    index.get(indexKey(slug, mode.colorScheme, mode.contrast, mode.scale)) ??
+    null
+  );
 }

--- a/tools/ios-override-importer/src/gaps-report.js
+++ b/tools/ios-override-importer/src/gaps-report.js
@@ -18,8 +18,13 @@ const KNOWN_GAPS = [
     "here, but the increased→high crosswalk isn't registered anywhere else.",
   "`pressed`/`down` state terms are advisory-only (state isn't hard-enforced by " +
     "registry.rs) — they pass through untouched, not a resolved equivalence.",
-  "Typography/size rows (`Scale(FontSize(...))`, 155 rows) are out of scope for " +
-    "this importer; see the follow-up bead for font-size/letter-spacing import.",
+  "`FontSize(N)`/`Scale(FontSize(N))` rows import as overrides against the " +
+    "`mobile` scale-set member (spectrum-design-data-h890.15); rows with no " +
+    "resolvable font-size alias fall through to the unresolved list below.",
+  "`letter-spacing-font-size-*` (Measurement) and `letter-spacing-body-*` " +
+    "(DynamicTypeSizeSet) rows have no foundation equivalent — no per-size " +
+    "letter-spacing scale or DynamicTypeSize mode-set exists yet. Deferred to " +
+    "spectrum-design-data-h890.16 pending a foundation naming/units decision.",
 ];
 
 /**

--- a/tools/ios-override-importer/src/parse-scale.js
+++ b/tools/ios-override-importer/src/parse-scale.js
@@ -1,0 +1,32 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+// Swift `FontSize(N)` / `Scale(FontSize(N))` literal -> foundation font-size
+// value. iOS's font-size scale is unconditionally the `mobile` member of the
+// foundation scale-set (see find-token-uuid.js for why `scale` disambiguates
+// mobile/desktop). ponytail: only FontSize/Scale(FontSize) handled here —
+// Measurement (letter-spacing) and DynamicTypeSizeSet have no foundation
+// equivalent yet (h890.16) and stay unresolved/out-of-scope.
+const FONT_SIZE_RE = /^(?:Scale\()?FontSize\(([\d.]+)\)\)?$/;
+
+/** True if `value` is a Swift `FontSize(...)` or `Scale(FontSize(...))` literal. */
+export function isFontSizeValue(value) {
+  return FONT_SIZE_RE.test(value.trim());
+}
+
+/** Parse `FontSize(14.0)` / `Scale(FontSize(14.0))` into `"14px"`. */
+export function parseFontSize(value) {
+  const match = FONT_SIZE_RE.exec(value.trim());
+  if (!match) {
+    throw new Error(`not a FontSize literal: ${value}`);
+  }
+  const n = Number(match[1]);
+  return `${n}px`;
+}

--- a/tools/ios-override-importer/src/resolve-target.js
+++ b/tools/ios-override-importer/src/resolve-target.js
@@ -85,7 +85,7 @@ export function resolveTarget(
   return { slug: null, candidates };
 }
 
-function splitAliases(aliases) {
+export function splitAliases(aliases) {
   if (!aliases) return [];
   return aliases
     .split(",")

--- a/tools/ios-override-importer/test/cli.test.js
+++ b/tools/ios-override-importer/test/cli.test.js
@@ -14,10 +14,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { run } from "../src/cli.js";
 
-// Out-of-scope (typography) rows only, so emitManifest never touches the
+// Out-of-scope (letter-spacing) rows only, so emitManifest never touches the
 // Rust CLI oracle or the foundation-token corpus — this test is a
 // dependency-free smoke check of arg parsing + file writing, not the
-// resolution pipeline (covered by emit-manifest.test.js).
+// resolution pipeline (covered by emit-manifest.test.js). FontSize rows do
+// touch the corpus (via the legacy-key index), so they're deliberately kept
+// out of this fixture.
 test("writes a manifest and gap report from a CSV", (t) => {
   const dir = mkdtempSync(join(tmpdir(), "ios-importer-cli-"));
   const csvPath = join(dir, "override-log.csv");
@@ -27,7 +29,7 @@ test("writes a manifest and gap report from a CSV", (t) => {
   writeFileSync(
     csvPath,
     "Token Name,Old Value,New Value,Aliases,Override Source\n" +
-      'font-size-100,"Scale(FontSize(17.0))",FontSize(14.0),,figma-tokens.json\n',
+      'letter-spacing-font-size-10,"Custom token",Measurement(0.433),,letter-spacing.json\n',
   );
 
   run(["--csv", csvPath, "--out", outPath, "--gaps", gapsPath]);

--- a/tools/ios-override-importer/test/emit-manifest.test.js
+++ b/tools/ios-override-importer/test/emit-manifest.test.js
@@ -27,8 +27,8 @@ test("true-value-change emits uuid-targeted overrides, one per changed mode", (t
       "ColorSet(light: Color(9, 9, 9, 1.0), dark: Color(2, 2, 2, 1.0))",
   };
   const legacyKeyIndex = new Map([
-    ["accent-background-color-default::light::", "uuid-light"],
-    ["accent-background-color-default::dark::", "uuid-dark"],
+    ["accent-background-color-default::light::::", "uuid-light"],
+    ["accent-background-color-default::dark::::", "uuid-dark"],
   ]);
   const result = emitRow(row, {
     decompose,
@@ -120,11 +120,43 @@ test("contrast-addition includes contrast:high in the extension token's name", (
 
 test("out-of-scope rows emit nothing", (t) => {
   const row = {
-    "Old Value": "Scale(FontSize(17.0))",
-    "New Value": "FontSize(14.0)",
+    "Old Value": "Custom token",
+    "New Value": "Measurement(0.43)",
   };
   const result = emitRow(row, { decompose, colorFamilies: FAMILIES });
   t.deepEqual(result, { overrides: [], extensionTokens: [] });
+});
+
+test("font-size row resolves via alias to an override on the mobile scale member", (t) => {
+  const row = {
+    "Token Name": "action-bar-counter-font-size",
+    Aliases: "font-size-100",
+    "Old Value": "Scale(FontSize(17.0))",
+    "New Value": "FontSize(14.0)",
+  };
+  const legacyKeyIndex = new Map([
+    ["font-size-100::::::mobile", "uuid-font-size-100"],
+  ]);
+  const result = emitRow(row, { legacyKeyIndex });
+  t.deepEqual(result, {
+    overrides: [{ target: "uuid-font-size-100", value: "14px" }],
+    extensionTokens: [],
+  });
+});
+
+test("font-size row with no resolvable alias reports unresolved", (t) => {
+  const row = {
+    "Token Name": "alert-dialog-title-font-size",
+    Aliases: "",
+    "Old Value": "Scale(FontSize(24.0))",
+    "New Value": "Scale(FontSize(20.0))",
+  };
+  const result = emitRow(row, { legacyKeyIndex: new Map() });
+  t.deepEqual(result, {
+    overrides: [],
+    extensionTokens: [],
+    unresolved: ["alert-dialog-title-font-size"],
+  });
 });
 
 test("unresolved rows report candidates instead of a fragment", (t) => {

--- a/tools/ios-override-importer/test/find-token-uuid.test.js
+++ b/tools/ios-override-importer/test/find-token-uuid.test.js
@@ -12,9 +12,10 @@ import test from "ava";
 import { findTokenUuid } from "../src/find-token-uuid.js";
 
 const INDEX = new Map([
-  ["blue-1000::light::", "u-light"],
-  ["blue-1000::dark::", "u-dark"],
-  ["blue-1000::light::high", "u-light-high"],
+  ["blue-1000::light::::", "u-light"],
+  ["blue-1000::dark::::", "u-dark"],
+  ["blue-1000::light::high::", "u-light-high"],
+  ["font-size-100::::::mobile", "u-font-size-100-mobile"],
 ]);
 
 test("finds the uuid for an exact legacy-key + mode match", (t) => {
@@ -33,4 +34,9 @@ test("disambiguates plain vs. contrast:high modes", (t) => {
 test("returns null when no record matches", (t) => {
   const uuid = findTokenUuid(INDEX, "red-1000", { colorScheme: "light" });
   t.is(uuid, null);
+});
+
+test("disambiguates scale-set members sharing a legacy key (mobile vs. desktop)", (t) => {
+  const uuid = findTokenUuid(INDEX, "font-size-100", { scale: "mobile" });
+  t.is(uuid, "u-font-size-100-mobile");
 });

--- a/tools/ios-override-importer/test/parse-scale.test.js
+++ b/tools/ios-override-importer/test/parse-scale.test.js
@@ -1,0 +1,42 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { isFontSizeValue, parseFontSize } from "../src/parse-scale.js";
+
+test("isFontSizeValue: true for FontSize(N)", (t) => {
+  t.true(isFontSizeValue("FontSize(14.0)"));
+});
+
+test("isFontSizeValue: true for Scale(FontSize(N))", (t) => {
+  t.true(isFontSizeValue("Scale(FontSize(20.0))"));
+});
+
+test("isFontSizeValue: false for ColorSet/Measurement/DynamicTypeSizeSet", (t) => {
+  t.false(isFontSizeValue("ColorSet(light: Color(1, 1, 1, 1.0), dark: none)"));
+  t.false(isFontSizeValue("Measurement(0.43)"));
+  t.false(isFontSizeValue("DynamicTypeSizeSet(xSmall: Measurement(0.43))"));
+});
+
+test("parseFontSize: FontSize(14.0) -> 14px", (t) => {
+  t.is(parseFontSize("FontSize(14.0)"), "14px");
+});
+
+test("parseFontSize: Scale(FontSize(20.0)) -> 20px", (t) => {
+  t.is(parseFontSize("Scale(FontSize(20.0))"), "20px");
+});
+
+test("parseFontSize: keeps real decimals", (t) => {
+  t.is(parseFontSize("FontSize(13.5)"), "13.5px");
+});
+
+test("parseFontSize: throws on non-FontSize literal", (t) => {
+  t.throws(() => parseFontSize("Measurement(0.43)"));
+});


### PR DESCRIPTION
## Description

Extends `tools/ios-override-importer` (built for h890.8, colors-only) to also
import the font-size slice of the 155 typography/size rows it previously
deferred wholesale as out-of-scope.

- `sdk/cli/src/main.rs`: `dump-legacy-keys` now also emits each token's
  `scale` field. Font-size legacy keys (e.g. `font-size-100`) map to **two**
  uuids (the scale-set's `mobile` and `desktop` members), both with
  `colorScheme`/`contrast` = null — without `scale` to disambiguate, the
  index collapsed them and returned whichever loaded last.
- `tools/ios-override-importer/src/find-token-uuid.js`: index/lookup key now
  includes `scale`. Backward compatible — color lookups never set `scale`, so
  they still resolve to the same null/null bucket as before.
- `tools/ios-override-importer/src/parse-scale.js` (new): parses
  `FontSize(N)` / `Scale(FontSize(N))` into a `"Npx"` value.
- `tools/ios-override-importer/src/emit-manifest.js`: `emitRow` now handles
  font-size rows up front — resolves the target by uuid existence at the
  `mobile` scale (scanning Token Name + Aliases), not via `resolveTarget`'s
  structural decompose (which would wrongly resolve component slugs like
  `action-bar-counter-font-size` to themselves instead of following the
  alias to the real `font-size-100` foundation token).
- `tools/ios-override-importer/src/gaps-report.js`: updated the stale
  "typography is entirely out of scope" note; documents that letter-spacing
  rows (`Measurement`/`DynamicTypeSizeSet`) remain a gap pending h890.16 (no
  foundation per-size scale or DynamicTypeSize mode-set exists yet).

Scope note: of the 155 deferred rows, only the 89 `FontSize`/`Scale(FontSize)`
rows that alias a real foundation `font-size-*` token import cleanly as
overrides. Letter-spacing (68 rows) has no foundation equivalent to target —
minting one is a naming/units decision, tracked as h890.16 and left for
Josh's RFC review per the parent epic's plan.

## Related Issue

Closes spectrum-design-data-h890.15 (follow-up to h890.8).

## Motivation and Context

h890.8 built the importer against color rows only and explicitly deferred
typography/size as out of scope. This closes the highest-value slice of that
gap (font-size) using the same CSV-parsing and category-split machinery,
without pre-empting the still-undecided letter-spacing foundation work.

## How Has This Been Tested?

- `pnpm ava` in `tools/ios-override-importer`: 44 tests pass (9 new/updated
  covering `parse-scale.js`, the font-size override/unresolved paths in
  `emit-manifest.js`, and the scale-disambiguation case in
  `find-token-uuid.js`).
- `moon run sdk:test`: 1316 tests pass (Rust workspace, includes the
  `dump-legacy-keys` change).
- `moon run sdk:lint`: clean.
- End-to-end run against the real
  `spectrum-tokens-ios/ios-tokens/override-log.csv` (742 rows): manifest
  overrides went from prior color-only count to include 89 new font-size
  overrides, each verified to target the token's `mobile` scale-set uuid
  (not `desktop`) with the correct `"Npx"` value. `gaps.md` lists the
  remaining 52 unresolved rows (component-only font-size aliases,
  letter-spacing, figma sizing).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
