### PR TITLE
feat(design-data): export Figma variables from a manifest-resolved dataset (h890.11)

### DIFF
--- a/.changeset/figma-export-manifest-resolved.md
+++ b/.changeset/figma-export-manifest-resolved.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+The Figma export generator can now export from a manifest-resolved dataset
+instead of a raw token-source directory (closes spectrum-design-data-h890.11).
+
+- **sdk/core/src/figma/mapping.rs**: `build_export_payload` takes a
+  `tokens: &[(String, Value)]` slice instead of a token-source directory
+  path; `load_all_tokens` is now `pub` so callers load tokens themselves
+  before building the payload.
+- **sdk/cli/src/main.rs**: `figma export` gains a `--manifest <PATH>` flag;
+  when given, tokens are resolved through the platform manifest cascade
+  (include/exclude, overrides, extensions) before export instead of reading
+  `path` as a raw token directory. Behavior without `--manifest` is unchanged.

--- a/packages/design-data-spec/spec/mode-sets.md
+++ b/packages/design-data-spec/spec/mode-sets.md
@@ -27,11 +27,11 @@ A **mode set declaration** is a JSON object describing one axis of variation. It
 
 These mode sets are declared in the `mode-sets/` catalog (see [Mode Set catalog](#mode-set-catalog)) and **SHOULD** be used consistently across Spectrum-compatible datasets:
 
-| `name`        | `modes`                      | `default` | Notes                                                                             |
-| ------------- | ---------------------------- | --------- | --------------------------------------------------------------------------------- |
-| `colorScheme` | `light`, `dark`, `wireframe` | `light`   | Theme / appearance.                                                               |
-| `scale`       | `desktop`, `mobile`          | `desktop` | Density scale. Legacy names; desktop = medium, mobile = large in W3C terminology. |
-| `contrast`    | `regular`, `high`            | `regular` | Accessibility contrast level.                                                     |
+| `name`        | `modes`                      | `default` | Notes                                                                                                                                                        |
+| ------------- | ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `colorScheme` | `light`, `dark`, `wireframe` | `light`   | Theme / appearance.                                                                                                                                          |
+| `scale`       | `desktop`, `mobile`          | `desktop` | Density scale. Legacy names; desktop = medium, mobile = large in W3C terminology.                                                                            |
+| `contrast`    | `regular`, `high`            | `regular` | Accessibility contrast level. iOS platform data authors `increased` as a synonym for `high` — treat the two as the same crosswalk term, not distinct values. |
 
 ## Mode Set catalog
 

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -512,6 +512,11 @@ enum FigmaSub {
         /// take precedence over the default `{prefix}/{legacyKey}` naming
         #[arg(long, value_name = "PATH")]
         mapping: Option<PathBuf>,
+        /// Path to a platform manifest.json; when given, tokens are resolved
+        /// through the manifest cascade (include/exclude, overrides, extensions)
+        /// before export instead of reading `path` as a raw token directory
+        #[arg(long, value_name = "PATH")]
+        manifest: Option<PathBuf>,
     },
     /// Audit generated Figma Variable names against a captured snapshot (offline, no API call)
     Audit {
@@ -1414,6 +1419,7 @@ fn run_figma_export(
     token: &str,
     dry_run: bool,
     mapping: Option<&Path>,
+    manifest: Option<&Path>,
 ) -> miette::Result<ExitCode> {
     let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
     let client = figma::api::FigmaClient::new(token.to_string());
@@ -1421,19 +1427,48 @@ fn run_figma_export(
     // 0. Load name-mapping overrides, if given.
     let overrides = mapping.map(load_overrides).transpose()?;
 
-    // 1. GET existing variables to obtain collection/mode IDs.
+    // 1. Load tokens — either straight from the source directory, or resolved
+    // through the platform manifest cascade (include/exclude, overrides,
+    // extensions) when `--manifest` is given.
+    let tokens = match manifest {
+        None => figma::mapping::load_all_tokens(path).map_err(|e| miette::miette!("{e}"))?,
+        Some(manifest_path) => {
+            let resolved = resolve_data_source(CliPathOverrides {
+                tokens_root: Some(path.to_path_buf()),
+                platform_manifest: Some(manifest_path.to_path_buf()),
+                ..Default::default()
+            })?;
+            let (mut graph, _index) = TokenGraph::open_cached_with_index_with_catalogs(
+                &resolved.tokens_root,
+                resolved.mode_sets.as_deref(),
+                resolved.components.as_deref(),
+            )
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+            manifest::apply_configured(&mut graph, &resolved)
+                .into_diagnostic()
+                .wrap_err("failed to apply platform manifest cascade")?;
+            graph
+                .tokens
+                .values()
+                .map(|r| (r.name.clone(), r.raw.clone()))
+                .collect()
+        }
+    };
+
+    // 2. GET existing variables to obtain collection/mode IDs.
     eprintln!("Fetching existing variables from Figma...");
     let response = rt
         .block_on(client.get_local_variables(file_key))
         .map_err(|e| miette::miette!("{e}"))?;
 
-    // 2. Build the export payload.
+    // 3. Build the export payload.
     eprintln!("Building export payload from {}...", path.display());
     let (body, summary) =
-        figma::mapping::build_export_payload(path, &response.meta, overrides.as_ref())
+        figma::mapping::build_export_payload(&tokens, &response.meta, overrides.as_ref())
             .map_err(|e| miette::miette!("{e}"))?;
 
-    // 3. Output or post.
+    // 4. Output or post.
     if dry_run {
         println!("{}", serde_json::to_string_pretty(&body).into_diagnostic()?);
     } else {
@@ -1450,7 +1485,7 @@ fn run_figma_export(
         );
     }
 
-    // 4. Print summary to stderr.
+    // 5. Print summary to stderr.
     eprintln!(
         "\nSummary: {} variables, {} mode values",
         summary.variables_created, summary.mode_values_set
@@ -2104,7 +2139,15 @@ fn main() -> ExitCode {
                 token,
                 dry_run,
                 mapping,
-            } => run_figma_export(&path, &file_key, &token, dry_run, mapping.as_deref()),
+                manifest,
+            } => run_figma_export(
+                &path,
+                &file_key,
+                &token,
+                dry_run,
+                mapping.as_deref(),
+                manifest.as_deref(),
+            ),
             FigmaSub::Audit {
                 snapshot,
                 token_dir,

--- a/sdk/core/src/figma/audit.rs
+++ b/sdk/core/src/figma/audit.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use super::mapping::{build_export_payload, summarize_variables};
+use super::mapping::{build_export_payload, load_all_tokens, summarize_variables};
 use super::types::VariablesMeta;
 use super::FigmaError;
 
@@ -65,7 +65,8 @@ pub struct AuditReport {
 /// [`crate::legacy::convert_dir`] produces from cascade `.tokens.json` files,
 /// not the cascade format itself.
 pub fn audit_names(existing: &VariablesMeta, token_dir: &Path) -> Result<AuditReport, FigmaError> {
-    let (body, summary) = build_export_payload(token_dir, existing, None)?;
+    let tokens = load_all_tokens(token_dir)?;
+    let (body, summary) = build_export_payload(&tokens, existing, None)?;
 
     // Real variable names per collection, from the snapshot (non-remote only,
     // matching summarize_variables' existing convention). The real file has

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -109,7 +109,13 @@ pub struct ExportSummary {
     pub skipped_unparseable_value: Vec<String>,
 }
 
-/// Build a Figma POST payload from legacy token source files.
+/// Build a Figma POST payload from a flat set of legacy-shaped token entries.
+///
+/// `tokens` is `(name, raw legacy JSON entry)` pairs — either loaded straight
+/// from a token-source directory ([`load_all_tokens`]) or collected from a
+/// manifest-resolved [`crate::graph::TokenGraph`] (`(record.name, record.raw)`
+/// for each [`crate::graph::TokenRecord`]) so platform overrides/extensions are
+/// reflected in the export.
 ///
 /// `existing` is the result of `GET /v1/files/:file_key/variables/local` —
 /// used to look up collection and mode IDs for the target collections.
@@ -119,7 +125,7 @@ pub struct ExportSummary {
 /// default `{prefix}/{legacyKey}` naming. `None` or an empty map preserves
 /// today's naming for every token.
 pub fn build_export_payload(
-    token_dir: &Path,
+    tokens: &[(String, Value)],
     existing: &VariablesMeta,
     overrides: Option<&HashMap<String, String>>,
 ) -> Result<(PostVariablesBody, ExportSummary), FigmaError> {
@@ -140,11 +146,8 @@ pub fn build_export_payload(
     let color_default_mode = &color_col.default_mode_id;
     let scale_default_mode = &scale_col.default_mode_id;
 
-    // 2. Load all token files from the directory.
-    let all_tokens = load_all_tokens(token_dir)?;
-
-    // 3. Build a name→value lookup for alias resolution.
-    let value_index = build_value_index(&all_tokens);
+    // 2. Build a name→value lookup for alias resolution.
+    let value_index = build_value_index(tokens);
 
     // 4. Process each token.
     let mut summary = ExportSummary::default();
@@ -158,7 +161,7 @@ pub fn build_export_payload(
         .map(|v| (v.name.as_str(), v.id.as_str()))
         .collect();
 
-    for (token_name, token_entry) in &all_tokens {
+    for (token_name, token_entry) in tokens {
         let schema = token_entry
             .get("$schema")
             .and_then(|v| v.as_str())
@@ -225,7 +228,7 @@ pub fn build_export_payload(
                 color_default_mode,
                 scale_default_mode,
                 &value_index,
-                &all_tokens,
+                tokens,
                 &existing_var_index,
                 overrides,
                 &mut variables,
@@ -298,7 +301,7 @@ fn resolve_mode_ids(
 }
 
 /// Load all legacy JSON token files from a directory into a flat map.
-fn load_all_tokens(dir: &Path) -> Result<Vec<(String, Value)>, FigmaError> {
+pub fn load_all_tokens(dir: &Path) -> Result<Vec<(String, Value)>, FigmaError> {
     let mut tokens = Vec::new();
     let mut paths: Vec<_> = std::fs::read_dir(dir)
         .map_err(|e| FigmaError::Api {
@@ -893,7 +896,8 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
         assert_eq!(summary.variables_created, 1);
         assert_eq!(summary.mode_values_set, 3);
         assert_eq!(body.variables.len(), 1);
@@ -922,13 +926,38 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
         assert_eq!(summary.variables_created, 1);
         assert_eq!(body.variables[0].name, "platformScale/spacing-100");
         assert_eq!(body.variables[0].resolved_type, "FLOAT");
         // Value should be 8.0
         let val = &body.variable_mode_values[0].value;
         assert_eq!(val.as_f64(), Some(8.0));
+    }
+
+    #[test]
+    fn build_export_payload_accepts_in_memory_tokens_not_just_a_directory() {
+        // Mirrors what a manifest-resolved TokenGraph hands the exporter:
+        // `(record.name, record.raw)` pairs with no backing directory — the
+        // seam that lets `figma export --manifest` feed platform-overridden
+        // `raw` values (e.g. from `apply_platform_manifest`) straight through
+        // without materializing them to disk first.
+        let tokens = vec![(
+            "spacing-100".to_string(),
+            json!({
+                "$schema": "https://example.com/dimension.json",
+                "value": "12px",
+                "uuid": "d1"
+            }),
+        )];
+
+        let meta = mock_meta();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
+        assert_eq!(summary.variables_created, 1);
+        assert_eq!(body.variables[0].name, "platformScale/spacing-100");
+        let val = &body.variable_mode_values[0].value;
+        assert_eq!(val.as_f64(), Some(12.0));
     }
 
     #[test]
@@ -962,7 +991,8 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let (body, _summary) = build_export_payload(dir.path(), &meta, Some(&overrides)).unwrap();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, _summary) = build_export_payload(&tokens, &meta, Some(&overrides)).unwrap();
 
         let by_name = |n: &str| body.variables.iter().find(|v| v.name == n);
         assert!(by_name("Layout/spacing-100-real").is_some());
@@ -994,7 +1024,8 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (_body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (_body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
         // base-color (flat color) + alias-color (alias→color)
         assert_eq!(summary.variables_created, 2);
         assert!(summary.skipped_alias_unresolved.is_empty());
@@ -1040,7 +1071,8 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
 
         assert!(
             summary.skipped_alias_unresolved.is_empty(),
@@ -1101,7 +1133,8 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
         assert_eq!(summary.variables_created, 0);
         assert_eq!(summary.skipped_composite.len(), 2);
         assert!(body.variables.is_empty());


### PR DESCRIPTION
## Description

`figma export` reads a raw token-source directory today and never applies
the platform manifest cascade. This adds an optional `--manifest <PATH>`
flag: when given, tokens are resolved through `TokenGraph` +
`manifest::apply_configured` (include/exclude filters, overrides,
extensions) before export, mirroring how `query` and `validate-manifest`
already consume a manifest-resolved dataset. Without `--manifest`, behavior
is unchanged.

- **sdk/core/src/figma/mapping.rs**: `build_export_payload` now takes a
  `tokens: &[(String, Value)]` slice instead of a token-source directory
  path, decoupling payload-building from how tokens were sourced.
  `load_all_tokens` is now `pub` so callers (CLI, `figma audit`) load
  tokens themselves before building the payload.
- **sdk/cli/src/main.rs**: `figma export` gains `--manifest`; with it set,
  builds a `TokenGraph`, applies the manifest cascade via
  `manifest::apply_configured`, and exports `(record.name, record.raw)`
  pairs from the resolved graph.
- **sdk/core/src/figma/audit.rs**: updated its call site to the new
  `build_export_payload` signature.

## Related Issue

Closes bead `spectrum-design-data-h890.11` (WS5, initiative DNA-1741).

## Motivation and Context

Per-platform Figma variable collections need to be authored from a
platform's manifest-resolved dataset, not the raw shared token source.
This is the first of three WS5 tasks (h890.11/.12/.13); h890.12
(Figma→manifest importer) and h890.13 (wasm plugin spike) are separate,
unstarted work.

## How Has This Been Tested?

- `moon run sdk:test` — 1341 passed (1 pre-existing skip), including a new
  unit test proving `build_export_payload` accepts in-memory
  manifest-derived token pairs, not just a directory, plus the 6 existing
  mapping tests updated to the new signature.
- `moon run sdk:lint` — clean (clippy `-D warnings`).
- Manual dry-run smoke test: built a scratch token dir + manifest.json with
  an override, ran `figma export --dry-run` both with and without
  `--manifest` — both reach the (expected, credential-blocked) Figma API
  call identically, confirming the manifest cascade wiring runs cleanly
  against the real `manifest.schema.json` with no regression to the
  no-manifest path.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Screenshots (if appropriate):

N/A (CLI change).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
