### PR TITLE
docs(design-data-spec): decide against manifest schema overrides (spike)

### DIFF
--- a/.changeset/manifest-schema-override-spike.md
+++ b/.changeset/manifest-schema-override-spike.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-spec": patch
+---
+
+Record the h890.23.5 decision on whether a platform manifest may override
+Layer-1 schemas.
+
+- **packages/design-data-spec/spec/manifest-schema-override-spike.md**: new
+  decision doc — no-go, with rationale (circularity, broken conformance
+  guarantees, no concrete need).
+- **packages/design-data-spec/spec/manifest.md**: capability matrix gains an
+  explicit "Override Layer-1 schemas" row linking to the decision.

--- a/packages/design-data-spec/spec/manifest-schema-override-spike.md
+++ b/packages/design-data-spec/spec/manifest-schema-override-spike.md
@@ -1,0 +1,40 @@
+# Spike: may a platform manifest override Layer-1 schemas?
+
+**Status:** Decided — **No-go**. (bead spectrum-design-data-h890.23.5)
+
+## Question
+
+Layer 1 JSON Schemas (`packages/design-data-spec/schemas/*.schema.json`) validate every
+foundation and platform artifact, **including the manifest itself**
+(`manifest.schema.json`). Should a platform manifest be allowed to override or relax those
+schemas for its own data?
+
+## Why not
+
+1. **Circularity.** The manifest that would carry a schema override is itself validated
+   against `manifest.schema.json` — a fixed Layer-1 document. Letting that same manifest
+   redefine the rules it and its sibling artifacts are checked by breaks the trust
+   direction the cascade depends on: Layer 1 is supposed to be the thing platforms
+   conform *to*, not a parameter platforms can tune.
+2. **Conformance guarantees become meaningless.** The whole point of a shared schema set
+   is that "valid per Layer 1" means the same thing for every platform. A platform-local
+   override lets a platform mark its own non-conforming data as conforming, which
+   defeats the guarantee for every consumer that trusts "passed Layer 1 validation" as a
+   signal (CI, the MCP server, other tooling).
+3. **No concrete need surfaced.** Nothing in the h890.22/h890.23 work (iOS
+   externalization, or the guidelines/fields/relationships/naming-exceptions cascade
+   additions) needed schema relaxation — every platform-local addition validates fine
+   against the existing schemas via `extensions.*`. The `extensions` object is already
+   `additionalProperties: true`, which covers "the platform wants to attach data the
+   schema doesn't know about" without touching the schema itself.
+
+## Decision
+
+**No-go.** The manifest cascade will not gain a schema-override mechanism. The capability
+matrix in [`manifest.md`](manifest.md#capability-matrix) keeps schemas in the
+"no manifest-level override mechanism" bucket.
+
+If a concrete future need emerges (e.g. a platform genuinely needs a stricter, not
+looser, local schema for its own additive fields), scope a narrow follow-up bead then —
+additive-only, and never loosening what Layer 1 already requires. No such bead is opened
+now.

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -8,19 +8,20 @@ This document defines the **platform manifest**: how a platform implementation r
 
 The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; most other artifact types (fields, relationships/CTRs, exceptions, translations, schemas) have no manifest-level override mechanism at all.
 
-| Operation                                                                           | Supported?                                                 | Field                           | Applies to            |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------- | --------------------- |
-| Remove / exclude                                                                    | Yes                                                        | `exclude`                       | Tokens only           |
-| Include / whitelist                                                                 | Yes                                                        | `include`                       | Tokens only           |
-| Override value (type-preserving)                                                    | Yes                                                        | `overrides[].value`             | Tokens only           |
-| Override → re-alias                                                                 | Yes                                                        | `overrides[].$ref`              | Tokens only           |
-| Add new tokens (may alias via `$ref`)                                               | Yes                                                        | `extensions.tokens`             | Tokens                |
-| Add / replace components                                                            | Yes                                                        | `extensions.components`         | Components            |
-| Add / replace guideline documents                                                   | Yes                                                        | `extensions.guidelines`         | Guidelines            |
-| Annotate existing terminology (cannot add new ids)                                  | Yes                                                        | `extensions.platformExtensions` | Existing registry ids |
-| Restrict allowed mode-set values                                                    | Yes                                                        | `modeSetRestrictions`           | Mode sets             |
-| Reformat name serialization                                                         | Schema-declared only, not yet applied by the reference SDK | `extensions.formatting`         | Token name strings    |
-| Override/remove/alias fields, relationships/CTRs, exceptions, translations, schemas | No                                                         | —                               | —                     |
+| Operation                                                                  | Supported?                                                   | Field                           | Applies to            |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------- | --------------------- |
+| Remove / exclude                                                           | Yes                                                          | `exclude`                       | Tokens only           |
+| Include / whitelist                                                        | Yes                                                          | `include`                       | Tokens only           |
+| Override value (type-preserving)                                           | Yes                                                          | `overrides[].value`             | Tokens only           |
+| Override → re-alias                                                        | Yes                                                          | `overrides[].$ref`              | Tokens only           |
+| Add new tokens (may alias via `$ref`)                                      | Yes                                                          | `extensions.tokens`             | Tokens                |
+| Add / replace components                                                   | Yes                                                          | `extensions.components`         | Components            |
+| Add / replace guideline documents                                          | Yes                                                          | `extensions.guidelines`         | Guidelines            |
+| Annotate existing terminology (cannot add new ids)                         | Yes                                                          | `extensions.platformExtensions` | Existing registry ids |
+| Restrict allowed mode-set values                                           | Yes                                                          | `modeSetRestrictions`           | Mode sets             |
+| Reformat name serialization                                                | Schema-declared only, not yet applied by the reference SDK   | `extensions.formatting`         | Token name strings    |
+| Override/remove/alias fields, relationships/CTRs, exceptions, translations | No                                                           | —                               | —                     |
+| Override Layer-1 schemas                                                   | No (decided; see [spike](manifest-schema-override-spike.md)) | —                               | —                     |
 
 ## Manifest document
 
@@ -110,3 +111,4 @@ The platform manifest is the Layer 2 context document. For Layer 3 (product-laye
 
 * [#715 — Distributed Design Data Architecture](https://github.com/adobe/spectrum-design-data/discussions/715)
 * [#625 — Token Authoring Workflow](https://github.com/adobe/spectrum-design-data/discussions/625)
+* [Schema-override spike](manifest-schema-override-spike.md) — why the manifest cascade does not allow platform overrides of Layer-1 schemas


### PR DESCRIPTION
## Description

Decision doc for the h890.23.5 spike: should a platform manifest be allowed to override Layer-1 JSON Schemas? Decision: **no-go**. This is the final of five h890.23 cascade-parity children; no code changes.

## Related Issue

Closes spectrum-design-data-h890.23.5 (bead).

## Motivation and Context

The h890.23 epic extended the platform-manifest cascade to guidelines, fields, relationships, and naming exceptions. Before closing the epic we needed to decide whether the same treatment should extend to Layer-1 schemas themselves — since schemas validate every artifact including the manifest that would carry such an override, this needed a coherence check rather than just another cascade section.

## How Has This Been Tested?

N/A — docs-only change (decision doc + capability matrix update).

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
