### PR TITLE
feat(mcp): honor .design-data.toml manifest cascade in read/validate tools

### DIFF
--- a/.changeset/mcp-honors-cascade.md
+++ b/.changeset/mcp-honors-cascade.md
@@ -11,3 +11,5 @@ snapshot (closes bead h890.14).
   `describe_component` stays out of scope.
 - **src/config.js**, **src/index.js**, **src/cli.js**: wiring for the new
   `DESIGN_DATA_CONFIG` env var and startup bootstrap.
+- Cascade state lives in `config.cascadeDataPath`, separate from `dataPath`/
+  `dataRoot`, so it can't leak into unrelated write/authoring/data tools.

--- a/.changeset/mcp-honors-cascade.md
+++ b/.changeset/mcp-honors-cascade.md
@@ -1,0 +1,13 @@
+---
+"@adobe/design-data-agent-mcp": minor
+---
+
+MCP read tools now honor a `.design-data.toml` cascade, not just the embedded
+snapshot (closes bead h890.14).
+
+- **src/cascade-bootstrap.js**: new — resolves `DESIGN_DATA_CONFIG` via the CLI
+  once at startup, materializes to a temp dataset.
+- **src/tools/read.js**: `primer` reflects the cascade when active;
+  `describe_component` stays out of scope.
+- **src/config.js**, **src/index.js**, **src/cli.js**: wiring for the new
+  `DESIGN_DATA_CONFIG` env var and startup bootstrap.

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -47,15 +47,27 @@ node tools/design-data-agent-mcp/src/index.js
 
 ### Environment variables
 
-| Variable                 | Default       | Description                                       |
-| ------------------------ | ------------- | ------------------------------------------------- |
-| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary (authoring only) |
-| `DESIGN_DATA_ROOT`       | —             | Absolute root that relative paths are anchored to |
-| `DESIGN_DATA_PATH`       | `.`           | Dataset root path                                 |
-| `DESIGN_DATA_COMPONENTS` | —             | Override components directory                     |
-| `DESIGN_DATA_FIELDS`     | —             | Override fields directory                         |
-| `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)             |
-| `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`)         |
+| Variable                 | Default       | Description                                                                    |
+| ------------------------ | ------------- | ------------------------------------------------------------------------------ |
+| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary (authoring only)                              |
+| `DESIGN_DATA_ROOT`       | —             | Absolute root that relative paths are anchored to                              |
+| `DESIGN_DATA_PATH`       | `.`           | Dataset root path                                                              |
+| `DESIGN_DATA_COMPONENTS` | —             | Override components directory                                                  |
+| `DESIGN_DATA_FIELDS`     | —             | Override fields directory                                                      |
+| `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)                                          |
+| `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`)                                      |
+| `DESIGN_DATA_CONFIG`     | —             | Path to a `.design-data.toml` (or its directory) to resolve a platform cascade |
+
+> **Platform cascade.** If `DESIGN_DATA_CONFIG` is set, the server shells out to
+> the `design-data` CLI once at startup (`design-data query --filter "" --format
+> json`, run from the config's directory) to resolve its `.design-data.toml`
+> source (path/npm/github/git) and any top-level `manifest` cascade, then
+> materializes the result to a temp dir and points `primer` / `resolve_token` /
+> `query_tokens` / `validate_usage` at it instead of the embedded Spectrum
+> snapshot. `describe_component` is unaffected — it always reads components from
+> `@adobe/spectrum-design-data` regardless of cascade state. If resolution fails
+> (e.g. no network for a github source), the server logs a warning and falls
+> back to the embedded/local dataset rather than crashing.
 
 > **Path resolution.** The MCP client launches this server with the working
 > directory inherited from wherever the editor was opened — which may be a

--- a/tools/design-data-agent-mcp/src/cascade-bootstrap.js
+++ b/tools/design-data-agent-mcp/src/cascade-bootstrap.js
@@ -33,11 +33,15 @@ function resolveConfigDir(configPath) {
 }
 
 /**
- * Resolve `config.designDataConfig`'s cascade and repoint `config.dataPath` /
- * `config.dataRoot` / `config.cascadeActive` at the result. No-ops if
- * `designDataConfig` is unset. Never throws — a failed resolve (e.g. no
- * network for a github source) logs to stderr and leaves config untouched,
- * so the server still starts against the embedded/local fallback.
+ * Resolve `config.designDataConfig`'s cascade and populate
+ * `config.cascadeDataPath` / `config.cascadeActive` with the result.
+ * Deliberately does not touch `config.dataPath`/`config.dataRoot` — those
+ * remain the fallback anchors for unrelated write/authoring/data tools,
+ * which must keep targeting the real dataset root, not the cascade's
+ * resolved snapshot. No-ops if `designDataConfig` is unset. Never throws —
+ * a failed resolve (e.g. no network for a github source) logs to stderr and
+ * leaves config untouched, so the server still starts against the
+ * embedded/local fallback.
  *
  * @param {object} config - The mutable config object from ./config.js.
  * @param {{ run?: typeof runCli }} [opts] - `run` is injectable for tests.
@@ -71,8 +75,7 @@ export async function bootstrapCascade(config, { run = runCli } = {}) {
       "utf-8",
     );
 
-    config.dataPath = dir;
-    config.dataRoot = configDir;
+    config.cascadeDataPath = dir;
     config.cascadeActive = true;
     console.error(
       `[design-data-mcp] cascade resolved from ${configDir} ` +

--- a/tools/design-data-agent-mcp/src/cascade-bootstrap.js
+++ b/tools/design-data-agent-mcp/src/cascade-bootstrap.js
@@ -1,0 +1,87 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Resolves a `.design-data.toml` platform source + manifest cascade once at
+ * startup, so the MCP's in-process read/validate tools (which only know how
+ * to read a local directory — see config.dataPath) see the platform-resolved
+ * dataset instead of the embedded Spectrum snapshot or a raw local dir.
+ *
+ * The CLI already does config discovery, github fetch/cache, and manifest-cascade
+ * application on every data-touching subcommand — this just shells out to it once
+ * (`design-data query --filter "" --format json`, cwd = the config's directory)
+ * and materializes the result as a single `*.tokens.json` cascade-array file in a
+ * temp dir, which loadDataset()/validateDataset() already know how to read.
+ */
+
+import { existsSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { runCli } from "./cli.js";
+
+/** Directory containing `.design-data.toml`, given either path. */
+function resolveConfigDir(configPath) {
+  if (!existsSync(configPath)) return null;
+  return statSync(configPath).isDirectory() ? configPath : dirname(configPath);
+}
+
+/**
+ * Resolve `config.designDataConfig`'s cascade and repoint `config.dataPath` /
+ * `config.dataRoot` / `config.cascadeActive` at the result. No-ops if
+ * `designDataConfig` is unset. Never throws — a failed resolve (e.g. no
+ * network for a github source) logs to stderr and leaves config untouched,
+ * so the server still starts against the embedded/local fallback.
+ *
+ * @param {object} config - The mutable config object from ./config.js.
+ * @param {{ run?: typeof runCli }} [opts] - `run` is injectable for tests.
+ */
+export async function bootstrapCascade(config, { run = runCli } = {}) {
+  if (!config.designDataConfig) return;
+
+  const configDir = resolveConfigDir(config.designDataConfig);
+  if (!configDir) {
+    console.error(
+      `[design-data-mcp] DESIGN_DATA_CONFIG "${config.designDataConfig}" not found; ` +
+        "ignoring, falling back to embedded/local dataset.",
+    );
+    return;
+  }
+
+  try {
+    const { exitCode, stdout, stderr } = await run(
+      ["query", "--filter", "", "--format", "json"],
+      { timeout: 60_000, cwd: configDir },
+    );
+    if (exitCode !== 0) {
+      throw new Error(stderr || `design-data exited with code ${exitCode}`);
+    }
+    const tokens = JSON.parse(stdout);
+
+    const dir = mkdtempSync(join(tmpdir(), "design-data-mcp-cascade-"));
+    writeFileSync(
+      join(dir, "resolved.tokens.json"),
+      JSON.stringify(tokens),
+      "utf-8",
+    );
+
+    config.dataPath = dir;
+    config.dataRoot = configDir;
+    config.cascadeActive = true;
+    console.error(
+      `[design-data-mcp] cascade resolved from ${configDir} ` +
+        `(${tokens.length} tokens) -> ${dir}`,
+    );
+  } catch (err) {
+    console.error(
+      `[design-data-mcp] cascade bootstrap failed, falling back to embedded/local ` +
+        `dataset: ${err.message}`,
+    );
+  }
+}

--- a/tools/design-data-agent-mcp/src/cli.js
+++ b/tools/design-data-agent-mcp/src/cli.js
@@ -11,13 +11,15 @@
 import { spawn } from "child_process";
 import { config } from "./config.js";
 
-export function runCli(args, { timeout = 10_000, stdin } = {}) {
+export function runCli(args, { timeout = 10_000, stdin, cwd } = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn(config.bin, args, {
       // Anchor the CLI's working directory to the resolved data root so its own
       // tier/probe logic (data_source::resolve, is_in_repo) resolves correctly
       // even when Claude Code launched the server from a monorepo subdirectory.
-      cwd: config.dataRoot,
+      // `cwd` override lets the cascade bootstrap point the CLI at a
+      // `.design-data.toml` directory that differs from config.dataRoot.
+      cwd: cwd ?? config.dataRoot,
       // isolates CLI stdout from the MCP JSON-RPC stream on the parent's stdout
       stdio: [stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
     });

--- a/tools/design-data-agent-mcp/src/config.js
+++ b/tools/design-data-agent-mcp/src/config.js
@@ -78,4 +78,15 @@ export const config = {
     anchorPath(process.env.DESIGN_DATA_FIELDS) ??
     resolveDataPackageDir("fields") ??
     null,
+  // Path to a `.design-data.toml` (or its containing directory) declaring a
+  // platform source + manifest cascade. When set, cascade-bootstrap.js
+  // resolves it once at startup (via the CLI, which already knows how to
+  // fetch/cache a github source and apply the manifest) and repoints
+  // dataPath/dataRoot/cascadeActive below at the result. Unset by default so
+  // an in-repo run's ambient .design-data.toml (if any) doesn't surprise it.
+  designDataConfig: anchorPath(process.env.DESIGN_DATA_CONFIG ?? null),
+  // Flipped to true by cascade-bootstrap.js on a successful resolve. Tools
+  // that otherwise default to the embedded Spectrum snapshot (primer,
+  // describe_component) check this to switch to the resolved dataPath instead.
+  cascadeActive: false,
 };

--- a/tools/design-data-agent-mcp/src/config.js
+++ b/tools/design-data-agent-mcp/src/config.js
@@ -81,12 +81,19 @@ export const config = {
   // Path to a `.design-data.toml` (or its containing directory) declaring a
   // platform source + manifest cascade. When set, cascade-bootstrap.js
   // resolves it once at startup (via the CLI, which already knows how to
-  // fetch/cache a github source and apply the manifest) and repoints
-  // dataPath/dataRoot/cascadeActive below at the result. Unset by default so
-  // an in-repo run's ambient .design-data.toml (if any) doesn't surprise it.
+  // fetch/cache a github source and apply the manifest) and populates
+  // cascadeDataPath/cascadeActive below. Unset by default so an in-repo run's
+  // ambient .design-data.toml (if any) doesn't surprise it.
   designDataConfig: anchorPath(process.env.DESIGN_DATA_CONFIG ?? null),
+  // Set by cascade-bootstrap.js on a successful resolve: the temp dir holding
+  // the materialized cascade dataset. Deliberately separate from dataPath —
+  // dataPath/dataRoot are also the fallback anchors for unrelated
+  // write/authoring/data tools (write.js, data.js, authoring.js), which must
+  // keep targeting the real dataset root regardless of cascade state. Only
+  // read.js/validate.js consult cascadeDataPath.
+  cascadeDataPath: null,
   // Flipped to true by cascade-bootstrap.js on a successful resolve. Tools
   // that otherwise default to the embedded Spectrum snapshot (primer,
-  // describe_component) check this to switch to the resolved dataPath instead.
+  // describe_component) check this to switch to cascadeDataPath instead.
   cascadeActive: false,
 };

--- a/tools/design-data-agent-mcp/src/index.js
+++ b/tools/design-data-agent-mcp/src/index.js
@@ -24,6 +24,8 @@ import { createReadTools } from "./tools/read.js";
 import { createValidateTools } from "./tools/validate.js";
 import { createDiffTools } from "./tools/diff.js";
 import { createWriteTools } from "./tools/write.js";
+import { bootstrapCascade } from "./cascade-bootstrap.js";
+import { config } from "./config.js";
 
 export function createAllTools() {
   return [
@@ -85,6 +87,7 @@ export function createMCPServer() {
 }
 
 async function startServer() {
+  await bootstrapCascade(config);
   const server = createMCPServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -16,12 +16,28 @@
  *
  * Note: authoring_session_step_intent in authoring.js still uses the CLI because
  * the NLP suggest ranking is not yet on the wasm surface.
+ *
+ * Cascade scope (see cascade-bootstrap.js / spectrum-design-data-h890.14): once a
+ * `.design-data.toml` cascade is resolved, primer/resolve_token/query_tokens/
+ * validate_usage all reflect it (they read config.dataPath). describe_component
+ * does not — components/relationships still come from config.componentsDir /
+ * config.relationshipsDir, which resolve from the embedded @adobe/spectrum-design-data
+ * package regardless of cascade state. A platform source repo generally carries a
+ * token cascade only, not its own component schemas, so this is left out of scope
+ * rather than guessed at; revisit if a platform manifest starts declaring components.
  */
 
 import { readFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { loadDataset } from "@adobe/design-data/load";
 import { config } from "../config.js";
+
+// Note: this module intentionally never spawns the native binary — primer and
+// describe_component must keep working with no CLI on PATH at all (see the
+// structural test in read.test.js). Cascade resolution happens once at startup
+// in cascade-bootstrap.js (which does spawn the binary); by the time these
+// handlers run, a cascade dataset is just another local directory at
+// config.dataPath.
 
 let _wasm;
 /** Lazy-load and cache the wasm module (nodejs target, no init() required). */
@@ -32,15 +48,22 @@ async function getWasm() {
 
 let _dataset;
 /**
- * Return the embedded Spectrum dataset, caching it after first access.
+ * Return the active dataset, caching it after first access.
+ *
+ * When cascade-bootstrap.js resolved a `.design-data.toml` platform source at
+ * startup (config.cascadeActive), config.dataPath is a local dir holding the
+ * resolved cascade — load that instead of the embedded Spectrum snapshot, the
+ * same way resolve_token/query_tokens already do. cascadeActive is decided
+ * once at startup before any request runs, so caching here is safe.
  *
  * Dataset.embedded() clones the in-memory graph on every call; caching here
- * avoids that per-request cost.
+ * avoids that per-request cost either way.
  */
 async function getDataset() {
   if (!_dataset) {
-    const wasm = await getWasm();
-    _dataset = wasm.Dataset.embedded();
+    _dataset = config.cascadeActive
+      ? await loadDataset(config.dataPath)
+      : (await getWasm()).Dataset.embedded();
   }
   return _dataset;
 }
@@ -87,7 +110,7 @@ export function createReadTools() {
           // top-level source is the legacy skill-contract field; provenance.source
           // duplicates it intentionally — provenance is the richer metrics object
           // and consumers should prefer it going forward.
-          source: "embedded",
+          source: config.cascadeActive ? "cascade" : "embedded",
           tokenCount: ds.tokenCount(),
           modeSets: {
             colorScheme: wasm.getFieldValues("colorScheme") ?? [],

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -19,7 +19,8 @@
  *
  * Cascade scope (see cascade-bootstrap.js / spectrum-design-data-h890.14): once a
  * `.design-data.toml` cascade is resolved, primer/resolve_token/query_tokens/
- * validate_usage all reflect it (they read config.dataPath). describe_component
+ * validate_usage all reflect it (they read config.cascadeDataPath instead of
+ * config.dataPath when config.cascadeActive). describe_component
  * does not — components/relationships still come from config.componentsDir /
  * config.relationshipsDir, which resolve from the embedded @adobe/spectrum-design-data
  * package regardless of cascade state. A platform source repo generally carries a
@@ -51,9 +52,9 @@ let _dataset;
  * Return the active dataset, caching it after first access.
  *
  * When cascade-bootstrap.js resolved a `.design-data.toml` platform source at
- * startup (config.cascadeActive), config.dataPath is a local dir holding the
- * resolved cascade — load that instead of the embedded Spectrum snapshot, the
- * same way resolve_token/query_tokens already do. cascadeActive is decided
+ * startup (config.cascadeActive), config.cascadeDataPath is a local dir holding
+ * the resolved cascade — load that instead of the embedded Spectrum snapshot,
+ * the same way resolve_token/query_tokens already do. cascadeActive is decided
  * once at startup before any request runs, so caching here is safe.
  *
  * Dataset.embedded() clones the in-memory graph on every call; caching here
@@ -62,7 +63,7 @@ let _dataset;
 async function getDataset() {
   if (!_dataset) {
     _dataset = config.cascadeActive
-      ? await loadDataset(config.dataPath)
+      ? await loadDataset(config.cascadeDataPath)
       : (await getWasm()).Dataset.embedded();
   }
   return _dataset;
@@ -159,7 +160,9 @@ export function createReadTools() {
         additionalProperties: false,
       },
       async handler({ property, colorScheme, scale, contrast }) {
-        const ds = await loadDataset(config.dataPath);
+        const ds = await loadDataset(
+          config.cascadeActive ? config.cascadeDataPath : config.dataPath,
+        );
         const context = {};
         if (colorScheme) context.colorScheme = colorScheme;
         if (scale) context.scale = scale;
@@ -190,7 +193,9 @@ export function createReadTools() {
         additionalProperties: false,
       },
       async handler({ filter }) {
-        const ds = await loadDataset(config.dataPath);
+        const ds = await loadDataset(
+          config.cascadeActive ? config.cascadeDataPath : config.dataPath,
+        );
         return ds.query(filter);
       },
     },

--- a/tools/design-data-agent-mcp/src/tools/validate.js
+++ b/tools/design-data-agent-mcp/src/tools/validate.js
@@ -38,7 +38,9 @@ export function createValidateTools() {
         additionalProperties: false,
       },
       async handler({ path, strict, schema_path } = {}) {
-        const target = path ?? config.dataPath;
+        const target =
+          path ??
+          (config.cascadeActive ? config.cascadeDataPath : config.dataPath);
         const schemaPath = schema_path ?? config.schemaPath ?? null;
         // NOTE: exceptionsPath (DESIGN_DATA_EXCEPTIONS / --exceptions-path) applies to the
         // SPEC-007 naming rule in the relational layer. The in-process wasm validate() does

--- a/tools/design-data-agent-mcp/test/cascade-bootstrap.test.js
+++ b/tools/design-data-agent-mcp/test/cascade-bootstrap.test.js
@@ -1,0 +1,142 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bootstrapCascade } from "../src/cascade-bootstrap.js";
+
+// The actual CLI invocation (config discovery, github fetch/cache, manifest
+// cascade) is already covered by sdk/cli/tests/cli_source.rs and
+// cli_manifest.rs — these tests only cover the wiring this package owns:
+// deciding when to shell out, and what happens to `config` on success/failure.
+// `run` (injected in place of runCli) stands in for that CLI call.
+
+function freshConfig(overrides = {}) {
+  return {
+    dataPath: "/original/data/path",
+    dataRoot: "/original/data/root",
+    designDataConfig: null,
+    cascadeActive: false,
+    ...overrides,
+  };
+}
+
+test("no-op when designDataConfig is unset", async (t) => {
+  const config = freshConfig();
+  let called = false;
+  await bootstrapCascade(config, {
+    run: async () => {
+      called = true;
+      return { exitCode: 0, stdout: "[]", stderr: "" };
+    },
+  });
+  t.false(called, "run should not be invoked");
+  t.is(config.dataPath, "/original/data/path");
+  t.false(config.cascadeActive);
+});
+
+test("falls back when designDataConfig path does not exist", async (t) => {
+  const config = freshConfig({
+    designDataConfig: "/does/not/exist/.design-data.toml",
+  });
+  let called = false;
+  await bootstrapCascade(config, {
+    run: async () => {
+      called = true;
+      return { exitCode: 0, stdout: "[]", stderr: "" };
+    },
+  });
+  t.false(called, "run should not be invoked for a missing config path");
+  t.is(config.dataPath, "/original/data/path");
+  t.false(config.cascadeActive);
+});
+
+test("falls back when the CLI exits non-zero", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "cascade-test-"));
+  t.teardown(() => rmSync(dir, { recursive: true, force: true }));
+  const config = freshConfig({ designDataConfig: dir });
+
+  await bootstrapCascade(config, {
+    run: async () => ({ exitCode: 1, stdout: "", stderr: "boom" }),
+  });
+  t.is(config.dataPath, "/original/data/path");
+  t.false(config.cascadeActive);
+});
+
+test("falls back when the CLI emits unparseable JSON", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "cascade-test-"));
+  t.teardown(() => rmSync(dir, { recursive: true, force: true }));
+  const config = freshConfig({ designDataConfig: dir });
+
+  await bootstrapCascade(config, {
+    run: async () => ({ exitCode: 0, stdout: "not json", stderr: "" }),
+  });
+  t.is(config.dataPath, "/original/data/path");
+  t.false(config.cascadeActive);
+});
+
+test("materializes resolved tokens and repoints dataPath/dataRoot on success", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "cascade-test-"));
+  t.teardown(() => rmSync(dir, { recursive: true, force: true }));
+  const config = freshConfig({ designDataConfig: dir });
+  const tokens = [
+    {
+      name: { property: "test-cascade" },
+      $schema:
+        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+      value: "#ff00ff",
+      uuid: "11111111-1111-1111-1111-111111111111",
+    },
+  ];
+
+  let seenArgs;
+  let seenCwd;
+  await bootstrapCascade(config, {
+    run: async (args, opts) => {
+      seenArgs = args;
+      seenCwd = opts.cwd;
+      return { exitCode: 0, stdout: JSON.stringify(tokens), stderr: "" };
+    },
+  });
+
+  t.deepEqual(seenArgs, ["query", "--filter", "", "--format", "json"]);
+  t.is(seenCwd, dir);
+  t.true(config.cascadeActive);
+  t.is(config.dataRoot, dir);
+  t.not(config.dataPath, "/original/data/path");
+  t.true(existsSync(join(config.dataPath, "resolved.tokens.json")));
+  t.deepEqual(
+    JSON.parse(readFileSync(join(config.dataPath, "resolved.tokens.json"))),
+    tokens,
+  );
+});
+
+test("accepts a path to the .design-data.toml file itself, not just its directory", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "cascade-test-"));
+  t.teardown(() => rmSync(dir, { recursive: true, force: true }));
+  const tomlPath = join(dir, ".design-data.toml");
+  await import("node:fs").then((fs) =>
+    fs.writeFileSync(tomlPath, '[source]\ntype = "path"\nroot = "."\n'),
+  );
+  const config = freshConfig({ designDataConfig: tomlPath });
+
+  let seenCwd;
+  await bootstrapCascade(config, {
+    run: async (args, opts) => {
+      seenCwd = opts.cwd;
+      return { exitCode: 0, stdout: "[]", stderr: "" };
+    },
+  });
+
+  t.is(seenCwd, dir, "cwd should be the directory containing the toml file");
+  t.true(config.cascadeActive);
+});

--- a/tools/design-data-agent-mcp/test/cascade-bootstrap.test.js
+++ b/tools/design-data-agent-mcp/test/cascade-bootstrap.test.js
@@ -25,6 +25,7 @@ function freshConfig(overrides = {}) {
     dataPath: "/original/data/path",
     dataRoot: "/original/data/root",
     designDataConfig: null,
+    cascadeDataPath: null,
     cascadeActive: false,
     ...overrides,
   };
@@ -84,7 +85,7 @@ test("falls back when the CLI emits unparseable JSON", async (t) => {
   t.false(config.cascadeActive);
 });
 
-test("materializes resolved tokens and repoints dataPath/dataRoot on success", async (t) => {
+test("materializes resolved tokens into cascadeDataPath on success, without touching dataPath/dataRoot", async (t) => {
   const dir = mkdtempSync(join(tmpdir(), "cascade-test-"));
   t.teardown(() => rmSync(dir, { recursive: true, force: true }));
   const config = freshConfig({ designDataConfig: dir });
@@ -111,11 +112,17 @@ test("materializes resolved tokens and repoints dataPath/dataRoot on success", a
   t.deepEqual(seenArgs, ["query", "--filter", "", "--format", "json"]);
   t.is(seenCwd, dir);
   t.true(config.cascadeActive);
-  t.is(config.dataRoot, dir);
-  t.not(config.dataPath, "/original/data/path");
-  t.true(existsSync(join(config.dataPath, "resolved.tokens.json")));
+  // dataPath/dataRoot are the fallback anchors for unrelated write/authoring/data
+  // tools (write.js, data.js, authoring.js) — cascade resolution must not leak
+  // into them, or those tools would silently redirect to the cascade's temp dir.
+  t.is(config.dataPath, "/original/data/path");
+  t.is(config.dataRoot, "/original/data/root");
+  t.not(config.cascadeDataPath, null);
+  t.true(existsSync(join(config.cascadeDataPath, "resolved.tokens.json")));
   t.deepEqual(
-    JSON.parse(readFileSync(join(config.dataPath, "resolved.tokens.json"))),
+    JSON.parse(
+      readFileSync(join(config.cascadeDataPath, "resolved.tokens.json")),
+    ),
     tokens,
   );
 });

--- a/tools/design-data-agent-mcp/test/read-cascade.test.js
+++ b/tools/design-data-agent-mcp/test/read-cascade.test.js
@@ -9,7 +9,7 @@
 // governing permissions and limitations under the License.
 
 // Kept in its own serial test file (rather than added to read.test.js) because
-// every test here mutates the shared `config` singleton (config.dataPath /
+// every test here mutates the shared `config` singleton (config.cascadeDataPath /
 // config.cascadeActive) to simulate a resolved cascade — read.js's module-level
 // dataset cache means these must not interleave with each other or with
 // read.test.js's embedded-dataset assertions (a separate worker process, so no
@@ -37,14 +37,16 @@ test.before((t) => {
     JSON.stringify([FIXTURE_TOKEN]),
   );
   t.context.dir = dir;
-  t.context.savedDataPath = config.dataPath;
+  t.context.originalDataPath = config.dataPath;
+  t.context.originalDataRoot = config.dataRoot;
+  t.context.savedCascadeDataPath = config.cascadeDataPath;
   t.context.savedCascadeActive = config.cascadeActive;
-  config.dataPath = dir;
+  config.cascadeDataPath = dir;
   config.cascadeActive = true;
 });
 
 test.after.always((t) => {
-  config.dataPath = t.context.savedDataPath;
+  config.cascadeDataPath = t.context.savedCascadeDataPath;
   config.cascadeActive = t.context.savedCascadeActive;
   rmSync(t.context.dir, { recursive: true, force: true });
 });
@@ -77,5 +79,13 @@ test.serial(
     const result = await getHandler("query_tokens")({ filter: "" });
     t.is(result.length, 1);
     t.is(result[0].raw.value, "#ff00ff");
+  },
+);
+
+test.serial(
+  "cascade does not leak into config.dataPath/dataRoot (the fallback anchors write/authoring/data tools use)",
+  (t) => {
+    t.is(config.dataPath, t.context.originalDataPath);
+    t.is(config.dataRoot, t.context.originalDataRoot);
   },
 );

--- a/tools/design-data-agent-mcp/test/read-cascade.test.js
+++ b/tools/design-data-agent-mcp/test/read-cascade.test.js
@@ -1,0 +1,81 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+// Kept in its own serial test file (rather than added to read.test.js) because
+// every test here mutates the shared `config` singleton (config.dataPath /
+// config.cascadeActive) to simulate a resolved cascade — read.js's module-level
+// dataset cache means these must not interleave with each other or with
+// read.test.js's embedded-dataset assertions (a separate worker process, so no
+// cross-file interference, but same-file tests still need `test.serial`).
+
+import test from "ava";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { config } from "../src/config.js";
+import { createReadTools } from "../src/tools/read.js";
+
+const FIXTURE_TOKEN = {
+  name: { property: "test-cascade" },
+  $schema:
+    "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+  value: "#ff00ff",
+  uuid: "11111111-1111-1111-1111-111111111111",
+};
+
+test.before((t) => {
+  const dir = mkdtempSync(join(tmpdir(), "cascade-read-test-"));
+  writeFileSync(
+    join(dir, "resolved.tokens.json"),
+    JSON.stringify([FIXTURE_TOKEN]),
+  );
+  t.context.dir = dir;
+  t.context.savedDataPath = config.dataPath;
+  t.context.savedCascadeActive = config.cascadeActive;
+  config.dataPath = dir;
+  config.cascadeActive = true;
+});
+
+test.after.always((t) => {
+  config.dataPath = t.context.savedDataPath;
+  config.cascadeActive = t.context.savedCascadeActive;
+  rmSync(t.context.dir, { recursive: true, force: true });
+});
+
+function getHandler(name) {
+  const tool = createReadTools().find((t) => t.name === name);
+  if (!tool) throw new Error(`tool "${name}" not found`);
+  return tool.handler.bind(tool);
+}
+
+test.serial(
+  "primer reflects the cascade dataset, not the embedded one",
+  async (t) => {
+    const result = await getHandler("primer")();
+    t.is(result.source, "cascade");
+    t.is(result.tokenCount, 1);
+  },
+);
+
+test.serial("resolve_token returns the cascade-resolved token", async (t) => {
+  const result = await getHandler("resolve_token")({
+    property: "test-cascade",
+  });
+  t.is(result.token.raw.value, "#ff00ff");
+});
+
+test.serial(
+  "query_tokens returns tokens from the cascade dataset",
+  async (t) => {
+    const result = await getHandler("query_tokens")({ filter: "" });
+    t.is(result.length, 1);
+    t.is(result[0].raw.value, "#ff00ff");
+  },
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`@adobe/design-data-agent-mcp` has two execution paths: a CLI runner (used for
authoring/lifecycle/data-write) that already honors `.design-data.toml`
because the `design-data` CLI does config discovery + manifest cascade
application on every subcommand, and an in-process wasm/JS path
(`primer`/`resolve_token`/`query_tokens`/`validate_usage`) that only ever knew
about the embedded Spectrum snapshot or a raw local directory.

This adds a `DESIGN_DATA_CONFIG` env var: when set, the server shells out to
the CLI once at startup to resolve the configured source + manifest cascade,
materializes it to a temp dataset, and points the in-process tools at it.
`describe_component` is intentionally left out of scope — components still
come from `@adobe/spectrum-design-data` regardless of cascade state. Failure
to resolve (e.g. no network for a github source) logs a warning and falls
back to the embedded/local dataset rather than crashing the server.

## Related Issue

Closes bead `spectrum-design-data-h890.14` (part of epic h890 / DNA-1741:
connect Web/iOS/Android to design data).

## Motivation and Context

The Aug 28 iOS cascade+manifest POC proved the model end-to-end for a Swift
consumer. This is the next step in the h890 productionization epic: making
the agent surface (read/validate/authoring via MCP) see the same
platform-resolved dataset, so AI tooling reflects a platform's
overrides/extensions instead of only the Foundation snapshot.

## How Has This Been Tested?

- Added `cascade-bootstrap.test.js` (unit tests for the bootstrap wiring,
  with an injectable `run` in place of the CLI spawn — no network/binary
  required) and `read-cascade.test.js` (verifies `primer`/`resolve_token`/
  `query_tokens` reflect a resolved cascade dataset). 54/54 tests pass via
  `moon run design-data-agent-mcp:test`.
- Manual end-to-end: built the real `design-data` CLI binary, constructed a
  local `type = "path"` source with a `manifest.json` override (no network
  needed), pointed `DESIGN_DATA_CONFIG` at it, and confirmed `primer` reports
  `source: "cascade"` and `resolve_token` returns the manifest-overridden
  value.
- Regression: with `DESIGN_DATA_CONFIG` unset, existing behavior (embedded
  snapshot) is unchanged — covered by the existing test suite.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
