### PR TITLE
feat(design-data): wire up Typography figma diff coverage

### DIFF
--- a/.changeset/figma-diff-typography-coverage.md
+++ b/.changeset/figma-diff-typography-coverage.md
@@ -1,0 +1,17 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+`figma diff`/`figma pair` now resolve the atomic Typography leaf variables
+instead of reporting them `figma-only` (closes spectrum-design-data-11k.10.3).
+
+- **sdk/core/src/figma/import.rs**: `invert_name` normalizes atomic
+  Typography-collection names (`Font size/100`, `Line height/Font size 100`,
+  `Font weight/Extra bold`, etc.) to their legacy keys, recovering 47 of the
+  177 `figma-only` Typography variables.
+- **sdk/cli/src/main.rs**: `PAIR_NAME_PREFIXES` adds the Typography grouping
+  prefixes (`Heading/`, `Body/`, `Title/`, `Detail/`, `Code/`) so `figma pair`
+  covers them; most report `ambiguous` since design-data models these
+  groupings as composites, not per-field tokens.
+- **sdk/core/tests/fixtures/figma/s2-typography.mapping.json**: new curated
+  mapping for the 5 grouping variables that pair cleanly by value.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1878,17 +1878,26 @@ fn run_figma_diff(
     Ok(ExitCode::SUCCESS)
 }
 
-/// S2.Color-theme name prefixes whose Figma names don't reliably invert to a
-/// legacy key by convention (`Palette/` does; see `invert_name`) — the only
-/// prefixes [`figma::import::pair_by_value`] is asked to cover today.
+/// Name prefixes whose Figma names don't reliably invert to a legacy key by
+/// convention (`Palette/` and the Typography atomic leaves do; see
+/// `invert_name`) — the prefixes [`figma::import::pair_by_value`] is asked
+/// to cover today.
 ///
-/// These are real-file naming conventions observed in the S2.Color-theme
-/// collection, not the exporter's own output — `mapping::COLLECTION_SPECS`
-/// models what `figma export` generates (`colorTheme/`, `platformScale/`)
-/// and has no entry for `Palette/`/`Alias/`/`Icon/`, so there's nothing to
-/// derive this list from automatically. If a new S2.Color-theme prefix group
-/// shows up, add it here by hand.
-const PAIR_NAME_PREFIXES: &[&str] = &["Alias/", "Icon/"];
+/// These are real-file naming conventions observed in specific collections,
+/// not the exporter's own output — `mapping::COLLECTION_SPECS` models what
+/// `figma export` generates (`colorTheme/`, `platformScale/`) and has no
+/// entry for these, so there's nothing to derive this list from
+/// automatically. If a new prefix group shows up, add it here by hand.
+///
+/// `Heading/`/`Body/`/`Title/`/`Detail/`/`Code/` are the Typography
+/// collection's grouping variables: most decompose onto a handful of
+/// shared atomic values already claimed by the Typography leaf variables
+/// (see `normalize_typography_leaf`), so `pair_by_value` is expected to
+/// report the bulk of them `ambiguous` rather than producing candidates —
+/// that's a structural fact about the source data, not a bug in pairing.
+const PAIR_NAME_PREFIXES: &[&str] = &[
+    "Alias/", "Icon/", "Heading/", "Body/", "Title/", "Detail/", "Code/",
+];
 
 fn run_figma_pair(
     file_key: Option<&str>,

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -426,8 +426,9 @@ pub fn diff_values(
 }
 
 /// Invert a Figma variable name back to its legacy token key: the rename
-/// map takes precedence, else strip everything up to and including the
-/// first `/` (the exact reverse of `format!("{prefix}/{token_name}")`).
+/// map takes precedence, else a Typography-leaf-specific rule (see
+/// [`normalize_typography_leaf`]), else strip everything up to and including
+/// the first `/` (the exact reverse of `format!("{prefix}/{token_name}")`).
 ///
 /// A nested Figma name (e.g. `Palette/blue/100`, from a source collection
 /// whose names cascade multiple path segments) leaves further `/`s in the
@@ -437,11 +438,42 @@ fn invert_name(figma_name: &str, renames: Option<&HashMap<String, String>>) -> O
     renames
         .and_then(|m| m.get(figma_name))
         .cloned()
+        .or_else(|| normalize_typography_leaf(figma_name))
         .or_else(|| {
             figma_name
                 .split_once('/')
                 .map(|(_, key)| key.replace('/', "-"))
         })
+}
+
+/// Map an atomic Typography-collection Figma name to its exact design-data
+/// legacy key, for the handful of prefixes whose naming convention diverges
+/// from the generic `{prefix}/{legacyKey}` one `invert_name`'s fallback
+/// assumes. `resolve_alias_key` does exact lookup only (no fuzzy matching),
+/// so this must reproduce the legacy key verbatim.
+///
+/// Only the five atomic leaf prefixes are handled — the Typography
+/// collection's grouping variables (`Heading/…`, `Body/…`, etc.) have no
+/// single design-data token to invert to (design-data models them as
+/// orthogonal composites) and are deliberately left unmatched here.
+fn normalize_typography_leaf(figma_name: &str) -> Option<String> {
+    let slug = |name: &str| name.to_lowercase().replace(' ', "-");
+    if let Some(n) = figma_name.strip_prefix("Font size/") {
+        return Some(format!("font-size-{n}"));
+    }
+    if let Some(n) = figma_name.strip_prefix("Line height/Font size ") {
+        return Some(format!("line-height-font-size-{n}"));
+    }
+    if let Some(name) = figma_name.strip_prefix("Font weight/") {
+        return Some(format!("{}-font-weight", slug(name)));
+    }
+    if let Some(name) = figma_name.strip_prefix("Font style/") {
+        return Some(format!("{}-font-style", slug(name)));
+    }
+    if let Some(name) = figma_name.strip_prefix("Font family/") {
+        return Some(format!("{}-font-family", slug(name)));
+    }
+    None
 }
 
 /// Collapse a variable's per-mode values into one comparable value, only when
@@ -1899,6 +1931,39 @@ mod tests {
         assert_eq!(
             invert_name("colorTheme/blue-100", None),
             Some("blue-100".to_string())
+        );
+    }
+
+    #[test]
+    fn invert_name_normalizes_typography_atomic_leaves() {
+        assert_eq!(
+            invert_name("Font size/100", None),
+            Some("font-size-100".to_string())
+        );
+        assert_eq!(
+            invert_name("Line height/Font size 100", None),
+            Some("line-height-font-size-100".to_string())
+        );
+        assert_eq!(
+            invert_name("Font weight/Extra bold", None),
+            Some("extra-bold-font-weight".to_string())
+        );
+        assert_eq!(
+            invert_name("Font style/Italic", None),
+            Some("italic-font-style".to_string())
+        );
+        assert_eq!(
+            invert_name("Font family/Default", None),
+            Some("default-font-family".to_string())
+        );
+        // No atomic `sans-serif`/`serif` font-family token exists in
+        // design-data (only `default-font-family`) — the rule still
+        // produces the naming-convention-correct key; `resolve_alias_key`
+        // legitimately fails to find it, so this stays `figma_only` rather
+        // than silently mismatching against an unrelated token.
+        assert_eq!(
+            invert_name("Font family/Serif", None),
+            Some("serif-font-family".to_string())
         );
     }
 

--- a/sdk/core/tests/fixtures/figma/s2-typography.mapping.json
+++ b/sdk/core/tests/fixtures/figma/s2-typography.mapping.json
@@ -1,0 +1,9 @@
+{
+  "overrides": {
+    "font-size-1100": "Heading/Size/XXL",
+    "font-size-1300": "Heading/Size/XXXL",
+    "font-size-1500": "Heading/Size/XXXXL",
+    "font-size-700": "Heading/Size/L",
+    "font-size-900": "Heading/Size/XL"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wires up `figma diff`/`figma pair` coverage for the Typography collection's
atomic leaf variables (`Font size/`, `Line height/`, `Font weight/`,
`Font family/`, `Font style/`), plus curates the 5 grouping variables that
pair cleanly by value.

Note on scope: the bead asked to wire Typography into `build_export_payload`
(`mapping.rs`), but that path only feeds the `design_data_only` side of the
diff and cannot move `figma_only` — that metric comes from `import.rs`'s
figma-driven walk (`invert_name` → `resolve_alias_key`), the same place
sibling bead 11k.10.2 (#1404) actually landed S2.Color-theme coverage. This
PR follows that precedent instead of the literal `mapping.rs` pointer;
`COLLECTION_SPECS`/`build_export_payload` are untouched.

- **sdk/core/src/figma/import.rs**: new `normalize_typography_leaf` helper,
  consulted from `invert_name`, maps the five atomic Typography Figma-name
  conventions to their exact design-data legacy keys.
- **sdk/cli/src/main.rs**: `PAIR_NAME_PREFIXES` adds the Typography grouping
  prefixes (`Heading/`, `Body/`, `Title/`, `Detail/`, `Code/`) so `figma pair`
  covers them.
- **sdk/core/tests/fixtures/figma/s2-typography.mapping.json**: new curated
  `--mapping` override for the 5 grouping variables (`Heading/Size/*`) that
  `figma pair` resolves without ambiguity.

Of the 177 Typography `figma_only` variables, 45 are true atomic leaves + 2
`Font family/` names (`Sans serif`/`Serif`) with no atomic design-data
equivalent (only `default-font-family` exists) — those 2 stay `figma_only`,
as expected. The remaining 130 are grouping variables keyed by
`(text-type × script × emphasis × field)`; design-data models typography
as composite tokens on an orthogonal axis instead
(`component-{xs…xl}-{regular|medium|bold}`, still `SKIP_SCHEMAS` — out of
scope here). Running `figma pair` confirms 125 of those report `ambiguous`
(collapsing onto shared atomic values already claimed), and 1 is
`unmatched`; only 5 pair cleanly. Filed
[spectrum-design-data-11k.10.7](../../issues) as a follow-up requiring a
composite-decomposition design.

## Related Issue

Closes spectrum-design-data-11k.10.3. Follow-up: spectrum-design-data-11k.10.7.

## Motivation and Context

Third increment of the Figma export/diff coverage work (after 11k.10.1's
collection-routing generalization and 11k.10.2/11k.10.6's S2.Color-theme
wiring). Reduces the still-large `figma_only` bucket in the S2 Web Figma
diff baseline so the diff is a more useful signal of real drift.

## How Has This Been Tested?

- Added unit tests for `invert_name`/`normalize_typography_leaf` covering
  each of the five atomic prefixes plus a deliberately-unresolvable
  `Font family/Serif` case (`cargo test -p design-data-core --features figma`).
- Ran `figma diff --snapshot sdk/core/tests/fixtures/figma/s2-web-variables.baseline.json --format json`
  before/after:
  - Before: `matched 845 / value_mismatch 13 / figma_only 1633 / design_data_only 410 / skipped_uncovered 460`
  - After: `matched 891 / value_mismatch 14 / figma_only 1586 / design_data_only 410 / skipped_uncovered 460`
  - `figma_only` drops by **47** (46 now match, 1 surfaces a genuine
    design-data/Figma value discrepancy at `line-height-font-size-900`
    — 50px vs 42px — left as-is, out of scope to fix here).
- Ran `figma pair --snapshot … --format json` to confirm the grouping split
  (326 candidates total incl. existing S2.Color-theme prefixes / 130
  ambiguous+unmatched for Typography groupings / 5 clean Typography
  candidates), then verified the curated mapping fixture:
  `figma diff … --mapping s2-typography.mapping.json` → `figma_only` drops a
  further 5 (to 1581), `renamed: 5`.
- `cargo test -p design-data-core --features figma`, `cargo test -p design-data-cli`,
  `moon run sdk:test` (1385/1385 passed), `moon run sdk:lint` (clean).
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
