### PR TITLE
feat(design-data): resolve figma-only variables through alias targets

### DIFF
--- a/.changeset/figma-diff-layout-alias-resolution.md
+++ b/.changeset/figma-diff-layout-alias-resolution.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+`figma diff` now resolves variables whose own name can't invert to a legacy
+key but which are themselves a Figma alias into a resolvable variable,
+recovering the `Layout` collection and more of `S2.Color-theme` (closes
+spectrum-design-data-11k.10.4).
+
+- **sdk/core/src/figma/import.rs**: new `resolve_alias_target` fallback in
+  `diff_values` follows a `VARIABLE_ALIAS` to its target and inverts the
+  target's name when the variable's own name doesn't resolve, turning ~586
+  `figma-only` variables into `match`/`value-mismatch` (all 329 `Layout`
+  variables, plus previously-uncovered `S2.Color-theme`/`.Platform
+  scale`/`Iconography` variables) without a per-collection override table.

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -312,7 +312,7 @@ pub fn diff_values(
             .resolve_alias_key(&legacy_key)
             .or_else(|| graph.resolve_relationship_ref(&legacy_key))
             .map(|record| (legacy_key.clone(), record))
-            .or_else(|| resolve_alias_target(variable, meta, graph))
+            .or_else(|| resolve_alias_target(variable, meta, graph, reversed.as_ref()))
         else {
             counts.figma_only += 1;
             entries.push(DiffEntry {
@@ -466,18 +466,29 @@ fn invert_name(figma_name: &str, renames: Option<&HashMap<String, String>>) -> O
 /// regress an existing one. Follows a single alias hop — every case observed
 /// against the S2 baseline aliases directly to a resolvable target.
 /// ponytail: one hop, not a chain walk; extend if a deeper chain ever appears.
+///
+/// Reads the variable's value from its collection's `default_mode_id` — the
+/// same mode `resolve_figma_value` reads for an alias target — rather than an
+/// arbitrary `HashMap` entry, since a multi-mode variable's iteration order
+/// isn't guaranteed to land on the mode that actually holds the alias.
+/// `renames` is the same reversed name-mapping `diff_values` threads into its
+/// own direct `invert_name` call, applied here to the alias target's name.
 fn resolve_alias_target<'a>(
     variable: &FigmaVariable,
     meta: &VariablesMeta,
     graph: &'a TokenGraph,
+    renames: Option<&HashMap<String, String>>,
 ) -> Option<(String, &'a crate::graph::TokenRecord)> {
-    let value = variable.values_by_mode.values().next()?;
+    let collection = meta
+        .variable_collections
+        .get(&variable.variable_collection_id)?;
+    let value = variable.values_by_mode.get(&collection.default_mode_id)?;
     if !is_alias(value) {
         return None;
     }
     let target_id = value.get("id").and_then(Value::as_str)?;
     let target_name = &meta.variables.get(target_id)?.name;
-    let key = invert_name(target_name, None)?;
+    let key = invert_name(target_name, renames)?;
     let record = graph
         .resolve_alias_key(&key)
         .or_else(|| graph.resolve_relationship_ref(&key))?;
@@ -2194,6 +2205,58 @@ mod tests {
         // Both the alias and its (also-unresolvable) target end up figma_only.
         assert_eq!(report.counts.figma_only, 2);
         assert_eq!(report.counts.matched, 0);
+    }
+
+    #[test]
+    fn diff_values_resolves_alias_target_via_supplied_renames() {
+        // The alias target's own Figma name ("PlatformScaleOddName") has no
+        // '/' at all, so invert_name's generic fallback can't invert it on
+        // its own — it only resolves through a `--mapping` override, exactly
+        // like diff_values' own direct-name resolution already supports.
+        // Regression test: resolve_alias_target must thread `reversed`
+        // through to its `invert_name` call, not just try `None`.
+        let target = mock_variable(
+            "PlatformScaleOddName",
+            "FLOAT",
+            vec![("m-modeless", json!(400.0))],
+        );
+        let alias = mock_variable(
+            "Standard dialog/Maximum width/Small",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": target.id.clone()}),
+            )],
+        );
+        let meta = mock_meta_modeless(vec![target, alias]);
+        let graph = mock_graph_with_schema(
+            "standard-dialog-maximum-width-small",
+            "u-sdmws",
+            json!("400px"),
+            "https://example.com/dimension.json",
+        );
+        let mapping: HashMap<String, String> = [(
+            "standard-dialog-maximum-width-small".to_string(),
+            "PlatformScaleOddName".to_string(),
+        )]
+        .into_iter()
+        .collect();
+
+        let report = diff_values(&meta, &graph, &[], Some(&mapping)).unwrap();
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "Standard dialog/Maximum width/Small")
+            .unwrap();
+        assert!(
+            matches!(entry.class, DiffClass::Match),
+            "expected Match, got {:?}",
+            entry.class
+        );
+        assert_eq!(
+            entry.legacy_key.as_deref(),
+            Some("standard-dialog-maximum-width-small")
+        );
     }
 
     /// End-to-end check: an emitted override must satisfy

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -308,9 +308,11 @@ pub fn diff_values(
             });
             continue;
         };
-        let Some(record) = graph
+        let Some((legacy_key, record)) = graph
             .resolve_alias_key(&legacy_key)
             .or_else(|| graph.resolve_relationship_ref(&legacy_key))
+            .map(|record| (legacy_key.clone(), record))
+            .or_else(|| resolve_alias_target(variable, meta, graph))
         else {
             counts.figma_only += 1;
             entries.push(DiffEntry {
@@ -450,6 +452,36 @@ fn invert_name(figma_name: &str, renames: Option<&HashMap<String, String>>) -> O
                 .split_once('/')
                 .map(|(_, key)| key.replace('/', "-"))
         })
+}
+
+/// Resolve a Figma variable that is itself a `VARIABLE_ALIAS` through to the
+/// design-data record its *alias target* maps to. Some collections (Layout,
+/// for one) model every variable as a semantic alias into `.Platform scale`
+/// (e.g. `Alert dialog/Maximum width` -> `platformScale/alert-dialog-maximum-width`)
+/// — the variable's own hierarchical name never inverts to a real legacy key,
+/// but its target's name does via the ordinary [`invert_name`] rules.
+///
+/// Fallback only: callers try direct name inversion first, so this can only
+/// turn a would-be `figma_only` variable into a match/value-mismatch, never
+/// regress an existing one. Follows a single alias hop — every case observed
+/// against the S2 baseline aliases directly to a resolvable target.
+/// ponytail: one hop, not a chain walk; extend if a deeper chain ever appears.
+fn resolve_alias_target<'a>(
+    variable: &FigmaVariable,
+    meta: &VariablesMeta,
+    graph: &'a TokenGraph,
+) -> Option<(String, &'a crate::graph::TokenRecord)> {
+    let value = variable.values_by_mode.values().next()?;
+    if !is_alias(value) {
+        return None;
+    }
+    let target_id = value.get("id").and_then(Value::as_str)?;
+    let target_name = &meta.variables.get(target_id)?.name;
+    let key = invert_name(target_name, None)?;
+    let record = graph
+        .resolve_alias_key(&key)
+        .or_else(|| graph.resolve_relationship_ref(&key))?;
+    Some((key, record))
 }
 
 /// Map an atomic Typography-collection Figma name to its exact design-data
@@ -2085,6 +2117,83 @@ mod tests {
             summary.unchanged, 1,
             "nested Palette name must resolve to the known key, not fall through as unresolved"
         );
+    }
+
+    #[test]
+    fn diff_values_resolves_alias_through_target_name() {
+        // "Standard dialog/Maximum width/Small" doesn't invert to any known
+        // legacy key (design-data has no such token), but it's a Figma
+        // VARIABLE_ALIAS into "platformScale/standard-dialog-maximum-width-small",
+        // which does. Mirrors the real Layout-collection shape: 329 variables
+        // that are all semantic aliases into `.Platform scale`.
+        let target = mock_variable(
+            "platformScale/standard-dialog-maximum-width-small",
+            "FLOAT",
+            vec![("m-modeless", json!(400.0))],
+        );
+        let alias = mock_variable(
+            "Standard dialog/Maximum width/Small",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": target.id.clone()}),
+            )],
+        );
+        let meta = mock_meta_modeless(vec![target, alias]);
+        let graph = mock_graph_with_schema(
+            "standard-dialog-maximum-width-small",
+            "u-sdmws",
+            json!("400px"),
+            "https://example.com/dimension.json",
+        );
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        // Both the alias and the target it points at are diffed as their own
+        // Figma variables (the target's own name also inverts cleanly here) —
+        // matched == 2, not 1.
+        assert_eq!(report.counts.matched, 2);
+        assert_eq!(report.counts.figma_only, 0);
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "Standard dialog/Maximum width/Small")
+            .unwrap();
+        assert_eq!(
+            entry.legacy_key.as_deref(),
+            Some("standard-dialog-maximum-width-small"),
+            "reported key should be the alias target's, not the unresolvable own name"
+        );
+    }
+
+    #[test]
+    fn diff_values_alias_with_unresolvable_target_stays_figma_only() {
+        // Same shape, but the target's own inverted name isn't a known
+        // design-data key either — the fallback must not invent a match.
+        let target = mock_variable(
+            "platformScale/totally-unknown-dimension",
+            "FLOAT",
+            vec![("m-modeless", json!(400.0))],
+        );
+        let alias = mock_variable(
+            "Standard dialog/Maximum width/Small",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": target.id.clone()}),
+            )],
+        );
+        let meta = mock_meta_modeless(vec![target, alias]);
+        let graph = mock_graph_with_schema(
+            "standard-dialog-maximum-width-small",
+            "u-sdmws",
+            json!("400px"),
+            "https://example.com/dimension.json",
+        );
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        // Both the alias and its (also-unresolvable) target end up figma_only.
+        assert_eq!(report.counts.figma_only, 2);
+        assert_eq!(report.counts.matched, 0);
     }
 
     /// End-to-end check: an emitted override must satisfy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`figma diff` classed all 329 `Layout`-collection variables as `figma-only`. The
bead assumed this would need a `normalize_layout_*` name rule plus a heavy
`overrides: HashMap<legacy_key, figma_name>` table, because Layout names are
deeply hierarchical (`Standard dialog/Maximum width/Small`) and don't fit the
flat `{prefix}/{legacy-key}` scheme `invert_name`'s generic fallback assumes.

Investigation against the real S2 baseline snapshot found a simpler,
structurally different root cause: **every Layout variable is itself a Figma
`VARIABLE_ALIAS` into `.Platform scale`** (e.g. `Alert dialog/Maximum width` →
`platformScale/alert-dialog-maximum-width`). The value path already resolves
these aliases to concrete floats — the only thing classing them `figma-only`
is that `invert_name`'s generic fallback inverts the variable's *own* deeply
hierarchical name, which never matches a design-data key.

This PR adds `resolve_alias_target`, a fallback in `diff_values`: when a
variable's own name doesn't resolve, follow its `VARIABLE_ALIAS` to the target
and invert *that* name instead (reusing the existing `invert_name` /
`resolve_alias_key` / `resolve_relationship_ref` chain — no new naming rules,
no override table). This is correct by construction for the density-qualified
cases that a pure kebab-case of the Layout name gets wrong (e.g.
`Group/Gap/Medium/Regular` aliases `group-gap-medium`, not
`group-gap-medium-regular`).

Scope: kept general rather than gated to the `Layout` collection (per
discussion) — it only fires on the existing figma-only path, so it's strictly
additive and can't regress an existing match.

## Related Issue

Closes bead `spectrum-design-data-11k.10.4` ("figma export: wire up Layout
collection").

## Motivation and Context

Part of the ongoing effort (11k epic) to close the gap between design-data
tokens and the S2 Figma Variables file so `figma diff`/`figma pair` give a
trustworthy signal of drift. Layout was the largest remaining figma-only
chunk (329 vars).

## How Has This Been Tested?

- Two new unit tests in `sdk/core/src/figma/import.rs`:
  `diff_values_resolves_alias_through_target_name` (alias resolves via
  target) and `diff_values_alias_with_unresolvable_target_stays_figma_only`
  (fallback doesn't invent a match when the target is also unresolvable).
- `cargo test -p design-data-core --features figma` — 794 tests pass.
- `moon run sdk:test` (full workspace, 1389 tests) and `moon run sdk:lint`
  (clippy `-D warnings`) both pass.
- **Empirical before/after** against the real CLI, the only trustworthy
  signal per the bead's own note:
  ```
  design-data figma diff --snapshot core/tests/fixtures/figma/s2-web-variables.baseline.json --format json
  ```
  - Before: `matched 1343 · value_mismatch 16 · figma_only 1123 · design_data_only 410`
  - After: `matched 1916 · value_mismatch 29 · figma_only 537 · design_data_only 410`
  - `Layout` collection specifically: 174 → match, 10 → value-mismatch
    (pre-existing drop-shadow X/Y drift inherited from `.Platform scale`), 145
    stay `figma-only` because their alias target itself has no design-data
    token (see follow-up below).
  - Verified zero regressions: no variable that was previously `match` (or
    any non-figma-only class) became `figma-only`.
  - The larger-than-`Layout`-alone drop (586 total, not ~329) is legitimate:
    the same fallback also recovers previously-uncovered `S2.Color-theme`
    (355), `.Platform scale` (33), and `Iconography` (14) variables that were
    aliases with the identical shape.

## Screenshots (if appropriate):

N/A (CLI/library change, no UI).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Follow-ups filed under the 11k epic

- 145 `Layout` variables stay `figma-only`: their `.Platform scale` alias
  target has no design-data token at all. This overlaps the existing 360
  `.Platform scale`-native `figma-only` gap and is real, documented drift —
  not something to force-fix in this PR.

initiative:DNA-1520, initiative:DNA-1796
