### PR TITLE
feat(design-data-mcp,design-data-agent-mcp): tell agents how to stay on the latest bundled dataset

### DIFF
--- a/.changeset/latest-mcp-instructions.md
+++ b/.changeset/latest-mcp-instructions.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-mcp": patch
+"@adobe/design-data-agent-mcp": patch
+---
+
+Tell agents how to stay on the latest bundled dataset (closes the Protopack Web
+stale-dataset gap surfaced in Slack).
+
+- **tools/design-data-mcp/src/index.js**: server now sends an `instructions` string
+  explaining the embedded dataset travels with the package version and how to check it.
+- **tools/design-data-mcp/README.md**: pin `@latest` in the npx configs; add a "Staying
+  current" note.
+- **tools/design-data-agent-mcp/src/index.js**: same `instructions` addition.
+- **tools/design-data-agent-mcp/README.md**: pin `@latest`; add a "Staying current" note.
+- **tools/design-data-agent-mcp/skills/design-data/SKILL.md**: pin `@latest` in the
+  bootstrap config; note the same.

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -26,17 +26,26 @@ https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-
 ### npm (MCP server)
 
 ```sh
-npx @adobe/design-data-agent-mcp
+npx @adobe/design-data-agent-mcp@latest
 ```
 
 The `@adobe/design-data` CLI binary is **only** needed for `authoring_session_step_intent`. All other tools run in-process. Set `DESIGN_DATA_BIN` if the binary is not on `PATH`.
+
+### Staying current
+
+The embedded Spectrum snapshot is baked into the wasm at build time and travels with the
+package version — there's no separate data update to run. Pin `@latest` (as above) so `npx`
+fetches the newest published version rather than reusing whatever it last cached; `-y` alone
+only skips the install confirmation, it doesn't force a re-fetch. Already on `/plugin`? Run
+`/plugin update design-data-agent@spectrum-design-data`. Call the primer tool and check
+`provenance.designDataVersion` to see which dataset version is embedded.
 
 ## MCP server
 
 Configure your MCP client to run:
 
 ```sh
-npx -y @adobe/design-data-agent-mcp
+npx -y @adobe/design-data-agent-mcp@latest
 ```
 
 Or from a repo clone:
@@ -100,7 +109,7 @@ node tools/design-data-agent-mcp/src/index.js
   "mcpServers": {
     "design-data-agent": {
       "command": "npx",
-      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "args": ["-y", "@adobe/design-data-agent-mcp@latest"],
       "env": {
         "DESIGN_DATA_ROOT": "/abs/path/to/your/repo",
         "DESIGN_DATA_PATH": "packages/design-data/tokens",
@@ -119,7 +128,7 @@ node tools/design-data-agent-mcp/src/index.js
   "mcpServers": {
     "design-data-agent": {
       "command": "npx",
-      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "args": ["-y", "@adobe/design-data-agent-mcp@latest"],
       "env": {
         "DESIGN_DATA_BIN": "design-data",
         "DESIGN_DATA_PATH": "/path/to/your/dataset"

--- a/tools/design-data-agent-mcp/skills/design-data/SKILL.md
+++ b/tools/design-data-agent-mcp/skills/design-data/SKILL.md
@@ -38,7 +38,7 @@ Add `@adobe/design-data-agent-mcp` to your `.cursor/mcp.json`:
   "mcpServers": {
     "design-data-agent": {
       "command": "npx",
-      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "args": ["-y", "@adobe/design-data-agent-mcp@latest"],
       "env": {
         "DESIGN_DATA_PATH": "./packages/tokens/src",
         "DESIGN_DATA_COMPONENTS": "./packages/design-data/components",
@@ -49,7 +49,9 @@ Add `@adobe/design-data-agent-mcp` to your `.cursor/mcp.json`:
 }
 ```
 
-Adjust paths to match your dataset layout.
+Adjust paths to match your dataset layout. Pin `@latest` — the embedded Spectrum snapshot is
+baked into the wasm at build time and travels with the package version, so there's no separate
+data update to run, but plain `npx -y <pkg>` (no tag) can reuse a cached older build.
 
 ***
 

--- a/tools/design-data-agent-mcp/src/index.js
+++ b/tools/design-data-agent-mcp/src/index.js
@@ -48,7 +48,17 @@ export function createMCPServer() {
   const allTools = createAllTools();
   const server = new Server(
     { name: "design-data-agent-mcp", version: pkg.version },
-    { capabilities: { tools: {} } },
+    {
+      capabilities: { tools: {} },
+      instructions:
+        "This server bundles a snapshot of Spectrum design data (tokens, components, " +
+        "guidelines) baked into its wasm at build time. The data version travels with the " +
+        "package version, so there is nothing to update separately. To get newer Spectrum " +
+        "data, install the latest published package (npx -y @adobe/design-data-agent-mcp@latest " +
+        '— plain "npx -y @adobe/design-data-agent-mcp" can reuse a cached older build). Call ' +
+        "the design-data primer tool and read provenance.designDataVersion to see the " +
+        "embedded dataset version.",
+    },
   );
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: allTools.map(({ name, description, inputSchema }) => ({

--- a/tools/design-data-mcp/README.md
+++ b/tools/design-data-mcp/README.md
@@ -23,7 +23,7 @@ Add to `.cursor/mcp-servers.json` in your project root:
   "mcpServers": {
     "design-data": {
       "command": "npx",
-      "args": ["-y", "@adobe/design-data-mcp"]
+      "args": ["-y", "@adobe/design-data-mcp@latest"]
     }
   }
 }
@@ -38,11 +38,19 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "design-data": {
       "command": "npx",
-      "args": ["-y", "@adobe/design-data-mcp"]
+      "args": ["-y", "@adobe/design-data-mcp@latest"]
     }
   }
 }
 ```
+
+## Staying current
+
+The embedded Spectrum snapshot is baked into the wasm at build time and travels with the
+package version — there's no separate data update to run. Pin `@latest` (as above) so `npx`
+fetches the newest published version rather than reusing whatever it last cached; `-y` alone
+only skips the install confirmation, it doesn't force a re-fetch. Call `design-data-primer` and
+check `provenance.designDataVersion` to see which dataset version is embedded.
 
 ## Tools
 

--- a/tools/design-data-mcp/src/index.js
+++ b/tools/design-data-mcp/src/index.js
@@ -34,10 +34,18 @@ const packageJson = JSON.parse(
   readFileSync(resolve(__dirname, "../package.json"), "utf8"),
 );
 
+const SERVER_INSTRUCTIONS =
+  `This server bundles a snapshot of Spectrum design data (tokens, ` +
+  `components, guidelines) baked into its wasm at build time. The data version travels with ` +
+  `the package version, so there is nothing to update separately. To get newer Spectrum data, ` +
+  `install the latest published package (npx -y @adobe/design-data-mcp@latest — plain ` +
+  `"npx -y @adobe/design-data-mcp" can reuse a cached older build). Call design-data-primer ` +
+  `and read provenance.designDataVersion to see the embedded dataset version.`;
+
 export function createMCPServer() {
   const server = new Server(
     { name: "design-data", version: packageJson.version },
-    { capabilities: { tools: {} } },
+    { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS },
   );
 
   const tools = createDesignDataTools();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds agent-facing guidance to `@adobe/design-data-mcp` and `@adobe/design-data-agent-mcp` so
an agent (or its human operator) understands that the embedded Spectrum dataset is baked into
the wasm at build time and travels with the package version — and how to get the current one.

- Both MCP servers now send an `instructions` string in the `initialize` response (previously
  unset) explaining the bundling model, how to refresh (`npx ... @latest`), and pointing at
  `provenance.designDataVersion` from the primer tool to check the embedded version.
- READMEs and the Claude Code skill's bootstrap config now pin `@latest` in their npx examples
  and add a short "Staying current" note — plain `npx -y <pkg>` (no tag) can silently reuse a
  cached older build.

## Related Issue

Surfaced in a Slack thread (Matt Knorr / CJ Gammon / Mihai Botezatu / Garth Braithwaite):
Protopack Web's MCP was reporting `@adobe/spectrum-design-data@0.16.0` (latest is `2.3.0`)
because it was pinned to a hand-built GitHub checkout rather than the published npm package.
Confirmed the wasm cache itself (`sdk/wasm/src/embedded_cache.redb`) is not stale — it's a
gitignored artifact rebuilt from `packages/design-data/*` and already ships current data
(2.3.0) in the latest published `@adobe/design-data-mcp@1.7.30`. The real gap was that no
agent-facing text explained the bundling model or nudged toward `@latest`.

## Motivation and Context

Without this, an agent connecting to either MCP server has no signal that it might be on a
stale dataset, and no instruction for how to fix that if so.

## How Has This Been Tested?

- `pnpm --filter @adobe/design-data-mcp test` — full suite passes.
- `pnpm --filter @adobe/design-data-agent-mcp test` — 55 tests pass, including the
  `skill-version` test that locks `SKILL.md`'s `metadata.version` to `package.json` (untouched
  here — only prose changed).
- Instantiated both servers directly (`createMCPServer()`) and confirmed `server._instructions`
  is populated with the new text.
- Confirmed `design-data-primer`'s `provenance.designDataVersion` field still resolves.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Screenshots (if appropriate):

N/A — no UI change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
