### PR TITLE
feat(design-data): add read-only figma diff subcommand

### DIFF
--- a/.changeset/figma-diff-value-level-report.md
+++ b/.changeset/figma-diff-value-level-report.md
@@ -1,0 +1,17 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+New `figma diff` CLI command reports a value-level, read-only comparison
+between the manifest-resolved dataset and a Figma file's actual variable
+values (closes spectrum-design-data-11k.6).
+
+- **sdk/core/src/figma/import.rs**: add `diff_values`, `DiffReport`,
+  `DiffEntry`, `DiffClass`, and `DiffCounts`. Classifies every Figma
+  variable and design-data token as match / value-mismatch / figma-only /
+  design-data-only / renamed / skipped-uncovered, reusing the same
+  value-comparison codec as `build_import_overrides` and the same
+  export name-set diff `figma::audit::audit_names` uses.
+- **sdk/cli/src/main.rs**: `figma diff --file-key --token [--snapshot]
+  [--mapping] [--manifest] --format pretty|json`; `--snapshot` diffs
+  offline against a captured `VariablesMeta` snapshot, no API call.

--- a/.changeset/figma-diff-value-level-report.md
+++ b/.changeset/figma-diff-value-level-report.md
@@ -15,6 +15,7 @@ values (closes spectrum-design-data-11k.6).
 - **sdk/cli/src/main.rs**: `figma diff --file-key --token [--snapshot]
   [--mapping] [--manifest] --format pretty|json`; `--snapshot` diffs
   offline against a captured `VariablesMeta` snapshot, no API call.
-- **sdk/core/src/figma/{mapping,import}.rs**: the FLOAT codec now
-  normalizes opacity between design-data's 0-1 fraction and Figma's
-  0-100 scale across export, import, and diff.
+- **sdk/core/src/figma/{mapping,import}.rs**: the codec now normalizes
+  opacity (0-1 fraction vs Figma's 0-100), font-weight/style naming, `dp`
+  units, and per-scale mode alignment, so `figma diff` reports only
+  genuine value drift.

--- a/.changeset/figma-diff-value-level-report.md
+++ b/.changeset/figma-diff-value-level-report.md
@@ -15,3 +15,6 @@ values (closes spectrum-design-data-11k.6).
 - **sdk/cli/src/main.rs**: `figma diff --file-key --token [--snapshot]
   [--mapping] [--manifest] --format pretty|json`; `--snapshot` diffs
   offline against a captured `VariablesMeta` snapshot, no API call.
+- **sdk/core/src/figma/{mapping,import}.rs**: the FLOAT codec now
+  normalizes opacity between design-data's 0-1 fraction and Figma's
+  0-100 scale across export, import, and diff.

--- a/.changeset/figma-diff-value-level-report.md
+++ b/.changeset/figma-diff-value-level-report.md
@@ -6,16 +6,15 @@ New `figma diff` CLI command reports a value-level, read-only comparison
 between the manifest-resolved dataset and a Figma file's actual variable
 values (closes spectrum-design-data-11k.6).
 
-- **sdk/core/src/figma/import.rs**: add `diff_values`, `DiffReport`,
-  `DiffEntry`, `DiffClass`, and `DiffCounts`. Classifies every Figma
-  variable and design-data token as match / value-mismatch / figma-only /
-  design-data-only / renamed / skipped-uncovered, reusing the same
-  value-comparison codec as `build_import_overrides` and the same
-  export name-set diff `figma::audit::audit_names` uses.
+- **sdk/core/src/figma/import.rs**: add `diff_values`, classifying every
+  Figma variable and design-data token as match / value-mismatch /
+  figma-only / design-data-only / renamed / skipped-uncovered, reusing
+  the value-comparison codec `build_import_overrides` uses.
 - **sdk/cli/src/main.rs**: `figma diff --file-key --token [--snapshot]
-  [--mapping] [--manifest] --format pretty|json`; `--snapshot` diffs
-  offline against a captured `VariablesMeta` snapshot, no API call.
-- **sdk/core/src/figma/{mapping,import}.rs**: the codec now normalizes
-  opacity (0-1 fraction vs Figma's 0-100), font-weight/style naming, `dp`
-  units, and per-scale mode alignment, so `figma diff` reports only
-  genuine value drift.
+  [--mapping] [--manifest] --format pretty|json`.
+- **sdk/core/src/figma/{mapping,import}.rs**: normalizes opacity,
+  font-weight/style naming, `dp` units, and per-scale mode alignment
+  (only when the aligned scale actually matches) so `figma diff` reports
+  only genuine drift; a `--mapping`-renamed design-data-only entry now
+  reports its real legacy key; `renamed` prints separately from the
+  counts it can overlap with.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -165,6 +165,16 @@ no API call:
 design-data figma audit --snapshot figma-vars.json --token-dir packages/design-data/tokens
 ```
 
+Diff the manifest-resolved dataset against a Figma file's actual variable
+values — read-only, value-level, and works either offline against a captured
+snapshot or live against `--file-key`/`--token`. Classifies every variable/
+token as `match`, `value-mismatch`, `figma-only`, `design-data-only`,
+`renamed` (via `--mapping`), or `skipped-uncovered`:
+
+```bash
+design-data figma diff --snapshot figma-vars.json --format json
+```
+
 ### primer
 
 Emit a structural overview of the dataset — useful as context at the start of an agent session.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1793,9 +1793,13 @@ fn run_figma_diff(
         }
         OutputFormat::Pretty => {
             let c = &report.counts;
+            // `renamed` is an orthogonal flag (a variable can be renamed *and*
+            // matched, mismatched, etc.), not a sibling partition — print it
+            // separately so the other five don't look like they should sum
+            // to the total entry count.
             println!(
-                "match={} value-mismatch={} figma-only={} design-data-only={} renamed={} skipped-uncovered={}",
-                c.matched, c.value_mismatch, c.figma_only, c.design_data_only, c.renamed, c.skipped_uncovered,
+                "match={} value-mismatch={} figma-only={} design-data-only={} skipped-uncovered={} (renamed={})",
+                c.matched, c.value_mismatch, c.figma_only, c.design_data_only, c.skipped_uncovered, c.renamed,
             );
             for entry in report
                 .entries

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -553,6 +553,31 @@ enum FigmaSub {
         #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
         format: OutputFormat,
     },
+    /// Value-level diff between the manifest-resolved dataset and a Figma file (read-only)
+    Diff {
+        /// Figma file key to read from (required unless `--snapshot` is given)
+        #[arg(long)]
+        file_key: Option<String>,
+        /// Figma personal access token (or set FIGMA_TOKEN env var); required unless `--snapshot`
+        #[arg(long, env = "FIGMA_TOKEN")]
+        token: Option<String>,
+        /// Diff offline against a captured `figma read --format json` snapshot instead of
+        /// calling the Figma API
+        #[arg(long, value_name = "PATH")]
+        snapshot: Option<PathBuf>,
+        /// Path to a name-mapping override artifact (from `figma audit`); overrides take
+        /// precedence over the default `{prefix}/{legacyKey}` naming
+        #[arg(long, value_name = "PATH")]
+        mapping: Option<PathBuf>,
+        /// Path to a platform manifest.json; when given, tokens are resolved through the
+        /// manifest cascade (include/exclude, overrides, extensions) instead of the default
+        /// resolved dataset
+        #[arg(long, value_name = "PATH")]
+        manifest: Option<PathBuf>,
+        /// Output format (pretty or json)
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -1691,6 +1716,100 @@ fn run_figma_audit(
     Ok(ExitCode::SUCCESS)
 }
 
+/// Value-level diff between the manifest-resolved dataset and a Figma file —
+/// read-only counterpart to `figma import`. Either `--snapshot` (offline, no
+/// token needed) or `--file-key`/`--token` (a live API call) must be given.
+fn run_figma_diff(
+    file_key: Option<&str>,
+    token: Option<&str>,
+    snapshot: Option<&Path>,
+    mapping: Option<&Path>,
+    manifest: Option<&Path>,
+    format: OutputFormat,
+) -> miette::Result<ExitCode> {
+    // 0. Get the file's variables — offline from a snapshot, or a live fetch.
+    let meta: figma::types::VariablesMeta = if let Some(snapshot_path) = snapshot {
+        let text = std::fs::read_to_string(snapshot_path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read snapshot {}", snapshot_path.display()))?;
+        serde_json::from_str(&text)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to parse snapshot {}", snapshot_path.display()))?
+    } else {
+        let file_key = file_key.ok_or_else(|| {
+            miette::miette!("either --snapshot or --file-key/--token is required")
+        })?;
+        let token = token.ok_or_else(|| {
+            miette::miette!("either --snapshot or --file-key/--token is required")
+        })?;
+        let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
+        let client = figma::api::FigmaClient::new(token.to_string());
+        eprintln!("Fetching variables from Figma...");
+        rt.block_on(client.get_local_variables(file_key))
+            .map_err(|e| miette::miette!("{e}"))?
+            .meta
+    };
+
+    // 1. Load the name-mapping artifact, if given — same forward direction
+    // (legacyKey -> figmaName) `figma export`/`build_export_payload` use.
+    let mapping_map = mapping.map(load_overrides).transpose()?;
+
+    // 2. Load the manifest-resolved TokenGraph, same as `figma export`/`import`.
+    let resolved = resolve_data_source(CliPathOverrides {
+        platform_manifest: manifest.map(Path::to_path_buf),
+        ..Default::default()
+    })?;
+    let (mut graph, _index) = TokenGraph::open_cached_with_index_with_catalogs(
+        &resolved.tokens_root,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| {
+        format!(
+            "failed to load tokens from {}",
+            resolved.tokens_root.display()
+        )
+    })?;
+    manifest::apply_configured(&mut graph, &resolved)
+        .into_diagnostic()
+        .wrap_err("failed to apply platform manifest cascade")?;
+    let tokens: Vec<(String, serde_json::Value)> = graph
+        .tokens
+        .values()
+        .map(|r| (r.name.clone(), r.raw.clone()))
+        .collect();
+
+    // 3. Diff.
+    let report = figma::import::diff_values(&meta, &graph, &tokens, mapping_map.as_ref())
+        .map_err(|e| miette::miette!("{e}"))?;
+
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report).into_diagnostic()?
+            );
+        }
+        OutputFormat::Pretty => {
+            let c = &report.counts;
+            println!(
+                "match={} value-mismatch={} figma-only={} design-data-only={} renamed={} skipped-uncovered={}",
+                c.matched, c.value_mismatch, c.figma_only, c.design_data_only, c.renamed, c.skipped_uncovered,
+            );
+            for entry in report
+                .entries
+                .iter()
+                .filter(|e| !matches!(e.class, figma::import::DiffClass::Match))
+            {
+                println!("  {} — {:?}", entry.name, entry.class);
+            }
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
 fn run_figma_read(file_key: &str, token: &str, format: OutputFormat) -> miette::Result<ExitCode> {
     let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
     let client = figma::api::FigmaClient::new(token.to_string());
@@ -2294,6 +2413,21 @@ fn main() -> ExitCode {
                 token_dir,
                 format,
             } => run_figma_audit(&snapshot, &token_dir, format),
+            FigmaSub::Diff {
+                file_key,
+                token,
+                snapshot,
+                mapping,
+                manifest,
+                format,
+            } => run_figma_diff(
+                file_key.as_deref(),
+                token.as_deref(),
+                snapshot.as_deref(),
+                mapping.as_deref(),
+                manifest.as_deref(),
+                format,
+            ),
         },
         Commands::Primer {
             path,

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -23,7 +23,9 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::color::{format_color, parse_color};
-use super::mapping::{build_export_payload, figma_opacity_to_fraction, OPACITY};
+use super::mapping::{
+    build_export_payload, figma_opacity_to_fraction, FONT_STYLE, FONT_WEIGHT, OPACITY,
+};
 use super::types::{FigmaColor, FigmaVariable, VariablesMeta};
 use super::FigmaError;
 use crate::graph::TokenGraph;
@@ -37,10 +39,56 @@ fn record_is_opacity(record: &crate::graph::TokenRecord, graph: &TokenGraph) -> 
         .is_some_and(|s| s.ends_with(OPACITY))
 }
 
+/// Whether `record` is a font-weight/font-style token, whose STRING value is
+/// compared name-insensitively (`canon_font_name`) rather than verbatim.
+fn record_is_font_name(record: &crate::graph::TokenRecord, graph: &TokenGraph) -> bool {
+    record
+        .resolve_leaf(graph)
+        .raw
+        .get("$schema")
+        .and_then(Value::as_str)
+        .is_some_and(|s| s.ends_with(FONT_STYLE) || s.ends_with(FONT_WEIGHT))
+}
+
+/// Canonicalize a font-weight/style name for comparison: casing and
+/// kebab-case punctuation aren't meaningful ("extra-bold" == "ExtraBold"),
+/// and "normal" is Figma's "Regular" — the only such synonym seen in the
+/// corpus (ponytail: add more, e.g. "oblique", only if they show up).
+fn canon_font_name(s: &str) -> String {
+    let s = s.to_lowercase().replace('-', "");
+    if s == "normal" {
+        "regular".to_string()
+    } else {
+        s
+    }
+}
+
+/// The Figma mode name a scale-set token's `name.scale` field would match
+/// ("Desktop" -> "desktop"), used to align a per-scale-divergent design-data
+/// token to the one Figma mode actually present, instead of an arbitrary
+/// scale entry. Only applied when the variable has exactly one populated
+/// mode — with more than one, which scale to align to is ambiguous
+/// (ponytail: no case in the corpus needs that; add it if one shows up).
+fn figma_mode_scale(variable: &FigmaVariable, meta: &VariablesMeta) -> Option<String> {
+    if variable.values_by_mode.len() != 1 {
+        return None;
+    }
+    let mode_id = variable.values_by_mode.keys().next()?;
+    let collection = meta
+        .variable_collections
+        .get(&variable.variable_collection_id)?;
+    collection
+        .modes
+        .iter()
+        .find(|m| &m.mode_id == mode_id)
+        .map(|m| m.name.to_lowercase())
+}
+
 /// The unit suffixes recognized on a dimension-like token value, matching the
-/// ones stripped on export (`mapping.rs`'s `value_to_figma`). `dp` is
-/// intentionally excluded — it was never exported to Figma either.
-const UNIT_SUFFIXES: &[&str] = &["rem", "em", "px", "%"];
+/// ones stripped on export (`mapping.rs`'s `value_to_figma`), plus `dp` —
+/// recognized here for comparison only; export still never strips it (see
+/// `value_to_figma`'s FLOAT arm).
+const UNIT_SUFFIXES: &[&str] = &["rem", "em", "px", "%", "dp"];
 
 /// Summary of one import run.
 #[derive(Debug, Default)]
@@ -100,13 +148,19 @@ pub fn build_import_overrides(
             }
         };
 
+        // ponytail: a manifest override is single-valued, so there's no scale
+        // to align to here the way diff_values does below — leave this arbitrary
+        // scale-entry pick as-is; a per-scale override target is a separate,
+        // thornier design question that hasn't come up in practice.
         let source_value = record.resolve_leaf(graph).raw.get("value").cloned();
         let is_opacity = record_is_opacity(record, graph);
+        let is_font_name = record_is_font_name(record, graph);
         match diff_against_source(
             &variable.resolved_type,
             &collapsed,
             source_value.as_ref(),
             is_opacity,
+            is_font_name,
         ) {
             Ok(None) => summary.unchanged += 1,
             Ok(Some(value)) => {
@@ -266,13 +320,30 @@ pub fn diff_values(
             }
         };
 
-        let source_value = record.resolve_leaf(graph).raw.get("value").cloned();
+        let leaf = record.resolve_leaf(graph);
+        // Align to the design-data entry for the Figma variable's own scale
+        // (e.g. Desktop -> "desktop") when the source is a scale-set token
+        // (`set_uuid` present) that diverges per scale — otherwise a single
+        // arbitrary scale entry gets compared against a specific Figma mode
+        // and can false-positive (or false-negative) the diff.
+        let scale_source_value = figma_mode_scale(variable, meta).and_then(|scale| {
+            let set_uuid = leaf.raw.get("set_uuid").and_then(Value::as_str)?;
+            let ctx = HashMap::from([("scale".to_string(), scale)]);
+            graph
+                .resolve_set_in_context(set_uuid, &ctx)?
+                .raw
+                .get("value")
+                .cloned()
+        });
+        let source_value = scale_source_value.or_else(|| leaf.raw.get("value").cloned());
         let is_opacity = record_is_opacity(record, graph);
+        let is_font_name = record_is_font_name(record, graph);
         let class = match diff_against_source(
             &variable.resolved_type,
             &collapsed,
             source_value.as_ref(),
             is_opacity,
+            is_font_name,
         ) {
             Ok(None) => {
                 counts.matched += 1;
@@ -411,6 +482,7 @@ fn diff_against_source(
     figma_value: &Value,
     source: Option<&Value>,
     is_opacity: bool,
+    is_font_name: bool,
 ) -> Result<Option<Value>, ()> {
     let source_str = source.and_then(Value::as_str);
     match resolved_type {
@@ -452,6 +524,13 @@ fn diff_against_source(
             let s = figma_value.as_str().ok_or(())?;
             if source_str == Some(s) {
                 return Ok(None);
+            }
+            if is_font_name {
+                if let Some(src) = source_str {
+                    if canon_font_name(src) == canon_font_name(s) {
+                        return Ok(None);
+                    }
+                }
             }
             Ok(Some(Value::String(s.to_string())))
         }
@@ -699,6 +778,180 @@ mod tests {
         let (overrides, summary) = build_import_overrides(&meta, &graph, None);
         assert!(overrides.is_empty());
         assert_eq!(summary.unchanged, 1);
+    }
+
+    #[test]
+    fn font_weight_name_casing_agrees() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/bold-font-weight",
+            "STRING",
+            vec![("m-desktop", json!("Bold"))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "bold-font-weight",
+            "u-bold",
+            json!("bold"),
+            "https://example.com/font-weight.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    #[test]
+    fn font_style_normal_agrees_with_figma_regular() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/default-font-style",
+            "STRING",
+            vec![("m-desktop", json!("Regular"))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "default-font-style",
+            "u-default-style",
+            json!("normal"),
+            "https://example.com/font-style.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    /// A genuinely different weight must still be reported — canonicalization
+    /// normalizes naming, not the underlying value.
+    #[test]
+    fn font_weight_genuine_difference_still_mismatches() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/bold-font-weight",
+            "STRING",
+            vec![("m-desktop", json!("Black"))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "bold-font-weight",
+            "u-bold",
+            json!("bold"),
+            "https://example.com/font-weight.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.value_mismatch, 1);
+    }
+
+    #[test]
+    fn dp_unit_agrees_with_bare_figma_number() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/android-elevation",
+            "FLOAT",
+            vec![("m-desktop", json!(2.0))],
+        )]);
+        let graph = mock_graph("android-elevation", "u-elevation", json!("2dp"));
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    /// Two-entry scale-set graph (desktop/mobile sharing `set_uuid`), used to
+    /// verify the diff aligns to the Figma variable's own scale instead of an
+    /// arbitrary entry.
+    fn mock_scale_graph(legacy_key: &str, desktop: Value, mobile: Value) -> TokenGraph {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!([
+                {
+                    "$schema": "https://example.com/dimension.json",
+                    "name": {"property": "padding", "scale": "desktop", "legacyKey": legacy_key},
+                    "value": desktop,
+                    "uuid": format!("u-{legacy_key}-desktop"),
+                    "set_uuid": format!("su-{legacy_key}"),
+                },
+                {
+                    "$schema": "https://example.com/dimension.json",
+                    "name": {"property": "padding", "scale": "mobile", "legacyKey": legacy_key},
+                    "value": mobile,
+                    "uuid": format!("u-{legacy_key}-mobile"),
+                    "set_uuid": format!("su-{legacy_key}"),
+                },
+            ])
+        )
+        .unwrap();
+        TokenGraph::from_json_dir(dir.path()).unwrap()
+    }
+
+    fn mock_meta_with_single_mode(
+        variable: FigmaVariable,
+        mode_name: &str,
+        mode_id: &str,
+    ) -> VariablesMeta {
+        use super::super::types::{FigmaMode, FigmaVariableCollection};
+        let mut variable_collections = HashMap::new();
+        variable_collections.insert(
+            variable.variable_collection_id.clone(),
+            FigmaVariableCollection {
+                id: variable.variable_collection_id.clone(),
+                name: ".Platform scale".to_string(),
+                key: "k".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: mode_id.to_string(),
+                    name: mode_name.to_string(),
+                }],
+                default_mode_id: mode_id.to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        let mut variables = HashMap::new();
+        variables.insert(variable.id.clone(), variable);
+        VariablesMeta {
+            variables,
+            variable_collections,
+        }
+    }
+
+    /// The false-positive case this fix targets: design-data's mobile entry
+    /// (50) differs from Figma's captured Desktop mode (42), but the desktop
+    /// entry (42) agrees — the diff must align to Figma's scale, not an
+    /// arbitrary entry, and report a match.
+    #[test]
+    fn scale_set_aligns_to_figmas_captured_mode() {
+        let var = mock_variable(
+            "platformScale/line-height-900",
+            "FLOAT",
+            vec![("m-desktop", json!(42.0))],
+        );
+        let meta = mock_meta_with_single_mode(var, "Desktop", "m-desktop");
+        let graph = mock_scale_graph("line-height-900", json!("42px"), json!("50px"));
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    /// A genuine desktop-to-desktop difference must still be reported once
+    /// aligned to the correct scale.
+    #[test]
+    fn scale_set_still_mismatches_on_real_desktop_drift() {
+        let var = mock_variable(
+            "platformScale/base-padding-horizontal-large",
+            "FLOAT",
+            vec![("m-desktop", json!(16.0))],
+        );
+        let meta = mock_meta_with_single_mode(var, "Desktop", "m-desktop");
+        let graph = mock_scale_graph(
+            "base-padding-horizontal-large",
+            json!("14px"),
+            json!("12px"),
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.value_mismatch, 1);
+        let entry = &report.entries[0];
+        match &entry.class {
+            DiffClass::ValueMismatch { design_data, .. } => {
+                assert_eq!(design_data, &json!("14px"));
+            }
+            other => panic!("expected ValueMismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -198,6 +198,9 @@ pub fn diff_values(
         let renamed = reversed
             .as_ref()
             .is_some_and(|m| m.contains_key(&variable.name));
+        if renamed {
+            counts.renamed += 1;
+        }
 
         let Some(legacy_key) = invert_name(&variable.name, reversed.as_ref()) else {
             counts.figma_only += 1;
@@ -269,9 +272,6 @@ pub fn diff_values(
                     }
                 }
             };
-        if renamed {
-            counts.renamed += 1;
-        }
         entries.push(DiffEntry {
             name: variable.name.clone(),
             legacy_key: Some(legacy_key),
@@ -282,17 +282,21 @@ pub fn diff_values(
 
     // Design-data-only pass: names the generator would produce that no real
     // Figma variable in the file covers.
-    let (body, _summary) = build_export_payload(tokens, meta, mapping)?;
-    for action in &body.variables {
-        if !seen.contains(&action.name) {
-            counts.design_data_only += 1;
-            let legacy_key = action.name.split_once('/').map(|(_, key)| key.to_string());
-            entries.push(DiffEntry {
-                name: action.name.clone(),
-                legacy_key,
-                renamed: false,
-                class: DiffClass::DesignDataOnly,
-            });
+    // A file missing the `.Color theme`/`.Platform scale` collections can't
+    // produce an export payload at all; that's a reason to skip this one
+    // pass, not to discard the Figma-driven diff already computed above.
+    if let Ok((body, _summary)) = build_export_payload(tokens, meta, mapping) {
+        for action in &body.variables {
+            if !seen.contains(&action.name) {
+                counts.design_data_only += 1;
+                let legacy_key = action.name.split_once('/').map(|(_, key)| key.to_string());
+                entries.push(DiffEntry {
+                    name: action.name.clone(),
+                    legacy_key,
+                    renamed: false,
+                    class: DiffClass::DesignDataOnly,
+                });
+            }
         }
     }
 

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -17,12 +17,15 @@
 //! Figma value has actually diverged — re-running import on an unedited file
 //! produces an empty `overrides` array.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
+use serde::Serialize;
 use serde_json::Value;
 
 use super::color::{format_color, parse_color};
+use super::mapping::build_export_payload;
 use super::types::{FigmaColor, FigmaVariable, VariablesMeta};
+use super::FigmaError;
 use crate::graph::TokenGraph;
 
 /// The unit suffixes recognized on a dimension-like token value, matching the
@@ -101,6 +104,200 @@ pub fn build_import_overrides(
     }
 
     (overrides, summary)
+}
+
+/// One variable/token's classification in a [`DiffReport`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "class", rename_all = "kebab-case")]
+pub enum DiffClass {
+    /// Figma's value matches the manifest-resolved source.
+    Match,
+    /// Figma's value diverges from the manifest-resolved source.
+    ValueMismatch { design_data: Value, figma: Value },
+    /// A Figma variable with no corresponding design-data token.
+    FigmaOnly,
+    /// A design-data token the generator would export, but no matching
+    /// Figma variable exists in the file.
+    DesignDataOnly,
+    /// Covered by neither an override (multi-mode divergent) nor a
+    /// convertible value (unresolved alias, or an unhandled resolved type).
+    SkippedUncovered { reason: String },
+}
+
+/// One entry in a [`DiffReport`]: a Figma variable name (or, for
+/// [`DiffClass::DesignDataOnly`], the name the generator would produce)
+/// paired with its classification.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffEntry {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legacy_key: Option<String>,
+    /// True when this variable's name came from the `--mapping` rename
+    /// artifact rather than the default `{prefix}/{legacyKey}` convention.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub renamed: bool,
+    #[serde(flatten)]
+    pub class: DiffClass,
+}
+
+/// Per-category totals for a [`DiffReport`], for quick scanning.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DiffCounts {
+    pub matched: usize,
+    pub value_mismatch: usize,
+    pub figma_only: usize,
+    pub design_data_only: usize,
+    pub renamed: usize,
+    pub skipped_uncovered: usize,
+}
+
+/// Value-level diff report: every Figma variable and every design-data
+/// token the generator would export, classified.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DiffReport {
+    /// Sorted by name for stable, script-friendly output.
+    pub entries: Vec<DiffEntry>,
+    pub counts: DiffCounts,
+}
+
+/// Read-only, value-level counterpart to [`build_import_overrides`]: instead
+/// of emitting manifest overrides for divergent variables, classifies *every*
+/// Figma variable and design-data token as match / value-mismatch /
+/// figma-only / design-data-only / skipped-uncovered (with a `renamed` flag
+/// when the `--mapping` artifact supplied the name).
+///
+/// `mapping` is the forward name-mapping artifact (legacy key → Figma name),
+/// the same direction `figma export --mapping` and [`build_export_payload`]
+/// use; this reverses it internally for the Figma-driven walk, which needs
+/// the opposite direction (as `build_import_overrides` does).
+///
+/// The design-data-only pass reuses [`build_export_payload`] to compute the
+/// set of Figma names the generator would produce (the same approach
+/// `figma::audit::audit_names` uses for its `generated_only` bucket), so it
+/// requires the file to contain the `.Color theme` and `.Platform scale`
+/// collections `build_export_payload` targets.
+pub fn diff_values(
+    meta: &VariablesMeta,
+    graph: &TokenGraph,
+    tokens: &[(String, Value)],
+    mapping: Option<&HashMap<String, String>>,
+) -> Result<DiffReport, FigmaError> {
+    let reversed: Option<HashMap<String, String>> =
+        mapping.map(|m| m.iter().map(|(k, v)| (v.clone(), k.clone())).collect());
+
+    let mut entries = Vec::new();
+    let mut counts = DiffCounts::default();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    let mut variables: Vec<&FigmaVariable> =
+        meta.variables.values().filter(|v| !v.remote).collect();
+    variables.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for variable in variables {
+        seen.insert(variable.name.clone());
+        let renamed = reversed
+            .as_ref()
+            .is_some_and(|m| m.contains_key(&variable.name));
+
+        let Some(legacy_key) = invert_name(&variable.name, reversed.as_ref()) else {
+            counts.figma_only += 1;
+            entries.push(DiffEntry {
+                name: variable.name.clone(),
+                legacy_key: None,
+                renamed,
+                class: DiffClass::FigmaOnly,
+            });
+            continue;
+        };
+        let Some(record) = graph.resolve_alias_key(&legacy_key) else {
+            counts.figma_only += 1;
+            entries.push(DiffEntry {
+                name: variable.name.clone(),
+                legacy_key: Some(legacy_key),
+                renamed,
+                class: DiffClass::FigmaOnly,
+            });
+            continue;
+        };
+
+        let collapsed = match collapse_modes(variable) {
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                counts.skipped_uncovered += 1;
+                entries.push(DiffEntry {
+                    name: variable.name.clone(),
+                    legacy_key: Some(legacy_key),
+                    renamed,
+                    class: DiffClass::SkippedUncovered {
+                        reason: "multimode-divergent".to_string(),
+                    },
+                });
+                continue;
+            }
+            Err(()) => {
+                counts.skipped_uncovered += 1;
+                entries.push(DiffEntry {
+                    name: variable.name.clone(),
+                    legacy_key: Some(legacy_key),
+                    renamed,
+                    class: DiffClass::SkippedUncovered {
+                        reason: "unconvertible".to_string(),
+                    },
+                });
+                continue;
+            }
+        };
+
+        let source_value = record.resolve_leaf(graph).raw.get("value").cloned();
+        let class =
+            match diff_against_source(&variable.resolved_type, &collapsed, source_value.as_ref()) {
+                Ok(None) => {
+                    counts.matched += 1;
+                    DiffClass::Match
+                }
+                Ok(Some(figma_value)) => {
+                    counts.value_mismatch += 1;
+                    DiffClass::ValueMismatch {
+                        design_data: source_value.clone().unwrap_or(Value::Null),
+                        figma: figma_value,
+                    }
+                }
+                Err(()) => {
+                    counts.skipped_uncovered += 1;
+                    DiffClass::SkippedUncovered {
+                        reason: "unconvertible".to_string(),
+                    }
+                }
+            };
+        if renamed {
+            counts.renamed += 1;
+        }
+        entries.push(DiffEntry {
+            name: variable.name.clone(),
+            legacy_key: Some(legacy_key),
+            renamed,
+            class,
+        });
+    }
+
+    // Design-data-only pass: names the generator would produce that no real
+    // Figma variable in the file covers.
+    let (body, _summary) = build_export_payload(tokens, meta, mapping)?;
+    for action in &body.variables {
+        if !seen.contains(&action.name) {
+            counts.design_data_only += 1;
+            let legacy_key = action.name.split_once('/').map(|(_, key)| key.to_string());
+            entries.push(DiffEntry {
+                name: action.name.clone(),
+                legacy_key,
+                renamed: false,
+                class: DiffClass::DesignDataOnly,
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(DiffReport { entries, counts })
 }
 
 /// Invert a Figma variable name back to its legacy token key: the rename
@@ -306,6 +503,83 @@ mod tests {
         assert!(overrides.is_empty());
         assert_eq!(summary.unchanged, 1);
         assert_eq!(summary.overrides_emitted, 0);
+    }
+
+    #[test]
+    fn diff_values_reports_known_mismatch() {
+        use super::super::types::{FigmaMode, FigmaVariableCollection};
+
+        let var = mock_variable(
+            "colorTheme/blue-100",
+            "COLOR",
+            vec![("m-light", json!({"r": 0.0, "g": 0.0, "b": 1.0, "a": 1.0}))],
+        );
+        let mut variables = HashMap::new();
+        variables.insert(var.id.clone(), var);
+        let mut variable_collections = HashMap::new();
+        variable_collections.insert(
+            "col-1".to_string(),
+            FigmaVariableCollection {
+                id: "col-1".to_string(),
+                name: ".Color theme".to_string(),
+                key: "k1".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: "m-light".to_string(),
+                    name: "Light".to_string(),
+                }],
+                default_mode_id: "m-light".to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        variable_collections.insert(
+            "col-2".to_string(),
+            FigmaVariableCollection {
+                id: "col-2".to_string(),
+                name: ".Platform scale".to_string(),
+                key: "k2".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: "m-desktop".to_string(),
+                    name: "Desktop".to_string(),
+                }],
+                default_mode_id: "m-desktop".to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        let meta = VariablesMeta {
+            variables,
+            variable_collections,
+        };
+
+        let graph = mock_graph("blue-100", "u-blue-100", json!("#ff8000"));
+        let tokens = vec![(
+            "blue-100".to_string(),
+            json!({
+                "$schema": "https://example.com/color.json",
+                "name": "blue-100",
+                "value": "#ff8000",
+                "uuid": "u-blue-100",
+            }),
+        )];
+
+        let report = diff_values(&meta, &graph, &tokens, None).unwrap();
+        assert_eq!(report.counts.value_mismatch, 1);
+        assert_eq!(report.counts.matched, 0);
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "colorTheme/blue-100")
+            .expect("mismatched variable must be reported");
+        match &entry.class {
+            DiffClass::ValueMismatch { design_data, figma } => {
+                assert_eq!(design_data, &json!("#ff8000"));
+                assert_eq!(figma, &json!("#0000ff"));
+            }
+            other => panic!("expected ValueMismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -30,32 +30,31 @@ use super::types::{FigmaColor, FigmaVariable, VariablesMeta};
 use super::FigmaError;
 use crate::graph::TokenGraph;
 
-fn record_is_opacity(record: &crate::graph::TokenRecord, graph: &TokenGraph) -> bool {
-    record
-        .resolve_leaf(graph)
-        .raw
+/// Whether `leaf`'s (already alias-resolved) schema is the opacity schema.
+fn record_is_opacity(leaf: &crate::graph::TokenRecord) -> bool {
+    leaf.raw
         .get("$schema")
         .and_then(Value::as_str)
         .is_some_and(|s| s.ends_with(OPACITY))
 }
 
-/// Whether `record` is a font-weight/font-style token, whose STRING value is
-/// compared name-insensitively (`canon_font_name`) rather than verbatim.
-fn record_is_font_name(record: &crate::graph::TokenRecord, graph: &TokenGraph) -> bool {
-    record
-        .resolve_leaf(graph)
-        .raw
+/// Whether `leaf`'s (already alias-resolved) schema is a font-weight/style
+/// token, whose STRING value is compared name-insensitively
+/// (`canon_font_name`) rather than verbatim.
+fn record_is_font_name(leaf: &crate::graph::TokenRecord) -> bool {
+    leaf.raw
         .get("$schema")
         .and_then(Value::as_str)
         .is_some_and(|s| s.ends_with(FONT_STYLE) || s.ends_with(FONT_WEIGHT))
 }
 
 /// Canonicalize a font-weight/style name for comparison: casing and
-/// kebab-case punctuation aren't meaningful ("extra-bold" == "ExtraBold"),
-/// and "normal" is Figma's "Regular" — the only such synonym seen in the
-/// corpus (ponytail: add more, e.g. "oblique", only if they show up).
+/// kebab-case/space punctuation aren't meaningful ("extra-bold" == "ExtraBold"
+/// == "Extra Bold"), and "normal" is Figma's "Regular" — the only such
+/// synonym seen in the corpus (ponytail: add more, e.g. "oblique", only if
+/// they show up).
 fn canon_font_name(s: &str) -> String {
-    let s = s.to_lowercase().replace('-', "");
+    let s = s.to_lowercase().replace(['-', ' '], "");
     if s == "normal" {
         "regular".to_string()
     } else {
@@ -152,9 +151,10 @@ pub fn build_import_overrides(
         // to align to here the way diff_values does below — leave this arbitrary
         // scale-entry pick as-is; a per-scale override target is a separate,
         // thornier design question that hasn't come up in practice.
-        let source_value = record.resolve_leaf(graph).raw.get("value").cloned();
-        let is_opacity = record_is_opacity(record, graph);
-        let is_font_name = record_is_font_name(record, graph);
+        let leaf = record.resolve_leaf(graph);
+        let source_value = leaf.raw.get("value").cloned();
+        let is_opacity = record_is_opacity(leaf);
+        let is_font_name = record_is_font_name(leaf);
         match diff_against_source(
             &variable.resolved_type,
             &collapsed,
@@ -328,16 +328,18 @@ pub fn diff_values(
         // and can false-positive (or false-negative) the diff.
         let scale_source_value = figma_mode_scale(variable, meta).and_then(|scale| {
             let set_uuid = leaf.raw.get("set_uuid").and_then(Value::as_str)?;
-            let ctx = HashMap::from([("scale".to_string(), scale)]);
-            graph
-                .resolve_set_in_context(set_uuid, &ctx)?
-                .raw
-                .get("value")
-                .cloned()
+            let ctx = HashMap::from([("scale".to_string(), scale.clone())]);
+            let candidate = graph.resolve_set_in_context(set_uuid, &ctx)?;
+            // `resolve_set_in_context` degrades to an arbitrary tie-broken
+            // member when none actually matches `scale` (e.g. a Figma mode
+            // like "Tablet" with no design-data counterpart) — only trust
+            // the alignment when the candidate's own scale really agrees.
+            let candidate_scale = candidate.raw.get("name")?.get("scale")?.as_str()?;
+            (candidate_scale == scale).then(|| candidate.raw.get("value").cloned())?
         });
         let source_value = scale_source_value.or_else(|| leaf.raw.get("value").cloned());
-        let is_opacity = record_is_opacity(record, graph);
-        let is_font_name = record_is_font_name(record, graph);
+        let is_opacity = record_is_opacity(leaf);
+        let is_font_name = record_is_font_name(leaf);
         let class = match diff_against_source(
             &variable.resolved_type,
             &collapsed,
@@ -380,7 +382,7 @@ pub fn diff_values(
         for action in &body.variables {
             if !seen.contains(&action.name) {
                 counts.design_data_only += 1;
-                let legacy_key = action.name.split_once('/').map(|(_, key)| key.to_string());
+                let legacy_key = invert_name(&action.name, reversed.as_ref());
                 entries.push(DiffEntry {
                     name: action.name.clone(),
                     legacy_key,
@@ -700,6 +702,77 @@ mod tests {
         }
     }
 
+    /// A design-data-only token that's covered by `--mapping` must report its
+    /// real legacy key, not whatever comes after the last `/` in the mapped
+    /// Figma name (which can differ, e.g. `spacing-100` -> `Layout/spacing-100-real`).
+    #[test]
+    fn design_data_only_entry_uses_mapping_for_legacy_key() {
+        use super::super::types::{FigmaMode, FigmaVariableCollection};
+
+        let mut variable_collections = HashMap::new();
+        variable_collections.insert(
+            "col-1".to_string(),
+            FigmaVariableCollection {
+                id: "col-1".to_string(),
+                name: ".Color theme".to_string(),
+                key: "k1".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: "m-light".to_string(),
+                    name: "Light".to_string(),
+                }],
+                default_mode_id: "m-light".to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        variable_collections.insert(
+            "col-2".to_string(),
+            FigmaVariableCollection {
+                id: "col-2".to_string(),
+                name: ".Platform scale".to_string(),
+                key: "k2".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: "m-desktop".to_string(),
+                    name: "Desktop".to_string(),
+                }],
+                default_mode_id: "m-desktop".to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        let meta = VariablesMeta {
+            variables: HashMap::new(),
+            variable_collections,
+        };
+
+        let graph = mock_graph("spacing-100", "u-spacing-100", json!("8px"));
+        let tokens = vec![(
+            "spacing-100".to_string(),
+            json!({
+                "$schema": "https://example.com/dimension.json",
+                "name": "spacing-100",
+                "value": "8px",
+                "uuid": "u-spacing-100",
+            }),
+        )];
+        let mapping: HashMap<String, String> = [(
+            "spacing-100".to_string(),
+            "Layout/spacing-100-real".to_string(),
+        )]
+        .into_iter()
+        .collect();
+
+        let report = diff_values(&meta, &graph, &tokens, Some(&mapping)).unwrap();
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "Layout/spacing-100-real")
+            .expect("design-data-only entry must be reported");
+        assert_eq!(entry.legacy_key.as_deref(), Some("spacing-100"));
+    }
+
     #[test]
     fn opacity_scale_agrees_when_figma_is_percent_of_fraction() {
         let meta = mock_meta(vec![mock_variable(
@@ -791,6 +864,24 @@ mod tests {
             "bold-font-weight",
             "u-bold",
             json!("bold"),
+            "https://example.com/font-weight.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    #[test]
+    fn font_weight_space_variant_agrees() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/extra-bold-font-weight",
+            "STRING",
+            vec![("m-desktop", json!("Extra Bold"))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "extra-bold-font-weight",
+            "u-extra-bold",
+            json!("extra-bold"),
             "https://example.com/font-weight.json",
         );
         let report = diff_values(&meta, &graph, &[], None).unwrap();

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -23,10 +23,19 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::color::{format_color, parse_color};
-use super::mapping::build_export_payload;
+use super::mapping::{build_export_payload, figma_opacity_to_fraction, OPACITY};
 use super::types::{FigmaColor, FigmaVariable, VariablesMeta};
 use super::FigmaError;
 use crate::graph::TokenGraph;
+
+fn record_is_opacity(record: &crate::graph::TokenRecord, graph: &TokenGraph) -> bool {
+    record
+        .resolve_leaf(graph)
+        .raw
+        .get("$schema")
+        .and_then(Value::as_str)
+        .is_some_and(|s| s.ends_with(OPACITY))
+}
 
 /// The unit suffixes recognized on a dimension-like token value, matching the
 /// ones stripped on export (`mapping.rs`'s `value_to_figma`). `dp` is
@@ -92,7 +101,13 @@ pub fn build_import_overrides(
         };
 
         let source_value = record.resolve_leaf(graph).raw.get("value").cloned();
-        match diff_against_source(&variable.resolved_type, &collapsed, source_value.as_ref()) {
+        let is_opacity = record_is_opacity(record, graph);
+        match diff_against_source(
+            &variable.resolved_type,
+            &collapsed,
+            source_value.as_ref(),
+            is_opacity,
+        ) {
             Ok(None) => summary.unchanged += 1,
             Ok(Some(value)) => {
                 let target = record.uuid.clone().unwrap_or_else(|| record.name.clone());
@@ -252,26 +267,31 @@ pub fn diff_values(
         };
 
         let source_value = record.resolve_leaf(graph).raw.get("value").cloned();
-        let class =
-            match diff_against_source(&variable.resolved_type, &collapsed, source_value.as_ref()) {
-                Ok(None) => {
-                    counts.matched += 1;
-                    DiffClass::Match
+        let is_opacity = record_is_opacity(record, graph);
+        let class = match diff_against_source(
+            &variable.resolved_type,
+            &collapsed,
+            source_value.as_ref(),
+            is_opacity,
+        ) {
+            Ok(None) => {
+                counts.matched += 1;
+                DiffClass::Match
+            }
+            Ok(Some(figma_value)) => {
+                counts.value_mismatch += 1;
+                DiffClass::ValueMismatch {
+                    design_data: source_value.clone().unwrap_or(Value::Null),
+                    figma: figma_value,
                 }
-                Ok(Some(figma_value)) => {
-                    counts.value_mismatch += 1;
-                    DiffClass::ValueMismatch {
-                        design_data: source_value.clone().unwrap_or(Value::Null),
-                        figma: figma_value,
-                    }
+            }
+            Err(()) => {
+                counts.skipped_uncovered += 1;
+                DiffClass::SkippedUncovered {
+                    reason: "unconvertible".to_string(),
                 }
-                Err(()) => {
-                    counts.skipped_uncovered += 1;
-                    DiffClass::SkippedUncovered {
-                        reason: "unconvertible".to_string(),
-                    }
-                }
-            };
+            }
+        };
         entries.push(DiffEntry {
             name: variable.name.clone(),
             legacy_key: Some(legacy_key),
@@ -390,6 +410,7 @@ fn diff_against_source(
     resolved_type: &str,
     figma_value: &Value,
     source: Option<&Value>,
+    is_opacity: bool,
 ) -> Result<Option<Value>, ()> {
     let source_str = source.and_then(Value::as_str);
     match resolved_type {
@@ -403,7 +424,12 @@ fn diff_against_source(
             Ok(Some(Value::String(format_color(&color))))
         }
         "FLOAT" => {
-            let n = figma_value.as_f64().ok_or(())?;
+            let raw_n = figma_value.as_f64().ok_or(())?;
+            let n = if is_opacity {
+                figma_opacity_to_fraction(raw_n)
+            } else {
+                raw_n
+            };
             if let Some(source_n) = source.and_then(Value::as_f64) {
                 if approx_eq(n, source_n) {
                     return Ok(None);
@@ -473,6 +499,15 @@ mod tests {
     /// as the object-format fixtures `mapping.rs`'s export tests use) so the
     /// uuid/legacy-name indexes are populated exactly as they are in production.
     fn mock_graph(legacy_key: &str, uuid: &str, value: Value) -> TokenGraph {
+        mock_graph_with_schema(legacy_key, uuid, value, "https://example.com/color.json")
+    }
+
+    fn mock_graph_with_schema(
+        legacy_key: &str,
+        uuid: &str,
+        value: Value,
+        schema: &str,
+    ) -> TokenGraph {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tokens.json");
         let mut f = std::fs::File::create(&path).unwrap();
@@ -481,7 +516,7 @@ mod tests {
             "{}",
             json!({
                 legacy_key: {
-                    "$schema": "https://example.com/color.json",
+                    "$schema": schema,
                     "name": legacy_key,
                     "value": value,
                     "uuid": uuid,
@@ -587,6 +622,86 @@ mod tests {
     }
 
     #[test]
+    fn opacity_scale_agrees_when_figma_is_percent_of_fraction() {
+        let meta = mock_meta(vec![mock_variable(
+            "colorTheme/background-opacity-down",
+            "FLOAT",
+            vec![("m-light", json!(10.0))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "background-opacity-down",
+            "u-opacity-down",
+            json!("0.1"),
+            "https://example.com/opacity.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    #[test]
+    fn opacity_mismatch_reports_fraction_scale() {
+        let meta = mock_meta(vec![mock_variable(
+            "colorTheme/background-opacity-down",
+            "FLOAT",
+            vec![("m-light", json!(20.0))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "background-opacity-down",
+            "u-opacity-down",
+            json!("0.1"),
+            "https://example.com/opacity.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.value_mismatch, 1);
+        let entry = &report.entries[0];
+        match &entry.class {
+            DiffClass::ValueMismatch { design_data, figma } => {
+                assert_eq!(design_data, &json!("0.1"));
+                assert_eq!(figma, &json!("0.2"));
+            }
+            other => panic!("expected ValueMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opacity_import_override_uses_fraction_scale() {
+        let meta = mock_meta(vec![mock_variable(
+            "colorTheme/background-opacity-down",
+            "FLOAT",
+            vec![("m-light", json!(20.0))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "background-opacity-down",
+            "u-opacity-down",
+            json!("0.1"),
+            "https://example.com/opacity.json",
+        );
+        let (overrides, summary) = build_import_overrides(&meta, &graph, None);
+        assert_eq!(summary.overrides_emitted, 1);
+        assert_eq!(overrides[0]["target"], "u-opacity-down");
+        assert_eq!(overrides[0]["value"], "0.2");
+    }
+
+    #[test]
+    fn opacity_import_no_override_when_scales_agree() {
+        let meta = mock_meta(vec![mock_variable(
+            "colorTheme/background-opacity-down",
+            "FLOAT",
+            vec![("m-light", json!(10.0))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "background-opacity-down",
+            "u-opacity-down",
+            json!("0.1"),
+            "https://example.com/opacity.json",
+        );
+        let (overrides, summary) = build_import_overrides(&meta, &graph, None);
+        assert!(overrides.is_empty());
+        assert_eq!(summary.unchanged, 1);
+    }
+
+    #[test]
     fn diverged_color_emits_uuid_override() {
         let meta = mock_meta(vec![mock_variable(
             "colorTheme/blue-100",
@@ -613,17 +728,18 @@ mod tests {
         assert_eq!(overrides[0]["value"], "16px");
     }
 
-    /// A bare-number source (e.g. an opacity/font-weight token, not a
-    /// unit-suffixed dimension) must still be compared numerically —
+    /// A bare-number source (e.g. a font-weight token, not a unit-suffixed
+    /// dimension, and not opacity — this mock's schema is `color.json`, so no
+    /// opacity scaling applies) must still be compared numerically —
     /// otherwise an unedited FLOAT variable falsely reads as diverged.
     #[test]
     fn unchanged_bare_numeric_float_produces_no_override() {
         let meta = mock_meta(vec![mock_variable(
-            "platformScale/opacity-disabled",
+            "platformScale/font-weight-bold",
             "FLOAT",
             vec![("m-desktop", json!(0.6666))],
         )]);
-        let graph = mock_graph("opacity-disabled", "u-opacity-disabled", json!(0.6666));
+        let graph = mock_graph("font-weight-bold", "u-font-weight-bold", json!(0.6666));
         let (overrides, summary) = build_import_overrides(&meta, &graph, None);
         assert!(overrides.is_empty());
         assert_eq!(summary.unchanged, 1);

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -31,7 +31,7 @@ const COLOR_SET: &str = "color-set.json";
 const COLOR: &str = "color.json";
 const SCALE_SET: &str = "scale-set.json";
 const DIMENSION: &str = "dimension.json";
-const OPACITY: &str = "opacity.json";
+pub(crate) const OPACITY: &str = "opacity.json";
 const FONT_FAMILY: &str = "font-family.json";
 const FONT_SIZE: &str = "font-size.json";
 const FONT_STYLE: &str = "font-style.json";
@@ -400,8 +400,22 @@ fn schema_to_figma_type(schema: &str) -> &'static str {
     }
 }
 
+/// design-data stores opacity as a 0–1 fraction; Figma variables use a 0–100
+/// scale. `is_opacity` callers convert between them at the codec boundary so
+/// export/import/diff all agree on the fraction as the canonical scale.
+pub(crate) fn fraction_to_figma_opacity(fraction: f64) -> f64 {
+    // ponytail: round to 6 decimal places to shed float noise (0.1 * 100.0
+    // can land on 10.000000000000002); precision beyond that isn't meaningful
+    // for an opacity value.
+    ((fraction * 100.0) * 1e6).round() / 1e6
+}
+
+pub(crate) fn figma_opacity_to_fraction(figma_value: f64) -> f64 {
+    ((figma_value / 100.0) * 1e6).round() / 1e6
+}
+
 /// Convert a raw value string to a Figma-compatible JSON value.
-fn value_to_figma(value_str: &str, figma_type: &str) -> Option<Value> {
+fn value_to_figma(value_str: &str, figma_type: &str, is_opacity: bool) -> Option<Value> {
     match figma_type {
         "COLOR" => {
             let c = parse_color(value_str).ok()?;
@@ -418,6 +432,11 @@ fn value_to_figma(value_str: &str, figma_type: &str) -> Option<Value> {
                 .trim_end_matches("px")
                 .trim_end_matches('%');
             let n: f64 = s.parse().ok()?;
+            let n = if is_opacity {
+                fraction_to_figma_opacity(n)
+            } else {
+                n
+            };
             Some(Value::Number(serde_json::Number::from_f64(n)?))
         }
         "STRING" => Some(Value::String(value_str.to_string())),
@@ -530,7 +549,9 @@ fn process_color_set_token(
         });
 
         if let Some(val_str) = resolved {
-            if let Some(figma_val) = value_to_figma(val_str, figma_type) {
+            if let Some(figma_val) =
+                value_to_figma(val_str, figma_type, inner_schema.ends_with(OPACITY))
+            {
                 mode_values.push(ModeValueAction {
                     variable_id: var_id.clone(),
                     mode_id: mode_id.clone(),
@@ -628,7 +649,9 @@ fn process_scale_set_token(
         });
 
         if let Some(val_str) = resolved {
-            if let Some(figma_val) = value_to_figma(val_str, figma_type) {
+            if let Some(figma_val) =
+                value_to_figma(val_str, figma_type, inner_schema.ends_with(OPACITY))
+            {
                 mode_values.push(ModeValueAction {
                     variable_id: var_id.clone(),
                     mode_id: mode_id.clone(),
@@ -676,7 +699,11 @@ fn process_flat_token(
         raw_value
     };
 
-    let figma_val = match value_to_figma(resolved, figma_type) {
+    let is_opacity = entry
+        .get("$schema")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.ends_with(OPACITY));
+    let figma_val = match value_to_figma(resolved, figma_type, is_opacity) {
         Some(v) => v,
         None => {
             summary
@@ -791,10 +818,11 @@ fn process_alias_token(
         )
     };
 
-    let figma_val = match value_to_figma(resolved_value, figma_type) {
-        Some(v) => v,
-        None => return,
-    };
+    let figma_val =
+        match value_to_figma(resolved_value, figma_type, target_schema.ends_with(OPACITY)) {
+            Some(v) => v,
+            None => return,
+        };
 
     let desc = entry.get("description").and_then(|v| v.as_str());
     let (va, var_id) = make_variable_action(
@@ -934,6 +962,38 @@ mod tests {
         // Value should be 8.0
         let val = &body.variable_mode_values[0].value;
         assert_eq!(val.as_f64(), Some(8.0));
+    }
+
+    #[test]
+    fn opacity_token_scales_fraction_to_figma_percent() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("color-aliases.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "background-opacity-down": {
+                    "$schema": "https://example.com/opacity.json",
+                    "value": "0.1",
+                    "uuid": "o1"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
+        assert_eq!(summary.variables_created, 1);
+        assert_eq!(
+            body.variables[0].name,
+            "platformScale/background-opacity-down"
+        );
+        assert_eq!(body.variables[0].resolved_type, "FLOAT");
+        let val = &body.variable_mode_values[0].value;
+        assert_eq!(val.as_f64(), Some(10.0));
     }
 
     #[test]

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -34,8 +34,8 @@ const DIMENSION: &str = "dimension.json";
 pub(crate) const OPACITY: &str = "opacity.json";
 const FONT_FAMILY: &str = "font-family.json";
 const FONT_SIZE: &str = "font-size.json";
-const FONT_STYLE: &str = "font-style.json";
-const FONT_WEIGHT: &str = "font-weight.json";
+pub(crate) const FONT_STYLE: &str = "font-style.json";
+pub(crate) const FONT_WEIGHT: &str = "font-weight.json";
 const ALIAS: &str = "alias.json";
 
 // Schemas we skip (composite types with no Figma Variable equivalent).
@@ -425,6 +425,9 @@ fn value_to_figma(value_str: &str, figma_type: &str, is_opacity: bool) -> Option
             // Strip common unit suffixes: px, em, rem, %
             // Note: dp (Android density-independent pixels) is intentionally not
             // stripped — dp values have no Figma equivalent and are tracked separately.
+            // (The diff/import side's `UNIT_SUFFIXES` does recognize `dp`, for
+            // comparison purposes only — a captured Figma file can carry a
+            // dp-sourced numeric value even though export never writes one.)
             let s = value_str
                 .trim()
                 .trim_end_matches("rem")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a read-only `figma diff` CLI command: a value-level comparison between
the manifest-resolved design-data dataset and a Figma file's actual variable
values. Reuses the value-comparison codec from `figma import` (`invert_name`,
`collapse_modes`, `diff_against_source`) and the export name-set diff from
`figma audit` (`build_export_payload`) rather than re-deriving either.

Every Figma variable / design-data token is classified as one of:
`match`, `value-mismatch`, `figma-only`, `design-data-only`, `renamed` (via
`--mapping`), or `skipped-uncovered`.

## Related Issue

Closes spectrum-design-data-11k.6.

## Motivation and Context

Design-data can already push tokens into Figma (`figma export`) and pull
Figma edits back into manifest overrides (`figma import`), but there was no
way to see where Figma has drifted from the source of truth without
mutating either side. `figma diff` fills that gap for both humans (pretty
output) and scripts (`--format json`).

## How Has This Been Tested?

- New unit test `diff_values_reports_known_mismatch` in
  `sdk/core/src/figma/import.rs` asserts a known color mismatch is classified
  correctly.
- `moon run sdk:test` — full workspace green.
- `moon run sdk:lint` — clippy clean (`-D warnings`).
- End-to-end offline run against the real 2961-variable baseline fixture
  (`sdk/core/tests/fixtures/figma/s2-web-variables.baseline.json`):
  `cargo run -p design-data-cli -- figma diff --snapshot <fixture> --format json`
  produced a single clean JSON object (stdout/stderr verified separately —
  no interleaved log lines) and surfaced a real mismatch
  (`background-opacity-down`: design-data `0.1` vs Figma `10`).
- Changeset linted: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Screenshots (if appropriate):

N/A — CLI-only change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
