### PR TITLE
feat(design-data): recover Typography grouping variables via CTR resolution

### DIFF
--- a/.changeset/figma-diff-typography-grouping-coverage.md
+++ b/.changeset/figma-diff-typography-grouping-coverage.md
@@ -1,0 +1,19 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+`figma diff` now resolves Typography grouping variables against their
+Component/Token Relationship (CTR) targets instead of reporting them
+`figma-only` (closes spectrum-design-data-11k.10.7).
+
+- **sdk/core/src/figma/import.rs**: `invert_name` normalizes the Typography
+  grouping prefixes (`Heading/`, `Body/`, `Title/`, `Detail/`, `Code/`) to
+  their CTR `legacyKey`, recovering 129 of the remaining 130 `figma-only`
+  Typography variables.
+- **sdk/core/src/graph.rs**: new `TokenGraph::resolve_relationship_ref`
+  follows a CTR's `$ref` to its target token, as a fallback when
+  `resolve_alias_key` finds no direct token match.
+- **sdk/cli/src/main.rs**: `figma diff`'s graph now loads
+  `packages/design-data/relationships` so CTRs are available to resolve
+  against, also recovering non-Typography CTR-backed variables previously
+  reported `figma-only`.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1814,6 +1814,12 @@ fn load_figma_diff_inputs(
             resolved.tokens_root.display()
         )
     })?;
+    if let Some(dir) = resolved.relationships.as_deref() {
+        let rels = TokenGraph::load_spec_relationships(dir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to load relationships from {}", dir.display()))?;
+        graph = graph.with_relationships(rels);
+    }
     manifest::apply_configured(&mut graph, &resolved)
         .into_diagnostic()
         .wrap_err("failed to apply platform manifest cascade")?;

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -308,7 +308,10 @@ pub fn diff_values(
             });
             continue;
         };
-        let Some(record) = graph.resolve_alias_key(&legacy_key) else {
+        let Some(record) = graph
+            .resolve_alias_key(&legacy_key)
+            .or_else(|| graph.resolve_relationship_ref(&legacy_key))
+        else {
             counts.figma_only += 1;
             entries.push(DiffEntry {
                 name: variable.name.clone(),
@@ -427,8 +430,10 @@ pub fn diff_values(
 
 /// Invert a Figma variable name back to its legacy token key: the rename
 /// map takes precedence, else a Typography-leaf-specific rule (see
-/// [`normalize_typography_leaf`]), else strip everything up to and including
-/// the first `/` (the exact reverse of `format!("{prefix}/{token_name}")`).
+/// [`normalize_typography_leaf`]), else a Typography-grouping rule (see
+/// [`normalize_typography_grouping`]), else strip everything up to and
+/// including the first `/` (the exact reverse of
+/// `format!("{prefix}/{token_name}")`).
 ///
 /// A nested Figma name (e.g. `Palette/blue/100`, from a source collection
 /// whose names cascade multiple path segments) leaves further `/`s in the
@@ -439,6 +444,7 @@ fn invert_name(figma_name: &str, renames: Option<&HashMap<String, String>>) -> O
         .and_then(|m| m.get(figma_name))
         .cloned()
         .or_else(|| normalize_typography_leaf(figma_name))
+        .or_else(|| normalize_typography_grouping(figma_name))
         .or_else(|| {
             figma_name
                 .split_once('/')
@@ -452,10 +458,10 @@ fn invert_name(figma_name: &str, renames: Option<&HashMap<String, String>>) -> O
 /// assumes. `resolve_alias_key` does exact lookup only (no fuzzy matching),
 /// so this must reproduce the legacy key verbatim.
 ///
-/// Only the five atomic leaf prefixes are handled — the Typography
-/// collection's grouping variables (`Heading/…`, `Body/…`, etc.) have no
-/// single design-data token to invert to (design-data models them as
-/// orthogonal composites) and are deliberately left unmatched here.
+/// Only the five atomic leaf prefixes are handled here — the Typography
+/// collection's grouping variables (`Heading/…`, `Body/…`, etc.) invert via
+/// [`normalize_typography_grouping`] instead, to their Component/Token
+/// Relationship (CTR) `legacyKey` in `packages/design-data/relationships/`.
 fn normalize_typography_leaf(figma_name: &str) -> Option<String> {
     let slug = |name: &str| name.to_lowercase().replace(' ', "-");
     if let Some(n) = figma_name.strip_prefix("Font size/") {
@@ -472,6 +478,22 @@ fn normalize_typography_leaf(figma_name: &str) -> Option<String> {
     }
     if let Some(name) = figma_name.strip_prefix("Font family/") {
         return Some(format!("{}-font-family", slug(name)));
+    }
+    None
+}
+
+/// Map a Typography-grouping Figma name (`Heading/…`, `Body/…`, `Title/…`,
+/// `Detail/…`, `Code/…`) to its Component/Token Relationship (CTR)
+/// `legacyKey` in `packages/design-data/relationships/*.json`, resolved by
+/// [`crate::graph::TokenGraph::resolve_relationship_ref`]. Every grouping
+/// shape (`{Type}/{Script}/[Strong/][Emphasized/]{Field}`,
+/// `{Type}/[Emphasized/]{Field}`, `{Type}/Size/{Tier}`) reduces to the same
+/// slug transform — verified against all 130 grouping variables in the
+/// Typography collection.
+fn normalize_typography_grouping(figma_name: &str) -> Option<String> {
+    const PREFIXES: [&str; 5] = ["Heading/", "Body/", "Title/", "Detail/", "Code/"];
+    if PREFIXES.iter().any(|p| figma_name.starts_with(p)) {
+        return Some(figma_name.to_lowercase().replace(['/', ' '], "-"));
     }
     None
 }
@@ -1964,6 +1986,33 @@ mod tests {
         assert_eq!(
             invert_name("Font family/Serif", None),
             Some("serif-font-family".to_string())
+        );
+    }
+
+    #[test]
+    fn invert_name_normalizes_typography_groupings() {
+        assert_eq!(
+            invert_name("Body/Sans serif/Emphasized/Font weight", None),
+            Some("body-sans-serif-emphasized-font-weight".to_string())
+        );
+        assert_eq!(
+            invert_name("Body/Sans serif/Strong/Emphasized/Font style", None),
+            Some("body-sans-serif-strong-emphasized-font-style".to_string())
+        );
+        assert_eq!(
+            invert_name("Detail/Serif/Strong/Font style", None),
+            Some("detail-serif-strong-font-style".to_string())
+        );
+        // The lone grouping without a `$ref` CTR target (an inline value) —
+        // still inverts to the correct legacy key; `resolve_relationship_ref`
+        // is the one that (correctly) can't resolve it further.
+        assert_eq!(
+            invert_name("Code/Font family", None),
+            Some("code-font-family".to_string())
+        );
+        assert_eq!(
+            invert_name("Heading/Size/XXXXL", None),
+            Some("heading-size-xxxxl".to_string())
         );
     }
 

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1543,6 +1543,22 @@ impl TokenGraph {
         })
     }
 
+    /// Resolve a Component/Token Relationship (CTR) `legacyKey` to the token
+    /// its `$ref` points at, for callers that already tried
+    /// [`Self::resolve_alias_key`] (token-side) and came up empty.
+    ///
+    /// Returns `None` when no CTR has that `legacyKey`, or when it carries an
+    /// inline `value` instead of a `$ref` (e.g. `code-font-family`) — inline
+    /// CTR values aren't compared today.
+    pub fn resolve_relationship_ref<'a>(&'a self, legacy_key: &str) -> Option<&'a TokenRecord> {
+        let rec = self
+            .relationships
+            .iter()
+            .find(|r| r.raw.get("legacyKey").and_then(|v| v.as_str()) == Some(legacy_key))?;
+        let target = rec.raw.get("$ref").and_then(|v| v.as_str())?;
+        self.resolve_alias_key(target)
+    }
+
     /// Resolve a set-level UUID to the context-appropriate child record.
     ///
     /// Picks the child from `set_uuid_index` whose name-object fields best match
@@ -2208,6 +2224,49 @@ mod tests {
         let alias_rec = g.tokens.get(&alias_key).unwrap();
         let resolved = alias_rec.resolve_leaf(&g);
         assert_eq!(resolved.raw["value"], "rgb(0,0,255)");
+    }
+
+    #[test]
+    fn resolve_relationship_ref_follows_ctr_ref_to_token() {
+        // A leaf token plus a CTR (Component/Token Relationship) whose $ref
+        // points at it by UUID, keyed by legacyKey the way
+        // packages/design-data/relationships/*.json entries are.
+        let uuid = "cccccccc-0000-0000-0000-000000000001";
+        let g = cascade_graph_from(json!([{
+            "name": { "property": "font-weight", "value": "regular" },
+            "$schema": "https://example.com/font-weight.json",
+            "value": "regular",
+            "uuid": uuid
+        }]))
+        .with_relationships(vec![RelationshipRecord {
+            file: PathBuf::from("relationships/body.json"),
+            index: 0,
+            uuid: Some("dddddddd-0000-0000-0000-000000000001".to_string()),
+            raw: json!({
+                "legacyKey": "body-sans-serif-emphasized-font-weight",
+                "$ref": uuid
+            }),
+        }]);
+
+        let rec = g
+            .resolve_relationship_ref("body-sans-serif-emphasized-font-weight")
+            .expect("CTR $ref lookup must succeed");
+        assert_eq!(rec.raw["value"], "regular");
+
+        // Unknown legacyKey and a $ref-less (inline-value) CTR both miss.
+        assert!(g.resolve_relationship_ref("no-such-key").is_none());
+        let g_inline = g.with_relationships(vec![RelationshipRecord {
+            file: PathBuf::from("relationships/code.json"),
+            index: 0,
+            uuid: Some("dddddddd-0000-0000-0000-000000000002".to_string()),
+            raw: json!({
+                "legacyKey": "code-font-family",
+                "value": "Source Code Pro"
+            }),
+        }]);
+        assert!(g_inline
+            .resolve_relationship_ref("code-font-family")
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow-up to #1407, which recovered the 47 atomic Typography leaf `figma-only` variables.
This closes the remaining ~130 Typography **grouping** variables (`Body/Sans serif/Emphasized/Font
weight`, `Heading/Size/L`, `Code/Font family`, …).

The bead that filed this framed it as a composite-decomposition / export-side modeling project,
premised on design-data having no target for these groupings at all (only orthogonal
`component-{size}-{weight}` composites). That premise doesn't hold: design-data models each
grouping as a **Component/Token Relationship (CTR)** entry in
`packages/design-data/relationships/{body,heading,title,detail,code}.json`. Every one of the 130
grouping names maps 1:1 to a CTR `legacyKey` via a simple slug transform
(`name.lower().replace('/','-').replace(' ','-')`); 129/130 CTRs carry a `$ref` to an atomic
`typography.tokens.json` token, 1 (`code-font-family`) carries an inline value.

The diff missed them for two independent reasons, both fixed here — no export-side change, no
un-skipping the `component-*` composites (they correctly stay non-exportable):

1. `invert_name` had no rule for the grouping prefixes (`Heading/`, `Body/`, `Title/`, `Detail/`,
   `Code/`), so it fell through to a generic fallback that produced the wrong key.
2. Even with the right key, `resolve_alias_key` only searches tokens, never CTRs — and
   `graph.relationships` was never loaded into the `figma diff` graph at all.

## Related Issue

Closes spectrum-design-data-11k.10.7. Related to initiatives **DNA-1520** (multi-platform
improvements / governance) and **DNA-1796**.

## Motivation and Context

`figma diff` is meant to be the ground truth for Figma↔design-data drift. 130 Typography
variables silently reporting `figma-only` — despite having an exact design-data target — hid real
signal (agreement or drift) behind a name-resolution/wiring gap rather than a genuine modeling gap.

## How Has This Been Tested?

- `cargo test -p design-data-core --features figma` — full suite green (792 unit + 10
  integration + 5 doctest), including two new tests: `invert_name_normalizes_typography_groupings`
  and `resolve_relationship_ref_follows_ctr_ref_to_token`.
- `moon run sdk:test` — 1387 passed, 1 skipped (pre-existing).
- `moon run sdk:lint` — clean.
- Empirical before/after run of `figma diff --snapshot sdk/core/tests/fixtures/figma/s2-web-variables.baseline.json`:

  | | before | after |
  |---|---|---|
  | `figma_only` | 1586 | 1123 |
  | `matched` | 891 | 1344 |
  | `value_mismatch` | 14 | 15 |
  | `design_data_only` | 410 | 410 (unchanged) |
  | `skipped_uncovered` | 460 | 469 |

  463 variables recovered total: **129/130** Typography groupings (the 1 remaining is the
  inline-value `code-font-family` CTR, documented as a residual below), plus 334 CTR-backed
  variables in other collections (`Component/*`, `colorTheme/*`) that hit the identical
  relationships-not-loaded gap and are recovered as a side effect of loading
  `packages/design-data/relationships` into the diff graph. Spot-checked several of the
  non-Typography recoveries against their source CTR files to confirm they're genuine matches,
  not false positives from key collisions. `design_data_only` is unchanged (no regressions on
  that axis); the `value_mismatch`/`skipped_uncovered` deltas are exactly the newly-reachable
  cases correctly falling into those buckets rather than `figma-only`.

**Residual**: `Code/Font family` (`code-font-family`) is the one grouping whose CTR carries an
inline `value` instead of a `$ref`; `resolve_relationship_ref` intentionally returns `None` for
it rather than adding a second, parallel raw-value comparison path for a single token. It stays
`figma-only` — flagging here rather than silently leaving it unexplained.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
