### PR TITLE
feat(design-data): register pressed as an alias of the active state

### DIFF
--- a/.changeset/ios-vocabulary-crosswalk.md
+++ b/.changeset/ios-vocabulary-crosswalk.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Register the iOS pressed/down state synonym surfaced by the iOS platform-manifest POC
+(spectrum-design-data-h890.17).
+
+- **packages/design-data/registry/states.json**: `active` gains `aliases: ["pressed"]`
+  (iOS's pressed/down terms) and cross-references `down`; regenerated
+  `sdk/core/src/registry_data.rs`.

--- a/packages/design-data/registry/states.json
+++ b/packages/design-data/registry/states.json
@@ -87,8 +87,10 @@
     {
       "id": "active",
       "label": "Active",
+      "aliases": ["pressed"],
       "description": "Active or pressed state",
-      "usedIn": ["component-options", "component-schemas"]
+      "usedIn": ["component-options", "component-schemas"],
+      "relatedTerms": ["down"]
     },
     {
       "id": "focus",
@@ -159,7 +161,8 @@
       "id": "down",
       "label": "Down",
       "description": "Pressed or down state (mouse button down)",
-      "usedIn": ["tokens", "component-schemas"]
+      "usedIn": ["tokens", "component-schemas"],
+      "relatedTerms": ["active"]
     },
     {
       "id": "pending",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -2531,8 +2531,10 @@ const STATES_JSON: &str = r##"{
     {
       "id": "active",
       "label": "Active",
+      "aliases": ["pressed"],
       "description": "Active or pressed state",
-      "usedIn": ["component-options", "component-schemas"]
+      "usedIn": ["component-options", "component-schemas"],
+      "relatedTerms": ["down"]
     },
     {
       "id": "focus",
@@ -2603,7 +2605,8 @@ const STATES_JSON: &str = r##"{
       "id": "down",
       "label": "Down",
       "description": "Pressed or down state (mouse button down)",
-      "usedIn": ["tokens", "component-schemas"]
+      "usedIn": ["tokens", "component-schemas"],
+      "relatedTerms": ["active"]
     },
     {
       "id": "pending",

--- a/sdk/core/src/validate/rules/spec009.rs
+++ b/sdk/core/src/validate/rules/spec009.rs
@@ -226,6 +226,18 @@ mod tests {
     }
 
     #[test]
+    fn compound_state_with_pressed_alias_no_warning() {
+        // "pressed" is a registered alias of the foundation "active" state and
+        // must resolve as a recognized value, not warn as an opaque string.
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "state": ["selected", "pressed"]}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
+    }
+
+    #[test]
     fn compound_state_with_unknown_segment_warns() {
         let g = TokenGraph::from_pairs(vec![(
             "t".into(),


### PR DESCRIPTION
## Description

Registers `pressed` as an alias of the foundation `active` state, and cross-references `active`/`down` via `relatedTerms`. iOS override data uses `pressed`/`down` state terms that the states registry didn't recognize as synonyms of the existing `active`/`down` entries, so they passed through as opaque advisory strings instead of resolving as recognized equivalences.

## Related Issue

spectrum-design-data-h890.17 (optional ergonomics follow-up from h890.8's iOS platform-manifest POC gap report)

## Motivation and Context

The iOS platform-manifest POC ([GarthDB/spectrum-ios-design-data](https://github.com/GarthDB/spectrum-ios-design-data)) surfaced that iOS-authored `pressed`/`down` state terms have no registered foundation equivalence. `pressed` is generic cross-platform vocabulary (not iOS-specific), so it belongs in the shared foundation registry rather than an iOS-side platform extension — the corresponding iOS-specific `increased`↔`high` contrast crosswalk was registered separately in the iOS repo's own manifest ([PR #4](https://github.com/GarthDB/spectrum-ios-design-data/pull/4)).

## How Has This Been Tested?

- `moon run design-data:validate-registry` — passes (no duplicate-alias or stale-relatedTerms errors)
- `moon run design-data:validate` — passes (pre-existing warnings only, unrelated to this change)
- `moon run sdk:codegen-check` — passes (`registry_data.rs` regenerated and committed)
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes
- `cargo test -p design-data-core spec009` — passes (14/14), including new `compound_state_with_pressed_alias_no_warning`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)