### PR TITLE
chore(design-data): document CTR records' absence from token indexes

### DIFF
--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -157,6 +157,14 @@ pub struct TokenGraph {
     /// CTRs (no `$ref`, e.g. `avatar-size-100`'s dimension value lives directly
     /// on the relationship). Rebuilt by [`Self::reindex_relationship_tokens`]
     /// whenever `relationships` changes; see [`Self::resolve_relationship_ref`].
+    ///
+    /// These synthetic records live *only* here — they never enter `self.tokens`,
+    /// `uuid_index`, or `set_uuid_index` (built solely from `tokens/*.tokens.json`).
+    /// So context-aware resolution (`Self::resolve_set_in_context`,
+    /// `Self::resolve_alias_in_context`) can't see CTR-only scale-sets; a future need
+    /// for that should follow the `ctrScaleValues` inline-stash pattern used by
+    /// `Self::reindex_relationship_tokens` rather than feeding these into the shared
+    /// indexes (which are iterated elsewhere for diff classification).
     relationship_tokens: HashMap<String, TokenRecord>,
     /// Platform manifest from `manifest.json` in the tokens root, if present.
     pub manifest: serde_json::Value,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Documentation-only change: expands the `relationship_tokens` field doc comment in
`sdk/core/src/graph.rs` to state plainly that synthetic CTR (Component/Token
Relationship) records never enter `self.tokens`, `uuid_index`, or `set_uuid_index` —
those indexes are built solely from `packages/design-data/tokens/*.tokens.json`. As a
result, context-aware resolvers (`resolve_set_in_context`, `resolve_alias_in_context`)
can't see CTR-only scale-sets. The note points any future need at the `ctrScaleValues`
inline-stash pattern (already used by `reindex_relationship_tokens` /
`scale_aligned_source_value`) rather than feeding CTR records into the shared indexes.

No functional code change. No changeset — internal Rust doc comment only.

## Related Issue

Closes bead `spectrum-design-data-11k.10.10`, raised during review of #1411.

## Motivation and Context

PR #1411 discovered that `scale_aligned_source_value` couldn't see CTR-only scale-sets
(e.g. `avatar-size-100`) through `resolve_set_in_context`, because CTR-sourced
`TokenRecord`s live only in the standalone `relationship_tokens` cache, never in the
shared token indexes. That PR fixed the one call site that needed it. This bead asked
whether the underlying architectural gap needed a broader fix (e.g. feeding
`relationship_tokens` into `set_uuid_index`/`uuid_index` during reindex) or was
documentation-only.

Investigation (exhaustive grep of every caller of `resolve_set_in_context`,
`set_uuid_index`, `uuid_index`, `resolve_alias_key`, and every iteration of
`self.tokens`) found:

- `resolve_set_in_context` has exactly two callers: `scale_aligned_source_value`
  (already solved via `ctrScaleValues`) and `resolve_alias_in_context`, which is gated
  on `set_uuid_index` membership (real tokens only) before ever calling it.
- `resolve_alias_in_context`'s only caller, `resolve_reference` (the cascade
  slug-resolution walker used by the WASM tokens-viewer binding), collects chain-start
  candidates exclusively from `graph.tokens.values()` — a CTR-only key can never begin
  a chain. Mid-chain, a hypothetical real-token→CTR-set alias would simply degrade
  gracefully (the walk breaks).
- Feeding `relationship_tokens` into the shared indexes (the alternative "fix at the
  index level" option) was confirmed risky for no current benefit: `self.tokens` is
  iterated elsewhere for diff classification and as `resolve_reference`'s chain-start
  candidate pool, so synthetic CTR entries there could spuriously surface as
  standalone tokens.

Conclusion: no current or imminent caller needs this. Closing as documentation-only per
the bead's own stated preferred outcome for that case.

## How Has This Been Tested?

- `cargo test -p design-data-core --features figma` — 797 passed, 0 failed (from `sdk/`).
- `moon run sdk:test` — 1392 passed, 1 skipped.
- `moon run sdk:lint` and `cargo clippy --workspace --features design-data-core/figma -- -D warnings` — clean.
- Doc-comment-only change; no behavior to regression-test beyond the existing
  `ctr_scale_set_aligns_to_figmas_captured_mode` regression test, which still passes.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(Documentation-only change; none of the above apply.)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
