### PR TITLE
feat(sdk): manifest support for extensions.relationships

### DIFF
--- a/.changeset/manifest-extensions-relationships.md
+++ b/.changeset/manifest-extensions-relationships.md
@@ -18,7 +18,5 @@ started for components/platformExtensions in h890.22.
   have no other stable key.
 - **sdk/core/src/graph.rs**: `apply_platform_manifest` adds a guarded
   section handling add/override/remove, reusing the existing
-  `RelationshipRecord` (already carries `uuid: Option<String>`) — no struct
-  change, so no cache-schema-version bump is needed. An override/remove
-  entry missing `uuid` is rejected with a clear error, not silently
-  skipped.
+  `RelationshipRecord`. Add always appends, even on a `uuid` collision;
+  override/remove require an explicit `uuid` or error.

--- a/.changeset/manifest-extensions-relationships.md
+++ b/.changeset/manifest-extensions-relationships.md
@@ -1,0 +1,24 @@
+---
+"@adobe/design-data-spec": minor
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
+---
+
+Let a platform manifest add, override, or remove Component/Token
+Relationship (CTR) entries via a new `extensions.relationships` section
+(bead spectrum-design-data-h890.23.3), continuing the cascade parity work
+started for components/platformExtensions in h890.22.
+
+- **packages/design-data-spec/schemas/manifest.schema.json**: `extensions`
+  gains `relationships` (array of `relationship.schema.json` items, or
+  `{op: "override"|"remove", uuid, value?}` targeting entries).
+- **packages/design-data-spec/spec/manifest.md**: capability matrix and a
+  new `extensions.relationships` subsection document the identity model —
+  add is positional, override/remove require a `uuid` since relationships
+  have no other stable key.
+- **sdk/core/src/graph.rs**: `apply_platform_manifest` adds a guarded
+  section handling add/override/remove, reusing the existing
+  `RelationshipRecord` (already carries `uuid: Option<String>`) — no struct
+  change, so no cache-schema-version bump is needed. An override/remove
+  entry missing `uuid` is rejected with a clear error, not silently
+  skipped.

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -101,6 +101,36 @@
           "items": { "$ref": "field.schema.json" },
           "description": "Platform-local field declarations, injected into the field catalog (add-or-replace by name)."
         },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "relationship.schema.json#/$defs/relationship" },
+              {
+                "type": "object",
+                "required": ["op", "uuid", "value"],
+                "properties": {
+                  "op": { "const": "override" },
+                  "uuid": { "type": "string", "format": "uuid" },
+                  "value": {
+                    "$ref": "relationship.schema.json#/$defs/relationship"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": ["op", "uuid"],
+                "properties": {
+                  "op": { "const": "remove" },
+                  "uuid": { "type": "string", "format": "uuid" }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "description": "Platform-local Component/Token Relationship (CTR) add/override/remove. Entries without \"op\" are added positionally; \"override\"/\"remove\" require a \"uuid\" to target an existing relationship."
+        },
         "platformExtensions": {
           "type": "array",
           "items": {

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -6,22 +6,23 @@ This document defines the **platform manifest**: how a platform implementation r
 
 ## Capability matrix
 
-The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
+The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (exceptions, translations, schemas) have no manifest-level override mechanism at all.
 
-| Operation                                                                    | Supported?                                                 | Field                           | Applies to            |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
-| Remove / exclude                                                             | Yes                                                        | `exclude`                       | Tokens only           |
-| Include / whitelist                                                         | Yes                                                        | `include`                       | Tokens only           |
-| Override value (type-preserving)                                            | Yes                                                        | `overrides[].value`             | Tokens only           |
-| Override → re-alias                                                         | Yes                                                        | `overrides[].$ref`              | Tokens only           |
-| Add new tokens (may alias via `$ref`)                                       | Yes                                                        | `extensions.tokens`             | Tokens                |
-| Add / replace components                                                    | Yes                                                        | `extensions.components`         | Components            |
-| Add / replace field declarations                                            | Yes                                                        | `extensions.fields`             | Fields                |
-| Add / replace guideline documents                                           | Yes                                                        | `extensions.guidelines`         | Guidelines            |
-| Annotate existing terminology (cannot add new ids)                          | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
-| Restrict allowed mode-set values                                            | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
-| Reformat name serialization                                                 | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
-| Override/remove/alias relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
+| Operation                                                           | Supported?                                                 | Field                           | Applies to            |
+| -------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
+| Remove / exclude                                                    | Yes                                                        | `exclude`                       | Tokens only           |
+| Include / whitelist                                                 | Yes                                                        | `include`                       | Tokens only           |
+| Override value (type-preserving)                                    | Yes                                                        | `overrides[].value`             | Tokens only           |
+| Override → re-alias                                                 | Yes                                                        | `overrides[].$ref`              | Tokens only           |
+| Add new tokens (may alias via `$ref`)                               | Yes                                                        | `extensions.tokens`             | Tokens                |
+| Add / replace components                                            | Yes                                                        | `extensions.components`         | Components            |
+| Add / replace field declarations                                    | Yes                                                        | `extensions.fields`             | Fields                |
+| Add / replace guideline documents                                   | Yes                                                        | `extensions.guidelines`         | Guidelines            |
+| Add relationships/CTRs; override/remove by `uuid`                   | Yes                                                        | `extensions.relationships`      | Relationships (CTRs)  |
+| Annotate existing terminology (cannot add new ids)                  | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
+| Restrict allowed mode-set values                                    | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
+| Reformat name serialization                                         | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
+| Override/remove/alias exceptions, translations, schemas             | No                                                         | —                               | —                     |
 
 ## Manifest document
 
@@ -36,13 +37,13 @@ A manifest **MUST** conform to [`manifest.schema.json`](../schemas/manifest.sche
 
 ## Optional fields
 
-| Field                 | Type            | Description                                                                                                                                                                 |
-| --------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                                |
-| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                             |
-| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                           |
-| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `fields`, `guidelines`, `platformExtensions`, `formatting` (see `extensions` section below). |
-| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                                      |
+| Field                 | Type            | Description                                                                                                                                                                              |
+| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                                              |
+| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                                           |
+| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                                         |
+| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `fields`, `guidelines`, `relationships`, `platformExtensions`, `formatting` (see `extensions` section below). |
+| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                                                   |
 
 ### `include` / `exclude`
 
@@ -77,6 +78,20 @@ Platform-local field declarations, injected into the field catalog. **NORMATIVE:
 #### `extensions.guidelines`
 
 Platform-local guideline documents, injected into the guideline catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by guideline `name` at the platform layer; each entry **MUST** validate against `guideline.schema.json`.
+
+#### `extensions.relationships`
+
+Platform-local Component/Token Relationship (CTR) entries. Relationships have no inherent
+stable key — only an optional `uuid` — so add and override/remove use different identity
+rules:
+
+* **Add:** an entry with no `op` field is a full relationship object (validated against
+  `relationship.schema.json`), appended at the platform layer.
+* **Override / remove:** relationships have no other stable identity, so targeting one
+  **MUST** carry a `uuid`. **NORMATIVE:** an `extensions.relationships` entry with `"op":
+  "override"` or `"op": "remove"` that omits `uuid` is a manifest error — the reference SDK
+  rejects it rather than silently skipping it. `"op": "override"` also carries a `value` (the
+  replacement relationship object); `"op": "remove"` drops the matching record.
 
 #### `extensions.platformExtensions`
 

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1062,18 +1062,15 @@ impl TokenGraph {
                         let record = RelationshipRecord {
                             file: PathBuf::from("manifest.json"),
                             index,
-                            uuid: uuid.clone(),
+                            uuid,
                             raw: entry.clone(),
                         };
-                        if let Some(target_uuid) = uuid.as_deref() {
-                            upsert_by_key(
-                                &mut self.relationships,
-                                |r| r.uuid.as_deref() == Some(target_uuid),
-                                record,
-                            );
-                        } else {
-                            self.relationships.push(record);
-                        }
+                        // Always append — a plain add has no "op" and must not
+                        // silently overwrite an existing relationship even if its
+                        // (optional, unconstrained) uuid happens to collide with
+                        // one already present. Overwriting requires an explicit
+                        // "op": "override" entry (handled below).
+                        self.relationships.push(record);
                     }
                     Some("override") => {
                         let target_uuid =

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1037,6 +1037,104 @@ impl TokenGraph {
             }
         }
 
+        // 9. extensions.relationships — platform-local CTR add/override/remove.
+        // Add: an entry with no "op" is a full relationship object (per
+        // relationship.schema.json), appended at the platform layer, keyed
+        // positionally (file "manifest.json", index = its position in this array).
+        // Override/remove: relationships have no stable identity besides an
+        // optional `uuid`, so targeting one requires an entry with "op":
+        // "override" or "op": "remove" plus a "uuid" — an override/remove entry
+        // missing a uuid is a manifest-authoring error, rejected rather than
+        // silently skipped. "override" also carries a "value" (the replacement
+        // relationship object); "remove" drops the matching record entirely.
+        if let Some(entries) = manifest
+            .get("extensions")
+            .and_then(|e| e.get("relationships"))
+            .and_then(|v| v.as_array())
+        {
+            for (index, entry) in entries.iter().enumerate() {
+                match entry.get("op").and_then(|v| v.as_str()) {
+                    None => {
+                        let uuid = entry
+                            .get("uuid")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
+                        let record = RelationshipRecord {
+                            file: PathBuf::from("manifest.json"),
+                            index,
+                            uuid: uuid.clone(),
+                            raw: entry.clone(),
+                        };
+                        if let Some(target_uuid) = uuid.as_deref() {
+                            upsert_by_key(
+                                &mut self.relationships,
+                                |r| r.uuid.as_deref() == Some(target_uuid),
+                                record,
+                            );
+                        } else {
+                            self.relationships.push(record);
+                        }
+                    }
+                    Some("override") => {
+                        let target_uuid =
+                            entry.get("uuid").and_then(|v| v.as_str()).ok_or_else(|| {
+                                CoreError::ParseError(
+                                    "platform manifest extensions.relationships override entry \
+                                     is missing a \"uuid\" — relationships have no other stable \
+                                     identity to target"
+                                        .to_string(),
+                                )
+                            })?;
+                        let value = entry.get("value").cloned().ok_or_else(|| {
+                            CoreError::ParseError(format!(
+                                "platform manifest extensions.relationships override for uuid \
+                                 \"{target_uuid}\" is missing a \"value\" (the replacement \
+                                 relationship object)"
+                            ))
+                        })?;
+                        let target = self
+                            .relationships
+                            .iter_mut()
+                            .find(|r| r.uuid.as_deref() == Some(target_uuid))
+                            .ok_or_else(|| {
+                                CoreError::ParseError(format!(
+                                    "platform manifest extensions.relationships override \
+                                     targets uuid \"{target_uuid}\" which does not exist"
+                                ))
+                            })?;
+                        target.raw = value;
+                    }
+                    Some("remove") => {
+                        let target_uuid =
+                            entry.get("uuid").and_then(|v| v.as_str()).ok_or_else(|| {
+                                CoreError::ParseError(
+                                    "platform manifest extensions.relationships remove entry is \
+                                     missing a \"uuid\" — relationships have no other stable \
+                                     identity to target"
+                                        .to_string(),
+                                )
+                            })?;
+                        let before = self.relationships.len();
+                        self.relationships
+                            .retain(|r| r.uuid.as_deref() != Some(target_uuid));
+                        if self.relationships.len() == before {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.relationships remove targets \
+                                 uuid \"{target_uuid}\" which does not exist"
+                            )));
+                        }
+                    }
+                    Some(other) => {
+                        return Err(CoreError::ParseError(format!(
+                            "platform manifest extensions.relationships entry has unknown op \
+                             \"{other}\" (expected \"override\" or \"remove\", or omit \"op\" \
+                             to add)"
+                        )));
+                    }
+                }
+            }
+        }
+
         Ok(PlatformManifest {
             mode_set_restrictions,
         })
@@ -1984,6 +2082,54 @@ mod tests {
             .find(|t| t.uuid.as_deref() == Some("u-card-elev"))
             .expect("extension token present");
         assert_eq!(ext.layer, Layer::Platform);
+    }
+
+    #[test]
+    fn manifest_relationship_override_without_uuid_errors() {
+        // Bypasses Layer 1 schema validation (which already requires "uuid"
+        // alongside "op": "override"/"remove") to exercise graph.rs's own
+        // uuid-required check directly.
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "relationships": [{
+                    "op": "override",
+                    "value": {"scope": {"component": "button", "property": "corner-radius"}, "value": "8px"}
+                }]
+            }
+        });
+        let err = g.apply_platform_manifest(&manifest).unwrap_err();
+        assert!(err.to_string().contains("missing a \"uuid\""));
+    }
+
+    #[test]
+    fn manifest_relationship_remove_without_uuid_errors() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "relationships": [{"op": "remove"}]
+            }
+        });
+        let err = g.apply_platform_manifest(&manifest).unwrap_err();
+        assert!(err.to_string().contains("missing a \"uuid\""));
+    }
+
+    #[test]
+    fn manifest_relationship_unknown_op_errors() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "relationships": [{"op": "rename", "uuid": "u-whatever"}]
+            }
+        });
+        let err = g.apply_platform_manifest(&manifest).unwrap_err();
+        assert!(err.to_string().contains("unknown op"));
     }
 
     #[test]

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -368,6 +368,149 @@ mod tests {
     }
 
     #[test]
+    fn manifest_injects_platform_relationship() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "relationships": [{
+                        "scope": {"component": "button", "property": "corner-radius"},
+                        "value": "4px",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let injected = graph
+            .relationships
+            .iter()
+            .find(|r| r.uuid.as_deref() == Some("9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"))
+            .expect("injected relationship present");
+        assert_eq!(injected.raw["value"], "4px");
+    }
+
+    #[test]
+    fn manifest_overrides_relationship_by_uuid() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "relationships": [
+                        {
+                            "scope": {"component": "button", "property": "corner-radius"},
+                            "value": "4px",
+                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                        },
+                        {
+                            "op": "override",
+                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a",
+                            "value": {
+                                "scope": {"component": "button", "property": "corner-radius"},
+                                "value": "8px",
+                                "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                            }
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let overridden = graph
+            .relationships
+            .iter()
+            .find(|r| r.uuid.as_deref() == Some("9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"))
+            .expect("overridden relationship present");
+        assert_eq!(overridden.raw["value"], "8px");
+        assert_eq!(graph.relationships.len(), 1);
+    }
+
+    #[test]
+    fn manifest_removes_relationship_by_uuid() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "relationships": [
+                        {
+                            "scope": {"component": "button", "property": "corner-radius"},
+                            "value": "4px",
+                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                        },
+                        {
+                            "op": "remove",
+                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        assert!(graph
+            .relationships
+            .iter()
+            .all(|r| r.uuid.as_deref() != Some("9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a")));
+    }
+
+    #[test]
+    fn manifest_rejects_relationship_override_without_uuid() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "relationships": [{
+                        "op": "override",
+                        "value": {
+                            "scope": {"component": "button", "property": "corner-radius"},
+                            "value": "8px"
+                        }
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        // Layer 1 schema requires "uuid" alongside "op": "override", so this is
+        // rejected at schema validation, before graph.rs's own uuid check runs.
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("schema validation"));
+    }
+
+    #[test]
     fn manifest_rejects_unknown_term_id() {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("manifest.json");

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -444,6 +444,53 @@ mod tests {
     }
 
     #[test]
+    fn manifest_plain_add_relationship_appends_even_on_uuid_collision() {
+        // A plain add (no "op") must never silently overwrite an existing
+        // relationship, even if its uuid happens to collide — only an explicit
+        // "op": "override" entry may replace. Regression for a bug where
+        // colliding plain adds were routed through upsert-by-uuid.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "extensions": {
+                    "relationships": [
+                        {
+                            "scope": {"component": "button", "property": "corner-radius"},
+                            "value": "4px",
+                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                        },
+                        {
+                            "scope": {"component": "slider", "property": "corner-radius"},
+                            "value": "2px",
+                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let matching: Vec<_> = graph
+            .relationships
+            .iter()
+            .filter(|r| r.uuid.as_deref() == Some("9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"))
+            .collect();
+        assert_eq!(
+            matching.len(),
+            2,
+            "both plain adds must be appended, not one overwriting the other"
+        );
+    }
+
+    #[test]
     fn manifest_removes_relationship_by_uuid() {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("manifest.json");


### PR DESCRIPTION
## Description

Extends the platform-manifest cascade (Layer 2) to support `extensions.relationships`, letting a platform manifest add, override, or remove Component/Token Relationship (CTR) entries. Part of the platform-manifest cascade parity work (h890.23), which follows the tokens/components/platformExtensions cascade shipped in h890.22.

Relationships have no inherent stable key besides an optional `uuid`, so this PR settles that identity question (h890.23.3's open decision):

- **Add** — an entry with no `op` field is a full relationship object, appended positionally at the platform layer.
- **Override / remove** — since there's no other stable identity, targeting an existing relationship **requires** a `uuid`. An `"op": "override"`/`"op": "remove"` entry missing `uuid` is rejected as a manifest error, not silently skipped.

Changes:

- **`sdk/core/src/graph.rs`**: `apply_platform_manifest` gains a new section handling add/override/remove for `extensions.relationships[]`, reusing the existing `RelationshipRecord` (already has `uuid: Option<String>`) and `upsert_by_key`. No struct change, so no `CACHE_SCHEMA_VERSION` bump is needed.
- **`sdk/core/src/manifest.rs`** / **`graph.rs`** tests: add, uuid-override, uuid-remove, and missing-uuid rejection (both at the Layer-1-schema level and directly in `graph.rs`, bypassing schema, to prove the graph-level guard independently).
- **`packages/design-data-spec/schemas/manifest.schema.json`**: `extensions.relationships` — array of `relationship.schema.json` items, or `{op: "override"|"remove", uuid, value?}`.
- **`packages/design-data-spec/spec/manifest.md`**: capability matrix flips relationships to "Yes", plus a new `#### extensions.relationships` subsection documenting the identity model.
- **`.changeset/manifest-extensions-relationships.md`**: minor bump for `@adobe/design-data-spec`, `@adobe/design-data-tui`, `@adobe/design-data-wasm`.

## Related Issue

spectrum-design-data-h890.23.3

## Motivation and Context

Platform repos need to declare platform-local Component/Token Relationships (CTRs) without a monorepo PR. This closes another artifact-type gap in the manifest cascade and resolves the open uuid-vs-positional identity question for relationships.

## How Has This Been Tested?

- `cargo test --workspace` — all green, including new add/override/remove/error-path tests.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.
- `moon run design-data-spec:check` — passes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
