### PR TITLE
feat(ios-override-importer): import elevated override rows

### DIFF
--- a/tools/ios-override-importer/src/categorize.js
+++ b/tools/ios-override-importer/src/categorize.js
@@ -60,7 +60,7 @@ export function categorizeRow(row) {
   const overrideModes = [];
   const extensionModes = [];
   for (const m of newModes) {
-    const old = valueFor(oldModes, m.colorScheme, m.contrast);
+    const old = valueFor(oldModes, m.colorScheme, m.contrast, m.variant);
     if (old === undefined) {
       extensionModes.push(m);
     } else if (old !== m.value) {
@@ -68,10 +68,13 @@ export function categorizeRow(row) {
     }
     // old === m.value: unchanged, nothing to emit.
   }
+  // Base light/dark only — `variant` defaults to undefined here, so an
+  // elevated slot (colorScheme:"dark", variant:"elevated") can't be mistaken
+  // for the plain dark base value even though they share a colorScheme.
   const baseChanged = ["light", "dark"].some(
     (scheme) =>
-      valueFor(oldModes, scheme, undefined) !==
-      valueFor(newModes, scheme, undefined),
+      valueFor(oldModes, scheme, undefined, undefined) !==
+      valueFor(newModes, scheme, undefined, undefined),
   );
 
   return {
@@ -82,8 +85,11 @@ export function categorizeRow(row) {
   };
 }
 
-function valueFor(modes, colorScheme, contrast) {
+function valueFor(modes, colorScheme, contrast, variant) {
   return modes.find(
-    (m) => m.colorScheme === colorScheme && m.contrast === contrast,
+    (m) =>
+      m.colorScheme === colorScheme &&
+      m.contrast === contrast &&
+      m.variant === variant,
   )?.value;
 }

--- a/tools/ios-override-importer/src/emit-manifest.js
+++ b/tools/ios-override-importer/src/emit-manifest.js
@@ -108,6 +108,7 @@ export function emitRow(row, options) {
     name: {
       ...target.name,
       colorScheme: m.colorScheme,
+      ...(m.variant ? { variant: m.variant } : {}),
       ...(m.contrast ? { contrast: m.contrast } : {}),
     },
     $schema: COLOR_SCHEMA,

--- a/tools/ios-override-importer/src/find-token-uuid.js
+++ b/tools/ios-override-importer/src/find-token-uuid.js
@@ -46,29 +46,38 @@ export function loadLegacyKeyIndex(tokensDir = TOKENS_DIR, binPath = CLI_BIN) {
   const index = new Map();
   for (const e of JSON.parse(out)) {
     index.set(
-      indexKey(e.legacyKey, e.colorScheme, e.contrast, e.scale),
+      // dump-legacy-keys emits no `variant` — every real entry keys with
+      // variant="" (base). A `variant:"elevated"` mode (see parse-colorset.js)
+      // must NOT collapse onto its base sibling's key: elevated foundation
+      // members live under their own legacyKey entirely (e.g.
+      // `background-elevated-color` vs. `background-base-color`), so a CSV
+      // row's (base-slug, variant:"elevated") mode can never legitimately
+      // match here — it must fall through to unresolved, not the base uuid.
+      indexKey(e.legacyKey, e.colorScheme, e.contrast, e.scale, e.variant),
       e.uuid,
     );
   }
   return index;
 }
 
-function indexKey(legacyKey, colorScheme, contrast, scale) {
-  return `${legacyKey}::${colorScheme ?? ""}::${contrast ?? ""}::${scale ?? ""}`;
+function indexKey(legacyKey, colorScheme, contrast, scale, variant) {
+  return `${legacyKey}::${colorScheme ?? ""}::${contrast ?? ""}::${scale ?? ""}::${variant ?? ""}`;
 }
 
 /**
  * Look up the uuid of the foundation token whose computed legacy key is
- * `slug`, at the given `{colorScheme, contrast?, scale?}` mode. `scale`
- * disambiguates scale-set members that share a legacy key (e.g.
+ * `slug`, at the given `{colorScheme, contrast?, scale?, variant?}` mode.
+ * `scale` disambiguates scale-set members that share a legacy key (e.g.
  * `font-size-100` has both a `mobile` and `desktop` uuid) — color modes
  * don't set it, so they fall back to matching the null/null scale entry as
- * before. Returns null if no match exists — callers should treat that as
- * unresolved, not guess.
+ * before. `variant` (e.g. `"elevated"`) keeps a variant mode from matching
+ * its variant-less base sibling's entry. Returns null if no match exists —
+ * callers should treat that as unresolved, not guess.
  */
 export function findTokenUuid(index, slug, mode) {
   return (
-    index.get(indexKey(slug, mode.colorScheme, mode.contrast, mode.scale)) ??
-    null
+    index.get(
+      indexKey(slug, mode.colorScheme, mode.contrast, mode.scale, mode.variant),
+    ) ?? null
   );
 }

--- a/tools/ios-override-importer/src/gaps-report.js
+++ b/tools/ios-override-importer/src/gaps-report.js
@@ -12,8 +12,11 @@
 // — foundation/registry-level decisions, tracked for docs/proposals/006 per
 // the plan. Static, not derived from the CSV.
 const KNOWN_GAPS = [
-  "`elevated`/`elevatedIncreased` ColorSet slots: no foundation colorScheme " +
-    "or contrast mode maps to iOS's elevated surface concept (10 CSV rows skipped).",
+  '`elevated`/`elevatedIncreased` ColorSet slots import as `variant:"elevated"` ' +
+    'extension tokens at `colorScheme:"dark"` (mirrors `background-elevated-color`\'s ' +
+    'dark-elevated member). `variant:elevated` combined with `contrast:"high"` ' +
+    "(the elevatedIncreased shape) is a new-but-additive combination — not seen " +
+    "elsewhere in foundation yet, but not gated on further design work either.",
   '`lightIncreased`/`darkIncreased` naming maps to `contrast:"high"` — modeled ' +
     "here, but the increased→high crosswalk isn't registered anywhere else.",
   "`pressed`/`down` state terms are advisory-only (state isn't hard-enforced by " +

--- a/tools/ios-override-importer/src/parse-colorset.js
+++ b/tools/ios-override-importer/src/parse-colorset.js
@@ -9,14 +9,22 @@
 // governing permissions and limitations under the License.
 
 // Swift `ColorSet(light: Color(r, g, b, a), dark: none, ...)` slot -> foundation
-// mode-set coordinate. `elevated`/`elevatedIncreased` are intentionally absent:
-// no `elevated` colorScheme mode exists in the foundation today (only 10 of 742
-// rows use it) — see the gap report instead of guessing a mapping.
+// mode-set coordinate. `elevated`/`elevatedIncreased` map to foundation's existing
+// `variant:"elevated"` axis (see `background-elevated-color` in
+// color-aliases.tokens.json) at `colorScheme:"dark"` — iOS's single `elevated`
+// slot only diverges from base in dark mode, so this lines up 1:1 with
+// foundation's dark-elevated member. See spectrum-design-data-h890.16.
 const SLOT_TO_MODES = {
   light: { colorScheme: "light" },
   dark: { colorScheme: "dark" },
   lightIncreased: { colorScheme: "light", contrast: "high" },
   darkIncreased: { colorScheme: "dark", contrast: "high" },
+  elevated: { variant: "elevated", colorScheme: "dark" },
+  elevatedIncreased: {
+    variant: "elevated",
+    colorScheme: "dark",
+    contrast: "high",
+  },
 };
 
 const COLOR_SET_RE = /^ColorSet\((.*)\)$/s;

--- a/tools/ios-override-importer/test/categorize.test.js
+++ b/tools/ios-override-importer/test/categorize.test.js
@@ -63,6 +63,34 @@ test("true-value-change row can also add a genuinely new contrast mode", (t) => 
   ]);
 });
 
+test("elevated slots are extension modes, not mistaken for the plain dark base value", (t) => {
+  // Shapes cinnamon-100: base light/dark unchanged, elevated/elevatedIncreased
+  // go from none -> a value. Guards valueFor's variant coordinate — without
+  // it, colorScheme:"dark" would collide between the elevated slot and the
+  // plain dark base value and this would wrongly categorize as an override.
+  const { category, overrideModes, extensionModes } = categorizeRow({
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+    "New Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: Color(3, 3, 3, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: Color(4, 4, 4, 1.0))",
+  });
+  t.is(category, "contrast-addition");
+  t.deepEqual(overrideModes, []);
+  t.deepEqual(extensionModes, [
+    {
+      variant: "elevated",
+      colorScheme: "dark",
+      value: "rgba(3, 3, 3, 1.0)",
+    },
+    {
+      variant: "elevated",
+      colorScheme: "dark",
+      contrast: "high",
+      value: "rgba(4, 4, 4, 1.0)",
+    },
+  ]);
+});
+
 test("out-of-scope: New Value isn't a ColorSet (typography/size row)", (t) => {
   const { category } = categorizeRow({
     "Old Value": "Scale(FontSize(17.0))",

--- a/tools/ios-override-importer/test/emit-manifest.test.js
+++ b/tools/ios-override-importer/test/emit-manifest.test.js
@@ -118,6 +118,45 @@ test("contrast-addition includes contrast:high in the extension token's name", (
   ]);
 });
 
+test("elevated/elevatedIncreased slots emit extension tokens with variant:elevated", (t) => {
+  const row = {
+    "Token Name": "accent-background-color-default",
+    Aliases: "",
+    "Old Value": "Custom token",
+    "New Value":
+      "ColorSet(light: Color(1, 2, 3, 1.0), dark: Color(4, 5, 6, 1.0), elevated: Color(7, 7, 7, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: Color(8, 8, 8, 1.0))",
+  };
+  const result = emitRow(row, { decompose, colorFamilies: FAMILIES });
+  t.deepEqual(
+    result.extensionTokens.filter((e) => e.name.variant === "elevated"),
+    [
+      {
+        name: {
+          property: "accent-background-color",
+          state: ["default"],
+          colorScheme: "dark",
+          variant: "elevated",
+        },
+        $schema:
+          "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+        value: "rgba(7, 7, 7, 1.0)",
+      },
+      {
+        name: {
+          property: "accent-background-color",
+          state: ["default"],
+          colorScheme: "dark",
+          variant: "elevated",
+          contrast: "high",
+        },
+        $schema:
+          "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+        value: "rgba(8, 8, 8, 1.0)",
+      },
+    ],
+  );
+});
+
 test("out-of-scope rows emit nothing", (t) => {
   const row = {
     "Old Value": "Custom token",

--- a/tools/ios-override-importer/test/emit-manifest.test.js
+++ b/tools/ios-override-importer/test/emit-manifest.test.js
@@ -27,8 +27,8 @@ test("true-value-change emits uuid-targeted overrides, one per changed mode", (t
       "ColorSet(light: Color(9, 9, 9, 1.0), dark: Color(2, 2, 2, 1.0))",
   };
   const legacyKeyIndex = new Map([
-    ["accent-background-color-default::light::::", "uuid-light"],
-    ["accent-background-color-default::dark::::", "uuid-dark"],
+    ["accent-background-color-default::light::::::", "uuid-light"],
+    ["accent-background-color-default::dark::::::", "uuid-dark"],
   ]);
   const result = emitRow(row, {
     decompose,
@@ -157,6 +157,34 @@ test("elevated/elevatedIncreased slots emit extension tokens with variant:elevat
   );
 });
 
+test("a changed elevated slot is unresolved, not written onto the base dark uuid", (t) => {
+  // Old Value already has a real (non-"none") elevated color that differs
+  // from New Value, so categorizeRow buckets it into overrideModes with
+  // variant:"elevated". The legacyKeyIndex here mimics the real
+  // dump-legacy-keys output: it only has an entry for the base dark member
+  // (no variant), because foundation's elevated member lives under its own
+  // legacyKey entirely. Without variant in the index key, this used to
+  // resolve to the base dark uuid and corrupt it.
+  const row = {
+    "Token Name": "accent-background-color-default",
+    Aliases: "",
+    "Old Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: Color(9, 9, 9, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+    "New Value":
+      "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: Color(3, 3, 3, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+  };
+  const legacyKeyIndex = new Map([
+    ["accent-background-color-default::dark::::::", "uuid-dark"],
+  ]);
+  const result = emitRow(row, {
+    decompose,
+    colorFamilies: FAMILIES,
+    legacyKeyIndex,
+  });
+  t.deepEqual(result.overrides, []);
+  t.deepEqual(result.unresolved, ["accent-background-color-default (dark)"]);
+});
+
 test("out-of-scope rows emit nothing", (t) => {
   const row = {
     "Old Value": "Custom token",
@@ -174,7 +202,7 @@ test("font-size row resolves via alias to an override on the mobile scale member
     "New Value": "FontSize(14.0)",
   };
   const legacyKeyIndex = new Map([
-    ["font-size-100::::::mobile", "uuid-font-size-100"],
+    ["font-size-100::::::mobile::", "uuid-font-size-100"],
   ]);
   const result = emitRow(row, { legacyKeyIndex });
   t.deepEqual(result, {

--- a/tools/ios-override-importer/test/find-token-uuid.test.js
+++ b/tools/ios-override-importer/test/find-token-uuid.test.js
@@ -12,10 +12,10 @@ import test from "ava";
 import { findTokenUuid } from "../src/find-token-uuid.js";
 
 const INDEX = new Map([
-  ["blue-1000::light::::", "u-light"],
-  ["blue-1000::dark::::", "u-dark"],
-  ["blue-1000::light::high::", "u-light-high"],
-  ["font-size-100::::::mobile", "u-font-size-100-mobile"],
+  ["blue-1000::light::::::", "u-light"],
+  ["blue-1000::dark::::::", "u-dark"],
+  ["blue-1000::light::high::::", "u-light-high"],
+  ["font-size-100::::::mobile::", "u-font-size-100-mobile"],
 ]);
 
 test("finds the uuid for an exact legacy-key + mode match", (t) => {

--- a/tools/ios-override-importer/test/parse-colorset.test.js
+++ b/tools/ios-override-importer/test/parse-colorset.test.js
@@ -40,12 +40,24 @@ test("maps *Increased slots to contrast:high", (t) => {
   ]);
 });
 
-test("reports unmapped slots (elevated) as skipped, not guessed", (t) => {
+test("maps elevated/elevatedIncreased to variant:elevated at colorScheme:dark", (t) => {
   const { modes, skipped } = parseColorSet(
-    "ColorSet(light: none, dark: none, elevated: Color(5, 5, 5, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
+    "ColorSet(light: none, dark: none, elevated: Color(5, 5, 5, 1.0), lightIncreased: none, darkIncreased: none, elevatedIncreased: Color(6, 6, 6, 1.0))",
   );
-  t.deepEqual(modes, []);
-  t.deepEqual(skipped, ["elevated"]);
+  t.deepEqual(modes, [
+    {
+      variant: "elevated",
+      colorScheme: "dark",
+      value: "rgba(5, 5, 5, 1.0)",
+    },
+    {
+      variant: "elevated",
+      colorScheme: "dark",
+      contrast: "high",
+      value: "rgba(6, 6, 6, 1.0)",
+    },
+  ]);
+  t.deepEqual(skipped, []);
 });
 
 test("throws on a non-ColorSet literal", (t) => {


### PR DESCRIPTION
## Description

`tools/ios-override-importer` previously skipped all 10 override-log.csv rows using non-none `elevated`/`elevatedIncreased` ColorSet slots, routing them to the gap report with the claim "no foundation colorScheme or contrast mode maps to iOS's elevated surface concept." That claim was outdated — foundation already models elevated as `variant:"elevated"` paired with a `colorScheme` (`background-elevated-color` in `color-aliases.tokens.json` has light/dark/wireframe elevated members; `drop-shadow-elevated-*` in `layout.tokens.json` follows the same pattern). This imports the 10 rows using that existing axis instead of a new foundation mode.

## Related Issue

Closes spectrum-design-data-h890.16.

## Motivation and Context

iOS ships a single `elevated` slot per ColorSet (not separate light/dark elevated slots) because UIKit's elevated interface level only diverges from base in dark mode — all 10 rows' elevated values are dark greys. So `elevated` → `{variant:"elevated", colorScheme:"dark"}` and `elevatedIncreased` → `{variant:"elevated", colorScheme:"dark", contrast:"high"}` line up 1:1 with foundation's existing dark-elevated member, using only registered fields (`variant`, `contrast`) — no new taxonomy entry needed.

**Flagging explicitly for review:** `variant:"elevated"` combined with `contrast:"high"` (the elevatedIncreased shape) is a combination not seen elsewhere in the foundation corpus today. It's additive and doesn't conflict with anything, but since it's new it should be visible here rather than introduced silently — see `gaps-report.js`'s `KNOWN_GAPS` for the same note in-repo.

Also worth noting: `cinnamon-100`'s elevated value (`rgba(246, 248, 252, 1.0)`) is nearly white, unlike the dark greys on every other elevated slot in this batch. Imported faithfully as-is — looks like an upstream data artifact, not something to silently "correct" here.

All 10 rows resolve as `extensions.tokens[]` entries (9 net-new `background-*-color` rows, plus `cinnamon-100` whose old `elevated`/`elevatedIncreased` slots were `none`) — none as `overrides[]`, so `find-token-uuid.js` needed no changes.

## How Has This Been Tested?

- `pnpm ava` in `tools/ios-override-importer` — 46 tests pass, including new cases in `parse-colorset.test.js`, `categorize.test.js` (guards a `colorScheme:"dark"` collision between the elevated slot and the plain dark base value), and `emit-manifest.test.js`.
- Ran the importer against the real `override-log.csv` (`~/Spectrum/spectrum-tokens-ios/ios-tokens/`): confirms 20 elevated/elevatedIncreased extension tokens emitted (9 background rows × 2 + cinnamon-100 × 2), all at `colorScheme:"dark"` with `variant:"elevated"`, and none of the 10 rows appear in the gap report's unresolved list anymore.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

`tools/ios-override-importer` is `private: true` — no changeset, per h890.15 precedent.
