### PR TITLE
feat(design-data): resolve inline-value CTRs for .Platform scale component tokens

### DIFF
--- a/.changeset/figma-diff-inline-ctr-resolution.md
+++ b/.changeset/figma-diff-inline-ctr-resolution.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+`figma diff`/`figma import` now resolve Component/Token Relationship (CTR)
+entries that carry their value inline instead of a `$ref`, recovering 438
+`.Platform scale` variables previously reported `figma-only` for lacking a
+design-data token (closes spectrum-design-data-11k.10.8).
+
+- **sdk/core/src/graph.rs**: `resolve_relationship_ref` now falls back to a
+  new `relationship_tokens` index of inline-value CTRs (dimension,
+  multiplier, gradient-stop schemas), preferring the `scale: "desktop"`
+  entry when a scale-set CTR shares one `legacyKey` across scales. Inline
+  `font-family` CTRs (e.g. `code-font-family`) still don't resolve — no
+  schema-driven comparison rule exists for them.

--- a/.changeset/figma-diff-inline-ctr-resolution.md
+++ b/.changeset/figma-diff-inline-ctr-resolution.md
@@ -7,9 +7,13 @@ entries that carry their value inline instead of a `$ref`, recovering 438
 `.Platform scale` variables previously reported `figma-only` for lacking a
 design-data token (closes spectrum-design-data-11k.10.8).
 
-- **sdk/core/src/graph.rs**: `resolve_relationship_ref` now falls back to a
-  new `relationship_tokens` index of inline-value CTRs (dimension,
-  multiplier, gradient-stop schemas), preferring the `scale: "desktop"`
-  entry when a scale-set CTR shares one `legacyKey` across scales. Inline
-  `font-family` CTRs (e.g. `code-font-family`) still don't resolve — no
-  schema-driven comparison rule exists for them.
+- **sdk/core/src/graph.rs**: `resolve_relationship_ref` falls back to a new
+  `relationship_tokens` index of inline-value CTRs (dimension, multiplier,
+  gradient-stop). Scale-set CTRs carry all scale values along, so per-mode
+  diffs align to Figma's own mode rather than a hardcoded scale. Inline
+  `font-family` CTRs still don't resolve — no comparison rule for them.
+- **sdk/core/src/figma/import.rs**: `scale_aligned_source_value` reads the
+  new per-scale values directly, since CTR scale-sets never enter
+  `set_uuid_index`.
+- **sdk/core/src/validate/mod.rs**: reindexes `relationship_tokens` after
+  loading a `relationships_path` catalog.

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -97,6 +97,9 @@ fn scale_aligned_source_value(
     leaf: &crate::graph::TokenRecord,
 ) -> Option<Value> {
     let scale_source_value = figma_mode_scale(variable, meta).and_then(|scale| {
+        if let Some(values) = leaf.raw.get("ctrScaleValues").and_then(Value::as_object) {
+            return values.get(&scale).cloned();
+        }
         let set_uuid = leaf.raw.get("set_uuid").and_then(Value::as_str)?;
         let ctx = HashMap::from([("scale".to_string(), scale.clone())]);
         let candidate = graph.resolve_set_in_context(set_uuid, &ctx)?;
@@ -1889,6 +1892,60 @@ mod tests {
             }
             other => panic!("expected ValueMismatch, got {other:?}"),
         }
+    }
+
+    /// Same false-positive-fix scenario as `scale_set_aligns_to_figmas_captured_mode`,
+    /// but sourced from a CTR-only scale-set (inline `value`, `setUuid`, no
+    /// standalone `tokens/*.tokens.json` entry — avatar-size-100's real shape)
+    /// instead of a cascade token. Regression test for the bug where
+    /// `reindex_relationship_tokens` cloned the CTR's raw as-is: since CTRs
+    /// never enter `set_uuid_index` and use `scope.options.scale` (not
+    /// `name.scale`), scale alignment silently fell back to the hardcoded
+    /// desktop value for every mode, including mobile.
+    #[test]
+    fn ctr_scale_set_aligns_to_figmas_captured_mode() {
+        use crate::graph::RelationshipRecord;
+
+        let var = mock_variable(
+            "platformScale/avatar-size-100",
+            "FLOAT",
+            vec![("m-mobile", json!(28.0))],
+        );
+        let meta = mock_meta_with_single_mode(var, "Mobile", "m-mobile");
+        let graph = TokenGraph::default().with_relationships(vec![
+            RelationshipRecord {
+                file: PathBuf::from("relationships/avatar.json"),
+                index: 0,
+                uuid: Some("dddddddd-0000-0000-0000-000000000001".to_string()),
+                raw: json!({
+                    "scope": {"component": "avatar", "property": "size", "options": {"scale": "desktop", "scaleIndex": 100}},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "value": "24px",
+                    "uuid": "dddddddd-0000-0000-0000-000000000001",
+                    "legacyKey": "avatar-size-100",
+                    "setUuid": "su-avatar-size-100",
+                    "setSchema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/avatar.json"),
+                index: 1,
+                uuid: Some("dddddddd-0000-0000-0000-000000000002".to_string()),
+                raw: json!({
+                    "scope": {"component": "avatar", "property": "size", "options": {"scale": "mobile", "scaleIndex": 100}},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "value": "28px",
+                    "uuid": "dddddddd-0000-0000-0000-000000000002",
+                    "legacyKey": "avatar-size-100",
+                    "setUuid": "su-avatar-size-100",
+                    "setSchema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+                }),
+            },
+        ]);
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
     }
 
     #[test]

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -153,6 +153,11 @@ pub struct TokenGraph {
     /// Component/Token Relationship (CTR) entries from the spec `relationships/`
     /// catalog, flattened from each file's top-level array.
     pub relationships: Vec<RelationshipRecord>,
+    /// Cache: CTR `legacyKey` → synthetic leaf [`TokenRecord`] for inline-value
+    /// CTRs (no `$ref`, e.g. `avatar-size-100`'s dimension value lives directly
+    /// on the relationship). Rebuilt by [`Self::reindex_relationship_tokens`]
+    /// whenever `relationships` changes; see [`Self::resolve_relationship_ref`].
+    relationship_tokens: HashMap<String, TokenRecord>,
     /// Platform manifest from `manifest.json` in the tokens root, if present.
     pub manifest: serde_json::Value,
     /// Secondary index: UUID value → primary key in `tokens`.
@@ -572,6 +577,7 @@ impl TokenGraph {
             guidelines: Vec::new(),
             fields: Vec::new(),
             relationships: Vec::new(),
+            relationship_tokens: HashMap::new(),
             manifest: serde_json::Value::Null,
             uuid_index,
             legacy_name_index,
@@ -622,6 +628,7 @@ impl TokenGraph {
             guidelines: Vec::new(),
             fields: Vec::new(),
             relationships: Vec::new(),
+            relationship_tokens: HashMap::new(),
             manifest: serde_json::Value::Null,
             uuid_index,
             legacy_name_index,
@@ -1132,6 +1139,8 @@ impl TokenGraph {
             }
         }
 
+        self.reindex_relationship_tokens();
+
         Ok(PlatformManifest {
             mode_set_restrictions,
         })
@@ -1362,7 +1371,91 @@ impl TokenGraph {
     /// Attach relationship records loaded from a relationships catalog directory.
     pub fn with_relationships(mut self, relationships: Vec<RelationshipRecord>) -> Self {
         self.relationships = relationships;
+        self.reindex_relationship_tokens();
         self
+    }
+
+    /// Schemas whose inline CTR `value` is a plain literal directly comparable
+    /// to a Figma value — unlike `font-family.json`, whose inline CTR value is
+    /// a bare family-name string with no schema-driven comparison rule, so it
+    /// deliberately stays unresolved here (see `resolve_relationship_ref`).
+    const INLINE_CTR_COMPARABLE_SCHEMAS: [&'static str; 3] =
+        ["dimension.json", "multiplier.json", "gradient-stop.json"];
+
+    /// Rebuild `relationship_tokens` from `self.relationships`: for every CTR
+    /// `legacyKey` with no `$ref`-backed entry, synthesize a leaf `TokenRecord`
+    /// from its inline `value`, so `resolve_relationship_ref` can return it.
+    ///
+    /// When a `legacyKey` has several inline entries (a scale-set CTR, e.g.
+    /// `avatar-size-100` has one per `scale`), prefers `scale: "desktop"` —
+    /// same convention as the alias-target fallback's default-mode pick —
+    /// then the first scale-less entry, then simply the first.
+    ///
+    /// Call after any mutation of `self.relationships` (this fn and
+    /// `apply_platform_manifest`'s CTR add/override/remove are the only two).
+    fn reindex_relationship_tokens(&mut self) {
+        self.relationship_tokens.clear();
+        let mut by_key: HashMap<&str, Vec<&RelationshipRecord>> = HashMap::new();
+        for rec in &self.relationships {
+            if rec.raw.get("$ref").is_some() {
+                continue; // $ref-backed CTRs resolve via resolve_alias_key instead.
+            }
+            let Some(legacy_key) = rec.raw.get("legacyKey").and_then(Value::as_str) else {
+                continue;
+            };
+            let comparable = rec
+                .raw
+                .get("$schema")
+                .and_then(Value::as_str)
+                .is_some_and(|s| {
+                    Self::INLINE_CTR_COMPARABLE_SCHEMAS
+                        .iter()
+                        .any(|suf| s.ends_with(suf))
+                });
+            if comparable && rec.raw.get("value").is_some() {
+                by_key.entry(legacy_key).or_default().push(rec);
+            }
+        }
+        for (legacy_key, candidates) in by_key {
+            let chosen = candidates
+                .iter()
+                .find(|r| {
+                    r.raw
+                        .get("scope")
+                        .and_then(|s| s.get("options"))
+                        .and_then(|o| o.get("scale"))
+                        .and_then(Value::as_str)
+                        == Some("desktop")
+                })
+                .or_else(|| {
+                    candidates.iter().find(|r| {
+                        r.raw
+                            .get("scope")
+                            .and_then(|s| s.get("options"))
+                            .and_then(|o| o.get("scale"))
+                            .is_none()
+                    })
+                })
+                .or_else(|| candidates.first())
+                .expect("candidates is non-empty by construction");
+            self.relationship_tokens.insert(
+                legacy_key.to_string(),
+                TokenRecord {
+                    name: legacy_key.to_string(),
+                    file: chosen.file.clone(),
+                    index: chosen.index,
+                    schema_url: chosen
+                        .raw
+                        .get("$schema")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    uuid: chosen.uuid.clone(),
+                    alias_target: None,
+                    raw: chosen.raw.clone(),
+                    layer: Layer::default(),
+                },
+            );
+        }
     }
 
     /// Find the `$schema` URL of any token whose `name.property` matches `property`.
@@ -1543,20 +1636,25 @@ impl TokenGraph {
         })
     }
 
-    /// Resolve a Component/Token Relationship (CTR) `legacyKey` to the token
-    /// its `$ref` points at, for callers that already tried
-    /// [`Self::resolve_alias_key`] (token-side) and came up empty.
+    /// Resolve a Component/Token Relationship (CTR) `legacyKey` to a token,
+    /// for callers that already tried [`Self::resolve_alias_key`] (token-side)
+    /// and came up empty.
     ///
-    /// Returns `None` when no CTR has that `legacyKey`, or when it carries an
-    /// inline `value` instead of a `$ref` (e.g. `code-font-family`) — inline
-    /// CTR values aren't compared today.
+    /// Tries the CTR's `$ref` target first. Falls back to the CTR's own
+    /// inline `value` when it carries one directly (e.g. `avatar-size-100`'s
+    /// dimension) — see [`Self::reindex_relationship_tokens`] for which
+    /// schemas qualify (`font-family`'s inline value, e.g. `code-font-family`,
+    /// deliberately doesn't: no schema-driven comparison rule for it here).
+    /// Returns `None` when no CTR has that `legacyKey`, or neither path found
+    /// a usable value.
     pub fn resolve_relationship_ref<'a>(&'a self, legacy_key: &str) -> Option<&'a TokenRecord> {
-        let rec = self
+        let via_ref = self
             .relationships
             .iter()
-            .find(|r| r.raw.get("legacyKey").and_then(|v| v.as_str()) == Some(legacy_key))?;
-        let target = rec.raw.get("$ref").and_then(|v| v.as_str())?;
-        self.resolve_alias_key(target)
+            .find(|r| r.raw.get("legacyKey").and_then(|v| v.as_str()) == Some(legacy_key))
+            .and_then(|rec| rec.raw.get("$ref").and_then(|v| v.as_str()))
+            .and_then(|target| self.resolve_alias_key(target));
+        via_ref.or_else(|| self.relationship_tokens.get(legacy_key))
     }
 
     /// Resolve a set-level UUID to the context-appropriate child record.
@@ -2267,6 +2365,63 @@ mod tests {
         assert!(g_inline
             .resolve_relationship_ref("code-font-family")
             .is_none());
+    }
+
+    #[test]
+    fn resolve_relationship_ref_resolves_inline_dimension_ctrs_preferring_desktop() {
+        // avatar-size-100's CTR shape: a scale-set with a desktop and a mobile
+        // entry sharing one legacyKey, each an inline dimension value (no
+        // $ref) — the real shape in packages/design-data/relationships/avatar.json.
+        let g = TokenGraph::default().with_relationships(vec![
+            RelationshipRecord {
+                file: PathBuf::from("relationships/avatar.json"),
+                index: 0,
+                uuid: Some("eeeeeeee-0000-0000-0000-000000000001".to_string()),
+                raw: json!({
+                    "scope": {"component": "avatar", "property": "size", "options": {"scale": "mobile", "scaleIndex": 100}},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "value": "28px",
+                    "uuid": "eeeeeeee-0000-0000-0000-000000000001",
+                    "legacyKey": "avatar-size-100"
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/avatar.json"),
+                index: 1,
+                uuid: Some("eeeeeeee-0000-0000-0000-000000000002".to_string()),
+                raw: json!({
+                    "scope": {"component": "avatar", "property": "size", "options": {"scale": "desktop", "scaleIndex": 100}},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "value": "24px",
+                    "uuid": "eeeeeeee-0000-0000-0000-000000000002",
+                    "legacyKey": "avatar-size-100"
+                }),
+            },
+            // A scale-less inline CTR, e.g. alert-dialog-maximum-width.
+            RelationshipRecord {
+                file: PathBuf::from("relationships/alert-dialog.json"),
+                index: 0,
+                uuid: Some("eeeeeeee-0000-0000-0000-000000000003".to_string()),
+                raw: json!({
+                    "scope": {"component": "alert-dialog", "property": "maximum-width"},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "value": "480px",
+                    "uuid": "eeeeeeee-0000-0000-0000-000000000003",
+                    "legacyKey": "alert-dialog-maximum-width"
+                }),
+            },
+        ]);
+
+        // Desktop entry wins even though mobile was inserted first.
+        let avatar = g
+            .resolve_relationship_ref("avatar-size-100")
+            .expect("inline dimension CTR must resolve");
+        assert_eq!(avatar.raw["value"], "24px");
+
+        let dialog = g
+            .resolve_relationship_ref("alert-dialog-maximum-width")
+            .expect("scale-less inline dimension CTR must resolve");
+        assert_eq!(dialog.raw["value"], "480px");
     }
 
     #[test]

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1379,6 +1379,13 @@ impl TokenGraph {
     /// to a Figma value — unlike `font-family.json`, whose inline CTR value is
     /// a bare family-name string with no schema-driven comparison rule, so it
     /// deliberately stays unresolved here (see `resolve_relationship_ref`).
+    ///
+    /// Not derived from `figma::import::diff_against_source`'s Figma-side
+    /// `resolved_type` match (`COLOR`/`FLOAT`/`STRING`) — that classifies by
+    /// Figma variable type, this by design-data `$schema`, and there's no
+    /// shared enum between them. Adding a schema here that isn't actually
+    /// FLOAT/STRING-comparable on the Figma side needs a matching look at
+    /// `diff_against_source`.
     const INLINE_CTR_COMPARABLE_SCHEMAS: [&'static str; 3] =
         ["dimension.json", "multiplier.json", "gradient-stop.json"];
 
@@ -1391,9 +1398,10 @@ impl TokenGraph {
     /// same convention as the alias-target fallback's default-mode pick —
     /// then the first scale-less entry, then simply the first.
     ///
-    /// Call after any mutation of `self.relationships` (this fn and
-    /// `apply_platform_manifest`'s CTR add/override/remove are the only two).
-    fn reindex_relationship_tokens(&mut self) {
+    /// Call after any mutation of `self.relationships` (this fn,
+    /// `apply_platform_manifest`'s CTR add/override/remove, and
+    /// `validate::validate_all_with_full_options`'s `relationships_path` load).
+    pub(crate) fn reindex_relationship_tokens(&mut self) {
         self.relationship_tokens.clear();
         let mut by_key: HashMap<&str, Vec<&RelationshipRecord>> = HashMap::new();
         for rec in &self.relationships {
@@ -1438,6 +1446,35 @@ impl TokenGraph {
                 })
                 .or_else(|| candidates.first())
                 .expect("candidates is non-empty by construction");
+            // CTRs key scale variants under `scope.options.scale` /
+            // `setUuid` (camelCase), not the `name.scale` / `set_uuid`
+            // (snake_case) shape `scale_aligned_source_value` reads off
+            // cascade-token records via `set_uuid_index` — and that index
+            // is built only from `self.tokens`, which CTR-only scale-sets
+            // never enter. Rather than force these into that pipeline,
+            // stash every scale's value directly on the synthetic raw so
+            // `scale_aligned_source_value` can pick the Figma-mode-matching
+            // one itself when there's more than one.
+            let mut raw = chosen.raw.clone();
+            if candidates.len() > 1 {
+                let mut scale_values = serde_json::Map::new();
+                for c in &candidates {
+                    let scale = c
+                        .raw
+                        .get("scope")
+                        .and_then(|s| s.get("options"))
+                        .and_then(|o| o.get("scale"))
+                        .and_then(Value::as_str);
+                    if let (Some(scale), Some(value)) = (scale, c.raw.get("value")) {
+                        scale_values.insert(scale.to_string(), value.clone());
+                    }
+                }
+                if let Some(obj) = raw.as_object_mut() {
+                    if !scale_values.is_empty() {
+                        obj.insert("ctrScaleValues".to_string(), Value::Object(scale_values));
+                    }
+                }
+            }
             self.relationship_tokens.insert(
                 legacy_key.to_string(),
                 TokenRecord {
@@ -1451,7 +1488,7 @@ impl TokenGraph {
                         .map(str::to_string),
                     uuid: chosen.uuid.clone(),
                     alias_target: None,
-                    raw: chosen.raw.clone(),
+                    raw,
                     layer: Layer::default(),
                 },
             );

--- a/sdk/core/src/validate/mod.rs
+++ b/sdk/core/src/validate/mod.rs
@@ -135,6 +135,7 @@ pub fn validate_all_with_full_options(
     if let Some(dir) = relationships_path {
         if dir.is_dir() {
             graph.relationships = TokenGraph::load_spec_relationships(dir)?;
+            graph.reindex_relationship_tokens();
         }
     }
     // Load manifest.json from the data directory when present.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`resolve_relationship_ref` in `sdk/core/src/graph.rs` previously only resolved
Component/Token Relationship (CTR) entries backed by a `$ref`. CTR entries that
carry their value inline (dimension, multiplier, gradient-stop schemas — no
`$ref`) were skipped. This left 438 `.Platform scale` Figma variables reported
`figma-only` even though the underlying data already existed in the CTR layer.

Adds a `relationship_tokens` index (legacy key → synthetic `TokenRecord`) built
from inline-value CTRs at graph-build time, and falls back to it after the
`$ref` path misses. When a scale-set CTR shares one legacy key across
`desktop`/`mobile` scale variants, the desktop entry is preferred, matching the
existing default-mode convention from #1409/8fdff4f3. Inline `font-family`
CTRs (e.g. `code-font-family`) are intentionally excluded — no schema-driven
comparison rule exists for them yet.

`import.rs`'s diff/alias-fallback paths already chain through
`resolve_relationship_ref`, so no changes were needed there.

## Related Issue

Closes spectrum-design-data-11k.10.8.
Initiatives: DNA-1520, DNA-1796.

## Motivation and Context

Investigation (see bead notes) initially assumed this was a data-authoring gap
(tokens migrated from legacy `@adobe/tokens` but never added to
`packages/design-data/tokens/*.tokens.json`). That was wrong — all 327
`platformScale/` keys already exist as Component/Token Relationships in
`packages/design-data/relationships/*.json`; the gap was purely in CTR
resolution coverage, not missing data. This is a small, additive extension to
the existing resolver rather than new token authoring.

A handful of edge cases (11 `$ref`-backed keys pointing at CTR-only UUIDs, and
1 inline `font-family` CTR) remain figma-only and are filed separately as
follow-up bead spectrum-design-data-11k.10.9 rather than expanding this PR's
scope.

## How Has This Been Tested?

- `cargo test -p design-data-core --features figma` — 796 passed, including a
  new unit test (`resolve_relationship_ref_resolves_inline_dimension_ctrs_preferring_desktop`).
- `moon run sdk:test` — 1391 passed, 1 skipped, exit 0.
- `moon run sdk:lint` (clippy `-D warnings`) and an explicit
  `cargo clippy --workspace --features design-data-core/figma -- -D warnings`
  (the figma feature isn't covered by the default lint task) — both clean.
- Re-ran the baseline Figma diff
  (`sdk/core/tests/fixtures/figma/s2-web-variables.baseline.json`) before/after:
  `figma_only` dropped 537 → 99 (−438), `matched` rose 1916 → 2351,
  `skipped_uncovered` unchanged (469), zero regressions (no entry newly became
  `figma-only`). 3 new `value_mismatch` entries spot-checked and confirmed to
  be genuine pre-existing floating-point drift (8/9 fraction rounding), not
  resolver defects.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
