### PR TITLE
feat(sdk): manifest support for extensions.guidelines

### DIFF
--- a/.changeset/manifest-extensions-guidelines.md
+++ b/.changeset/manifest-extensions-guidelines.md
@@ -1,0 +1,20 @@
+---
+"@adobe/design-data-spec": minor
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
+---
+
+Let a platform manifest carry guideline documents as a first-class,
+cascade-consumable `extensions` section (bead spectrum-design-data-h890.23.1),
+continuing the cascade parity work started for components/platformExtensions
+in h890.22.
+
+- **packages/design-data-spec/schemas/manifest.schema.json**: `extensions`
+  gains `guidelines` (array of `guideline.schema.json` items).
+- **packages/design-data-spec/spec/manifest.md**: capability matrix and a new
+  `extensions.guidelines` subsection document the add-or-replace-by-name
+  semantics.
+- **sdk/core/src/graph.rs**: `apply_platform_manifest` adds a guarded section
+  that add-or-replaces into the guideline catalog by `name`, reusing the
+  existing `GuidelineRecord`/`load_spec_guidelines` and `upsert_by_key` — no
+  struct change, so no cache-schema-version bump is needed.

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -103,6 +103,11 @@
           },
           "description": "Platform-local terminology extensions (e.g. iOS state vocabulary), annotating ids in an existing base registry."
         },
+        "guidelines": {
+          "type": "array",
+          "items": { "$ref": "guideline.schema.json" },
+          "description": "Platform-local guideline docs, injected into the guideline catalog (add-or-replace by name)."
+        },
         "formatting": {
           "type": "object",
           "description": "Rules for serializing structured name objects into platform-specific token name strings.",

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -6,20 +6,21 @@ This document defines the **platform manifest**: how a platform implementation r
 
 ## Capability matrix
 
-The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (fields, guidelines, relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
+The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (fields, relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
 
-| Operation                                                                                       | Supported?                                                 | Field                           | Applies to            |
-| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
-| Remove / exclude                                                                                | Yes                                                        | `exclude`                       | Tokens only           |
-| Include / whitelist                                                                             | Yes                                                        | `include`                       | Tokens only           |
-| Override value (type-preserving)                                                                | Yes                                                        | `overrides[].value`             | Tokens only           |
-| Override → re-alias                                                                             | Yes                                                        | `overrides[].$ref`              | Tokens only           |
-| Add new tokens (may alias via `$ref`)                                                           | Yes                                                        | `extensions.tokens`             | Tokens                |
-| Add / replace components                                                                        | Yes                                                        | `extensions.components`         | Components            |
-| Annotate existing terminology (cannot add new ids)                                              | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
-| Restrict allowed mode-set values                                                                | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
-| Reformat name serialization                                                                     | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
-| Override/remove/alias fields, guidelines, relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
+| Operation                                                                           | Supported?                                                 | Field                           | Applies to            |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
+| Remove / exclude                                                                    | Yes                                                        | `exclude`                       | Tokens only           |
+| Include / whitelist                                                                 | Yes                                                        | `include`                       | Tokens only           |
+| Override value (type-preserving)                                                    | Yes                                                        | `overrides[].value`             | Tokens only           |
+| Override → re-alias                                                                 | Yes                                                        | `overrides[].$ref`              | Tokens only           |
+| Add new tokens (may alias via `$ref`)                                               | Yes                                                        | `extensions.tokens`             | Tokens                |
+| Add / replace components                                                            | Yes                                                        | `extensions.components`         | Components            |
+| Add / replace guideline documents                                                   | Yes                                                        | `extensions.guidelines`         | Guidelines            |
+| Annotate existing terminology (cannot add new ids)                                  | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
+| Restrict allowed mode-set values                                                    | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
+| Reformat name serialization                                                         | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
+| Override/remove/alias fields, relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
 
 ## Manifest document
 
@@ -67,6 +68,10 @@ Platform-local token definitions, in cascade-file format. Inserted at the platfo
 #### `extensions.components`
 
 Platform-local component specs, injected into the component catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by component `name` at the platform layer.
+
+#### `extensions.guidelines`
+
+Platform-local guideline documents, injected into the guideline catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by guideline `name` at the platform layer; each entry **MUST** validate against `guideline.schema.json`.
 
 #### `extensions.platformExtensions`
 

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -35,13 +35,13 @@ A manifest **MUST** conform to [`manifest.schema.json`](../schemas/manifest.sche
 
 ## Optional fields
 
-| Field                 | Type            | Description                                                                                                                                          |
-| --------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                          |
-| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                       |
-| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                     |
-| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `platformExtensions`, `formatting` (see `extensions` section below). |
-| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                |
+| Field                 | Type            | Description                                                                                                                                                        |
+| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                        |
+| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                     |
+| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                   |
+| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `guidelines`, `platformExtensions`, `formatting` (see `extensions` section below). |
+| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                              |
 
 ### `include` / `exclude`
 

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -984,6 +984,26 @@ impl TokenGraph {
             }
         }
 
+        // 7. extensions.guidelines — platform-local guideline docs, add-or-replace
+        // by name into the guideline catalog.
+        if let Some(entries) = manifest
+            .get("extensions")
+            .and_then(|e| e.get("guidelines"))
+            .and_then(|v| v.as_array())
+        {
+            for entry in entries {
+                let Some(name) = entry.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let record = GuidelineRecord {
+                    name: name.to_string(),
+                    file: PathBuf::from("manifest.json"),
+                    raw: entry.clone(),
+                };
+                upsert_by_key(&mut self.guidelines, |g| g.name == name, record);
+            }
+        }
+
         Ok(PlatformManifest {
             mode_set_restrictions,
         })

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -297,6 +297,42 @@ mod tests {
     }
 
     #[test]
+    fn manifest_injects_platform_guideline() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "guidelines": [{
+                        "$id": "https://example.com/guidelines/ios-haptics",
+                        "name": "ios-haptics",
+                        "title": "iOS Haptics",
+                        "category": "developing",
+                        "documentBlocks": [
+                            {"type": "purpose", "content": "When to use haptic feedback on iOS."}
+                        ]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let injected = graph
+            .guidelines
+            .iter()
+            .find(|g| g.name == "ios-haptics")
+            .expect("injected guideline present");
+        assert_eq!(injected.raw["title"], "iOS Haptics");
+    }
+
+    #[test]
     fn manifest_rejects_unknown_term_id() {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("manifest.json");


### PR DESCRIPTION
## Description

Extend the platform-manifest cascade to guideline documents via a new
`extensions.guidelines` section, mirroring the `extensions.components`
pattern shipped in h890.22 (#1380). A platform manifest can now add or
replace guideline documents by `name` at the platform layer, in addition to
tokens, components, and platform-extension terminology.

- `sdk/core/src/graph.rs`: new guarded section in `apply_platform_manifest`
  — reuses the existing `GuidelineRecord`, `load_spec_guidelines`, and
  `upsert_by_key` helper, so no struct change and no cache-schema-version
  bump.
- `packages/design-data-spec/schemas/manifest.schema.json`: `extensions`
  gains `guidelines` (array of `guideline.schema.json` items).
- `packages/design-data-spec/spec/manifest.md`: capability matrix row +
  `extensions.guidelines` subsection + `extensions` field description.

## Related Issue

spectrum-design-data-h890.23.1 (child of h890.23, continuation of h890.22).

## Motivation and Context

Part of the platform-manifest cascade extension work (h890.23) that brings
the remaining foundation artifact types up to parity with tokens/components,
so external platform repos (e.g. spectrum-ios-design-data) can inject their
own guideline docs the same way they already inject components.

## How Has This Been Tested?

- `cargo test --workspace` (sdk): 739 passed, 0 failed.
- New test `manifest::tests::manifest_injects_platform_guideline` validates
  a manifest-injected guideline against the real `guideline.schema.json` and
  confirms it lands in the graph's guideline catalog.
- `moon run design-data-spec:check`: layout OK.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`: 3/3
  valid.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
