### PR TITLE
feat(sdk): manifest support for extensions.fields

### DIFF
--- a/.changeset/manifest-extensions-fields.md
+++ b/.changeset/manifest-extensions-fields.md
@@ -1,0 +1,20 @@
+---
+"@adobe/design-data-spec": minor
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
+---
+
+Let a platform manifest carry field declarations as a first-class,
+cascade-consumable `extensions` section (bead spectrum-design-data-h890.23.2),
+continuing the cascade parity work started for components/platformExtensions
+in h890.22.
+
+- **packages/design-data-spec/schemas/manifest.schema.json**: `extensions`
+  gains `fields` (array of `field.schema.json` items).
+- **packages/design-data-spec/spec/manifest.md**: capability matrix and a new
+  `extensions.fields` subsection document the add-or-replace-by-name
+  semantics, including the `conceptOrder` name-reference caveat.
+- **sdk/core/src/graph.rs**: `apply_platform_manifest` adds a guarded section
+  that add-or-replaces into the field catalog by `name`, reusing the
+  existing `FieldRecord`/`load_spec_fields` and `upsert_by_key` — no
+  struct change, so no cache-schema-version bump is needed.

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -96,6 +96,11 @@
           "items": { "$ref": "component.schema.json" },
           "description": "Platform-local component specs, injected into the component catalog (add-or-replace by name)."
         },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "field.schema.json" },
+          "description": "Platform-local field declarations, injected into the field catalog (add-or-replace by name)."
+        },
         "platformExtensions": {
           "type": "array",
           "items": {

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -6,20 +6,21 @@ This document defines the **platform manifest**: how a platform implementation r
 
 ## Capability matrix
 
-The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (fields, guidelines, relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
+The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (guidelines, relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
 
-| Operation                                                                                       | Supported?                                                 | Field                           | Applies to            |
-| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
-| Remove / exclude                                                                                | Yes                                                        | `exclude`                       | Tokens only           |
-| Include / whitelist                                                                             | Yes                                                        | `include`                       | Tokens only           |
-| Override value (type-preserving)                                                                | Yes                                                        | `overrides[].value`             | Tokens only           |
-| Override → re-alias                                                                             | Yes                                                        | `overrides[].$ref`              | Tokens only           |
-| Add new tokens (may alias via `$ref`)                                                           | Yes                                                        | `extensions.tokens`             | Tokens                |
-| Add / replace components                                                                        | Yes                                                        | `extensions.components`         | Components            |
-| Annotate existing terminology (cannot add new ids)                                              | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
-| Restrict allowed mode-set values                                                                | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
-| Reformat name serialization                                                                     | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
-| Override/remove/alias fields, guidelines, relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
+| Operation                                                                               | Supported?                                                 | Field                           | Applies to            |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
+| Remove / exclude                                                                        | Yes                                                        | `exclude`                       | Tokens only           |
+| Include / whitelist                                                                     | Yes                                                        | `include`                       | Tokens only           |
+| Override value (type-preserving)                                                        | Yes                                                        | `overrides[].value`             | Tokens only           |
+| Override → re-alias                                                                     | Yes                                                        | `overrides[].$ref`              | Tokens only           |
+| Add new tokens (may alias via `$ref`)                                                   | Yes                                                        | `extensions.tokens`             | Tokens                |
+| Add / replace components                                                                | Yes                                                        | `extensions.components`         | Components            |
+| Add / replace field declarations                                                        | Yes                                                        | `extensions.fields`             | Fields                |
+| Annotate existing terminology (cannot add new ids)                                      | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
+| Restrict allowed mode-set values                                                        | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
+| Reformat name serialization                                                             | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
+| Override/remove/alias guidelines, relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
 
 ## Manifest document
 
@@ -34,13 +35,13 @@ A manifest **MUST** conform to [`manifest.schema.json`](../schemas/manifest.sche
 
 ## Optional fields
 
-| Field                 | Type            | Description                                                                                                                                          |
-| --------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                          |
-| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                       |
-| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                     |
-| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `platformExtensions`, `formatting` (see `extensions` section below). |
-| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                |
+| Field                 | Type            | Description                                                                                                                                                    |
+| --------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                    |
+| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                 |
+| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                               |
+| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `fields`, `platformExtensions`, `formatting` (see `extensions` section below). |
+| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                          |
 
 ### `include` / `exclude`
 
@@ -67,6 +68,10 @@ Platform-local token definitions, in cascade-file format. Inserted at the platfo
 #### `extensions.components`
 
 Platform-local component specs, injected into the component catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by component `name` at the platform layer.
+
+#### `extensions.fields`
+
+Platform-local field declarations, injected into the field catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by field `name` at the platform layer; each entry **MUST** validate against `field.schema.json`. Note: `extensions.formatting.conceptOrder` (if declared) references field names by string — a platform that renames or removes a field it also references there is self-inconsistent; that is a manifest-authoring concern, not enforced by the reference SDK.
 
 #### `extensions.platformExtensions`
 

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -984,6 +984,39 @@ impl TokenGraph {
             }
         }
 
+        // 7. extensions.fields — platform-local field declarations, add-or-replace
+        // by name into the field catalog. `extensions.formatting.conceptOrder`
+        // (if present) references field names by string, so a platform that
+        // renames or removes a field it also references there is
+        // self-inconsistent; that is a manifest-authoring concern, not
+        // enforced here.
+        if let Some(entries) = manifest
+            .get("extensions")
+            .and_then(|e| e.get("fields"))
+            .and_then(|v| v.as_array())
+        {
+            for entry in entries {
+                let Some(name) = entry.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let required = entry
+                    .get("required")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let description = entry
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                let record = FieldRecord {
+                    name: name.to_string(),
+                    required,
+                    description,
+                };
+                upsert_by_key(&mut self.fields, |f| f.name == name, record);
+            }
+        }
+
         Ok(PlatformManifest {
             mode_set_restrictions,
         })

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -297,6 +297,41 @@ mod tests {
     }
 
     #[test]
+    fn manifest_injects_platform_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "fields": [{
+                        "name": "hapticStyle",
+                        "kind": "semantic",
+                        "registry": null,
+                        "validation": "none",
+                        "serialization": {"position": 9},
+                        "required": false
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let injected = graph
+            .fields
+            .iter()
+            .find(|f| f.name == "hapticStyle")
+            .expect("injected field present");
+        assert!(!injected.required);
+    }
+
+    #[test]
     fn manifest_rejects_unknown_term_id() {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("manifest.json");


### PR DESCRIPTION
## Description

Extends the platform-manifest cascade (Layer 2) to support `extensions.fields`, mirroring the existing `extensions.components` handling: a platform manifest can now add or replace field declarations in the field catalog by `name`. Part of the platform-manifest cascade parity work (h890.23), which follows the tokens/components/platformExtensions cascade shipped in h890.22.

- **`sdk/core/src/graph.rs`**: `apply_platform_manifest` gains a new section that reads `extensions.fields[]`, builds a `FieldRecord`, and add-or-replaces it into `self.fields` via the existing `upsert_by_key` helper. No struct fields were added, so no `CACHE_SCHEMA_VERSION` bump is needed.
- **`sdk/core/src/manifest.rs`**: new `manifest_injects_platform_field` test, validated against the real `field.schema.json`.
- **`packages/design-data-spec/schemas/manifest.schema.json`**: `extensions` gains an explicit `fields` property (`$ref: field.schema.json`).
- **`packages/design-data-spec/spec/manifest.md`**: capability matrix flips fields to "Yes", plus a new `#### extensions.fields` subsection documenting add-or-replace-by-name semantics and the `conceptOrder` name-reference caveat.
- **`.changeset/manifest-extensions-fields.md`**: minor bump for `@adobe/design-data-spec`, `@adobe/design-data-tui`, `@adobe/design-data-wasm`.

## Related Issue

spectrum-design-data-h890.23.2

## Motivation and Context

Platform repos (e.g. spectrum-ios-design-data) need to declare platform-local field declarations without a monorepo PR. This closes one of the remaining artifact-type gaps in the manifest cascade.

## How Has This Been Tested?

- `cargo test --workspace` (via `moon run sdk:test` equivalent) — all green, including the new `manifest_injects_platform_field` test.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.
- `moon run design-data-spec:check` — passes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
