### PR TITLE
feat(sdk): manifest support for extensions.namingExceptions

### DIFF
--- a/.changeset/manifest-extensions-naming-exceptions.md
+++ b/.changeset/manifest-extensions-naming-exceptions.md
@@ -1,0 +1,20 @@
+---
+"@adobe/design-data-spec": minor
+"@adobe/design-data-tui": minor
+"@adobe/design-data-wasm": minor
+---
+
+Let a platform manifest overlay add/remove naming exceptions onto the base
+set used by naming validation (bead spectrum-design-data-h890.23.4),
+completing the cascade parity work for h890.23.
+
+- **packages/design-data-spec/schemas/manifest.schema.json**: `extensions`
+  gains `namingExceptions` (`{ add, remove }`, both optional arrays of
+  non-empty strings).
+- **packages/design-data-spec/spec/manifest.md**: capability matrix and a new
+  `extensions.namingExceptions` subsection document the add/remove overlay
+  semantics (`remove` applied before `add`, so add wins on overlap).
+- **sdk/core/src/naming.rs**: new `apply_naming_exceptions_overlay` helper;
+  naming exceptions stay a plain `HashSet<String>` outside `TokenGraph`, so
+  the overlay is applied where `validate_all_with_full_options` already
+  loads the sibling `manifest.json`, rather than as a graph-cascade section.

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -108,6 +108,23 @@
           "items": { "$ref": "guideline.schema.json" },
           "description": "Platform-local guideline docs, injected into the guideline catalog (add-or-replace by name)."
         },
+        "namingExceptions": {
+          "type": "object",
+          "description": "Platform-local overlay on the base naming-exceptions set: names to add and/or remove for this platform's naming validation.",
+          "properties": {
+            "add": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "description": "Token names to add to the naming-exceptions set for this platform."
+            },
+            "remove": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "description": "Token names to remove from the base naming-exceptions set for this platform."
+            }
+          },
+          "additionalProperties": false
+        },
         "formatting": {
           "type": "object",
           "description": "Rules for serializing structured name objects into platform-specific token name strings.",

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -6,21 +6,22 @@ This document defines the **platform manifest**: how a platform implementation r
 
 ## Capability matrix
 
-The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (fields, relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
+The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (fields, relationships/CTRs, translations, schemas) have no manifest-level override mechanism at all.
 
-| Operation                                                                           | Supported?                                                 | Field                           | Applies to            |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
-| Remove / exclude                                                                    | Yes                                                        | `exclude`                       | Tokens only           |
-| Include / whitelist                                                                 | Yes                                                        | `include`                       | Tokens only           |
-| Override value (type-preserving)                                                    | Yes                                                        | `overrides[].value`             | Tokens only           |
-| Override → re-alias                                                                 | Yes                                                        | `overrides[].$ref`              | Tokens only           |
-| Add new tokens (may alias via `$ref`)                                               | Yes                                                        | `extensions.tokens`             | Tokens                |
-| Add / replace components                                                            | Yes                                                        | `extensions.components`         | Components            |
-| Add / replace guideline documents                                                   | Yes                                                        | `extensions.guidelines`         | Guidelines            |
-| Annotate existing terminology (cannot add new ids)                                  | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
-| Restrict allowed mode-set values                                                    | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
-| Reformat name serialization                                                         | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
-| Override/remove/alias fields, relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
+| Operation                                                               | Supported?                                                 | Field                           | Applies to            |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
+| Remove / exclude                                                        | Yes                                                        | `exclude`                       | Tokens only           |
+| Include / whitelist                                                     | Yes                                                        | `include`                       | Tokens only           |
+| Override value (type-preserving)                                        | Yes                                                        | `overrides[].value`             | Tokens only           |
+| Override → re-alias                                                     | Yes                                                        | `overrides[].$ref`              | Tokens only           |
+| Add new tokens (may alias via `$ref`)                                   | Yes                                                        | `extensions.tokens`             | Tokens                |
+| Add / replace components                                                | Yes                                                        | `extensions.components`         | Components            |
+| Add / replace guideline documents                                       | Yes                                                        | `extensions.guidelines`         | Guidelines            |
+| Add / remove naming exceptions                                          | Yes                                                        | `extensions.namingExceptions`   | Naming validation     |
+| Annotate existing terminology (cannot add new ids)                      | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
+| Restrict allowed mode-set values                                        | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
+| Reformat name serialization                                             | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
+| Override/remove/alias fields, relationships/CTRs, translations, schemas | No                                                         | —                               | —                     |
 
 ## Manifest document
 
@@ -35,13 +36,13 @@ A manifest **MUST** conform to [`manifest.schema.json`](../schemas/manifest.sche
 
 ## Optional fields
 
-| Field                 | Type            | Description                                                                                                                                                        |
-| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                        |
-| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                     |
-| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                   |
-| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `guidelines`, `platformExtensions`, `formatting` (see `extensions` section below). |
-| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                              |
+| Field                 | Type            | Description                                                                                                                                                                            |
+| --------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                                            |
+| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                                         |
+| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                                       |
+| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `guidelines`, `namingExceptions`, `platformExtensions`, `formatting` (see `extensions` section below). |
+| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                                                  |
 
 ### `include` / `exclude`
 
@@ -72,6 +73,18 @@ Platform-local component specs, injected into the component catalog. **NORMATIVE
 #### `extensions.guidelines`
 
 Platform-local guideline documents, injected into the guideline catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by guideline `name` at the platform layer; each entry **MUST** validate against `guideline.schema.json`.
+
+#### `extensions.namingExceptions`
+
+Platform-local overlay on the base naming-exceptions set used by naming validation.
+**NORMATIVE:** the reference SDK applies `remove` before `add`, so a name listed in both
+ends up present (add wins) rather than silently dropped. Absent this key, the base set
+(embedded or file-loaded) is used unchanged.
+
+| Field    | Type            | Description                                                  |
+| -------- | --------------- | ------------------------------------------------------------ |
+| `add`    | array of string | Names to add to the naming-exceptions set for this platform. |
+| `remove` | array of string | Names to remove from the base naming-exceptions set.         |
 
 #### `extensions.platformExtensions`
 

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -566,6 +566,37 @@ impl NamingExceptionsFile {
     }
 }
 
+/// Overlay a platform manifest's `extensions.namingExceptions.{add,remove}` onto
+/// a base naming-exceptions set, returning a new owned set. `remove` is applied
+/// before `add`, so a manifest that lists the same name in both ends up with it
+/// present (add wins) rather than silently dropped.
+///
+/// A no-op clone of `base` when `manifest` is absent or carries no
+/// `extensions.namingExceptions` key.
+pub fn apply_naming_exceptions_overlay(
+    base: &HashSet<String>,
+    manifest: Option<&serde_json::Value>,
+) -> HashSet<String> {
+    let mut set = base.clone();
+    let Some(overlay) = manifest
+        .and_then(|m| m.get("extensions"))
+        .and_then(|e| e.get("namingExceptions"))
+    else {
+        return set;
+    };
+    if let Some(remove) = overlay.get("remove").and_then(|v| v.as_array()) {
+        for name in remove.iter().filter_map(|v| v.as_str()) {
+            set.remove(name);
+        }
+    }
+    if let Some(add) = overlay.get("add").and_then(|v| v.as_array()) {
+        for name in add.iter().filter_map(|v| v.as_str()) {
+            set.insert(name.to_string());
+        }
+    }
+    set
+}
+
 /// Check whether `key` roundtrips through parse → generate **and** that no
 /// state word is embedded inside the `property` portion (which would indicate
 /// the legacy name has state in a non-canonical position).
@@ -1124,6 +1155,58 @@ mod tests {
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("informative-color")
+        );
+    }
+
+    fn set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn overlay_no_manifest_is_noop() {
+        let base = set(&["foo"]);
+        assert_eq!(apply_naming_exceptions_overlay(&base, None), base);
+    }
+
+    #[test]
+    fn overlay_manifest_without_naming_exceptions_key_is_noop() {
+        let base = set(&["foo"]);
+        let manifest = json!({"extensions": {"tokens": []}});
+        assert_eq!(
+            apply_naming_exceptions_overlay(&base, Some(&manifest)),
+            base
+        );
+    }
+
+    #[test]
+    fn overlay_add_only() {
+        let base = set(&["foo"]);
+        let manifest = json!({"extensions": {"namingExceptions": {"add": ["bar"]}}});
+        assert_eq!(
+            apply_naming_exceptions_overlay(&base, Some(&manifest)),
+            set(&["foo", "bar"])
+        );
+    }
+
+    #[test]
+    fn overlay_remove_only() {
+        let base = set(&["foo", "bar"]);
+        let manifest = json!({"extensions": {"namingExceptions": {"remove": ["bar"]}}});
+        assert_eq!(
+            apply_naming_exceptions_overlay(&base, Some(&manifest)),
+            set(&["foo"])
+        );
+    }
+
+    #[test]
+    fn overlay_add_and_remove_same_name_add_wins() {
+        let base = set(&["foo"]);
+        let manifest = json!({
+            "extensions": {"namingExceptions": {"add": ["foo"], "remove": ["foo"]}}
+        });
+        assert_eq!(
+            apply_naming_exceptions_overlay(&base, Some(&manifest)),
+            set(&["foo"])
         );
     }
 }

--- a/sdk/core/src/validate/mod.rs
+++ b/sdk/core/src/validate/mod.rs
@@ -150,7 +150,9 @@ pub fn validate_all_with_full_options(
     } else {
         None
     };
-    let rel = relational::validate_relational(&graph, naming_exceptions, manifest.as_ref());
+    let effective_exceptions =
+        crate::naming::apply_naming_exceptions_overlay(naming_exceptions, manifest.as_ref());
+    let rel = relational::validate_relational(&graph, &effective_exceptions, manifest.as_ref());
     report.merge(rel);
     Ok(report)
 }


### PR DESCRIPTION
## Description

Adds `extensions.namingExceptions` to the platform manifest cascade: a platform can now add and/or remove names from the base naming-exceptions set consumed by naming validation, without editing the shared exceptions file. `remove` is applied before `add`, so a name listed in both ends up present (add wins on overlap).

This is the fourth of five h890.23 cascade-parity children (guidelines #1387, fields #1388, relationships #1389 preceded this).

## Related Issue

Closes spectrum-design-data-h890.23.4 (bead).

## Motivation and Context

Platform repos need to silence a naming-validation exception for a platform-local token without forking or editing the shared naming-exceptions list. Naming exceptions live outside `TokenGraph` (a plain `HashSet<String>`), so this needed new overlay plumbing distinct from the `upsert_by_key` cascade pattern used for guidelines/fields/relationships/components.

## How Has This Been Tested?

- New unit tests for `apply_naming_exceptions_overlay` in `sdk/core/src/naming.rs`: no manifest (no-op), manifest without `namingExceptions` key (no-op), add-only, remove-only, add+remove on the same name (add wins).
- Confirmed the overlay is wired into `validate_all_with_full_options`, the single production choke point where a sibling `manifest.json` is already loaded — traced all four CLI validation call sites (`sdk/cli/src/main.rs`) and confirmed each delegates down to this function, so the overlay applies uniformly.
- `cargo test --workspace` (all crates, unit + integration + doc tests) green.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — 5/5 valid.
- `moon run design-data-spec:check` — passed.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
