### PR TITLE
fix(design-data): drop dangling VARIABLE_ALIAS refs in Figma export

### DIFF
--- a/.changeset/figma-export-dangling-alias.md
+++ b/.changeset/figma-export-dangling-alias.md
@@ -1,0 +1,11 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Figma export no longer sends `VARIABLE_ALIAS` references to variable ids that
+were never created, which Figma would reject (closes spectrum-design-data-qz1o).
+
+- **sdk/core/src/figma/mapping.rs**: `build_export_payload` now drops any
+  `ModeValueAction` whose `VARIABLE_ALIAS` targets an id absent from the
+  emitted `variables` list (e.g. an alias target with malformed `sets`) and
+  records a `mode_warnings` entry instead of emitting the dangling reference.

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -375,27 +375,49 @@ fn build_export_payload_with_specs(
     // a VARIABLE_ALIAS may only point at an id that actually made it into
     // `variables`. Drop any that don't and warn, rather than sending Figma a
     // POST that references an undefined variable id.
-    let emitted_ids: HashSet<&str> = variables.iter().filter_map(|v| v.id.as_deref()).collect();
-    mode_values.retain(|mv| {
-        let Some(alias_id) = mv
-            .value
-            .get("type")
-            .and_then(|t| t.as_str())
-            .filter(|t| *t == "VARIABLE_ALIAS")
-            .and_then(|_| mv.value.get("id"))
-            .and_then(|id| id.as_str())
-        else {
-            return true;
-        };
-        if emitted_ids.contains(alias_id) {
-            true
-        } else {
-            summary.mode_warnings.push(format!(
-                "dangling VARIABLE_ALIAS to '{alias_id}' — target variable was never created, value dropped"
-            ));
-            false
-        }
-    });
+    let mut dangling_variable_ids: HashSet<String> = HashSet::new();
+    {
+        let emitted_ids: HashSet<&str> = variables.iter().filter_map(|v| v.id.as_deref()).collect();
+        mode_values.retain(|mv| {
+            let Some(alias_id) = variable_alias_target_id(&mv.value) else {
+                return true;
+            };
+            if emitted_ids.contains(alias_id) {
+                true
+            } else {
+                dangling_variable_ids.insert(mv.variable_id.clone());
+                summary.mode_values_aliased = summary.mode_values_aliased.saturating_sub(1);
+                summary.mode_warnings.push(format!(
+                    "dangling VARIABLE_ALIAS to '{alias_id}' — target variable was never created, value dropped"
+                ));
+                false
+            }
+        });
+    }
+
+    // A variable whose every mode value pointed at a dangling alias now has no
+    // mode values at all — don't send Figma an otherwise-empty CREATE/UPDATE
+    // for it.
+    if !dangling_variable_ids.is_empty() {
+        let variable_ids_with_values: HashSet<&str> = mode_values
+            .iter()
+            .map(|mv| mv.variable_id.as_str())
+            .collect();
+        variables.retain(|v| {
+            let Some(id) = v.id.as_deref() else {
+                return true;
+            };
+            if dangling_variable_ids.contains(id) && !variable_ids_with_values.contains(id) {
+                summary.variables_created = summary.variables_created.saturating_sub(1);
+                summary.mode_warnings.push(format!(
+                    "'{id}' dropped entirely — every mode value pointed at a missing alias target"
+                ));
+                false
+            } else {
+                true
+            }
+        });
+    }
 
     let body = PostVariablesBody {
         variable_collections: vec![],
@@ -642,6 +664,17 @@ fn value_to_figma(value_str: &str, figma_type: &str, is_opacity: bool) -> Option
         "STRING" => Some(Value::String(value_str.to_string())),
         _ => None,
     }
+}
+
+/// Extract the target variable id from a [`ModeValueAction`] value if it's a
+/// `VARIABLE_ALIAS` reference. Shared by the post-loop dangling-alias sweep in
+/// [`build_export_payload_with_specs`] and its tests, so a shape change to the
+/// alias JSON can't drift the two apart.
+fn variable_alias_target_id(value: &Value) -> Option<&str> {
+    if value.get("type").and_then(|t| t.as_str()) != Some("VARIABLE_ALIAS") {
+        return None;
+    }
+    value.get("id").and_then(|id| id.as_str())
 }
 
 /// Resolve a token's Figma variable name and id (real id if it already exists in
@@ -1601,8 +1634,7 @@ mod tests {
             .filter_map(|v| v.id.as_deref())
             .collect();
         for mv in &body.variable_mode_values {
-            if mv.value.get("type").and_then(|t| t.as_str()) == Some("VARIABLE_ALIAS") {
-                let target = mv.value.get("id").and_then(|v| v.as_str()).unwrap();
+            if let Some(target) = variable_alias_target_id(&mv.value) {
                 assert!(
                     emitted_ids.contains(target),
                     "dangling VARIABLE_ALIAS to '{target}' with no matching VariableAction"
@@ -1616,6 +1648,26 @@ mod tests {
                 .any(|w| w.contains("dangling VARIABLE_ALIAS")),
             "expected a mode_warnings entry for the dropped alias, got: {:?}",
             summary.mode_warnings
+        );
+
+        // Every mode of `alias-color-set` aliased the malformed `base-color-set-a`,
+        // so after dropping the dangling aliases it has zero mode values left — it
+        // must be dropped entirely, not sent to Figma as an empty CREATE/UPDATE.
+        assert!(
+            !emitted_ids.contains("colorTheme__alias-color-set"),
+            "expected the fully-dangling variable to be dropped, ids: {emitted_ids:?}"
+        );
+        assert!(
+            summary
+                .mode_warnings
+                .iter()
+                .any(|w| w.contains("dropped entirely")),
+            "expected a mode_warnings entry for the dropped variable, got: {:?}",
+            summary.mode_warnings
+        );
+        assert_eq!(
+            summary.mode_values_aliased, 0,
+            "dropped alias values must not be counted in the summary"
         );
     }
 

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -14,7 +14,7 @@
 //! `{camelCasePrefix}/{kebab-case-token-name}` naming — matching legacy token
 //! names 1:1.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -367,6 +367,35 @@ fn build_export_payload_with_specs(
             summary.skipped_unknown_schema.push(token_name.clone());
         }
     }
+
+    // ponytail: the alias-target pre-pass registers an id for a token before
+    // knowing whether that token's own processing later bails (malformed
+    // `sets`/`value` — no schema validation runs before export). Enforce the
+    // invariant here, once, instead of threading it through every bail site:
+    // a VARIABLE_ALIAS may only point at an id that actually made it into
+    // `variables`. Drop any that don't and warn, rather than sending Figma a
+    // POST that references an undefined variable id.
+    let emitted_ids: HashSet<&str> = variables.iter().filter_map(|v| v.id.as_deref()).collect();
+    mode_values.retain(|mv| {
+        let Some(alias_id) = mv
+            .value
+            .get("type")
+            .and_then(|t| t.as_str())
+            .filter(|t| *t == "VARIABLE_ALIAS")
+            .and_then(|_| mv.value.get("id"))
+            .and_then(|id| id.as_str())
+        else {
+            return true;
+        };
+        if emitted_ids.contains(alias_id) {
+            true
+        } else {
+            summary.mode_warnings.push(format!(
+                "dangling VARIABLE_ALIAS to '{alias_id}' — target variable was never created, value dropped"
+            ));
+            false
+        }
+    });
 
     let body = PostVariablesBody {
         variable_collections: vec![],
@@ -1529,6 +1558,65 @@ mod tests {
             .collect();
         assert!(alias_target_ids.contains(&"colorTheme__base-color-set-a"));
         assert!(alias_target_ids.contains(&"colorTheme__base-color-set-b"));
+    }
+
+    #[test]
+    fn alias_to_malformed_set_target_drops_dangling_reference() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("colors.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                // Malformed: color-set schema but no `sets` object, so
+                // `process_color_set_token` bails without emitting a
+                // VariableAction — even though the pre-pass already
+                // registered an id for it.
+                "base-color-set-a": {
+                    "$schema": "https://example.com/color-set.json",
+                    "uuid": "a0"
+                },
+                "alias-color-set": {
+                    "$schema": "https://example.com/color-set.json",
+                    "sets": {
+                        "light": { "$schema": "https://example.com/color.json", "value": "{base-color-set-a}", "uuid": "al-light" },
+                        "dark": { "$schema": "https://example.com/color.json", "value": "{base-color-set-a}", "uuid": "al-dark" },
+                        "wireframe": { "$schema": "https://example.com/color.json", "value": "{base-color-set-a}", "uuid": "al-wire" }
+                    },
+                    "uuid": "al0"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
+
+        let emitted_ids: std::collections::HashSet<_> = body
+            .variables
+            .iter()
+            .filter_map(|v| v.id.as_deref())
+            .collect();
+        for mv in &body.variable_mode_values {
+            if mv.value.get("type").and_then(|t| t.as_str()) == Some("VARIABLE_ALIAS") {
+                let target = mv.value.get("id").and_then(|v| v.as_str()).unwrap();
+                assert!(
+                    emitted_ids.contains(target),
+                    "dangling VARIABLE_ALIAS to '{target}' with no matching VariableAction"
+                );
+            }
+        }
+        assert!(
+            summary
+                .mode_warnings
+                .iter()
+                .any(|w| w.contains("dangling VARIABLE_ALIAS")),
+            "expected a mode_warnings entry for the dropped alias, got: {:?}",
+            summary.mode_warnings
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`build_export_payload`'s alias-target pre-pass registers a Figma variable id for a
token before knowing whether that token's own processing later bails (malformed or
missing `sets`/`value` — no schema validation runs before export). If another token
aliases the bailed-out one, the export still emitted a `VARIABLE_ALIAS` mode value
pointing at that never-created id, producing a POST payload Figma would reject.

This adds a guard after the main export loop that drops any `VARIABLE_ALIAS` whose
target id isn't present in the emitted `variables` list, and records a
`mode_warnings` entry for each one dropped — turning a hard API rejection into a
graceful, reported skip.

## Related Issue

Closes spectrum-design-data-qz1o (filed from code review of #1400).

## Motivation and Context

Found during code review of #1400 (VARIABLE_ALIAS/mode-warning support): the gap is
latent and not exercised by the existing test suite, since no fixture has a
malformed `sets` object with something aliasing it.

## How Has This Been Tested?

Added `alias_to_malformed_set_target_drops_dangling_reference` in
`sdk/core/src/figma/mapping.rs`, asserting no `VARIABLE_ALIAS` mode value survives
without a matching `VariableAction`, and that a `mode_warnings` entry is recorded.
Ran `moon run sdk:test` (1372 passed, 1 skipped) and `moon run sdk:lint`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
