### PR TITLE
fix(design-data): resolve CTR $refs pointing at sibling CTR uuids

### DIFF
--- a/.changeset/figma-diff-ctr-sibling-ref-resolution.md
+++ b/.changeset/figma-diff-ctr-sibling-ref-resolution.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+`figma diff`/`figma import` now resolve CTR `$ref`s that target another CTR's
+own `uuid`/`setUuid` instead of a token, recovering 3 `drop-zone-*-font-size`
+`.Platform scale` variables previously reported `figma-only`
+(closes spectrum-design-data-11k.10.9).
+
+- **sdk/core/src/graph.rs**: `resolve_relationship_ref` recurses into a
+  sibling CTR when its `$ref` target isn't a token, following chains up to
+  16 hops deep (e.g. `drop-zone-title-font-size` → `illustrated-message-*` →
+  `body-*` → a token). `relationship_target_exists` now shares the same
+  sibling lookup. `code-cjk-font-family` still doesn't resolve — its chain
+  bottoms out at an inline `font-family` CTR, out of scope by design.

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1670,35 +1670,74 @@ impl TokenGraph {
         None
     }
 
+    /// Relationship whose own `uuid`, or `setUuid`, equals `target` — i.e.
+    /// `target` is a CTR-side alias anchor rather than a token-side one.
+    /// Shared by [`Self::relationship_target_exists`] and
+    /// [`Self::resolve_relationship_ref`]'s sibling-CTR fallback.
+    fn find_relationship_target(&self, target: &str) -> Option<&RelationshipRecord> {
+        self.relationships.iter().find(|r| {
+            r.uuid.as_deref() == Some(target)
+                || r.raw.get("setUuid").and_then(|v| v.as_str()) == Some(target)
+        })
+    }
+
     /// Whether `target` resolves to a relationship's own `uuid`, or to a
     /// mode-set group id that only survives as `setUuid` on sibling
     /// relationships — i.e. a CTR-side alias anchor, for callers that already
     /// tried [`Self::resolve_alias_key`] (token-side) and came up empty.
     pub fn relationship_target_exists(&self, target: &str) -> bool {
-        self.relationships.iter().any(|r| {
-            r.uuid.as_deref() == Some(target)
-                || r.raw.get("setUuid").and_then(|v| v.as_str()) == Some(target)
-        })
+        self.find_relationship_target(target).is_some()
     }
 
     /// Resolve a Component/Token Relationship (CTR) `legacyKey` to a token,
     /// for callers that already tried [`Self::resolve_alias_key`] (token-side)
     /// and came up empty.
     ///
-    /// Tries the CTR's `$ref` target first. Falls back to the CTR's own
-    /// inline `value` when it carries one directly (e.g. `avatar-size-100`'s
-    /// dimension) — see [`Self::reindex_relationship_tokens`] for which
-    /// schemas qualify (`font-family`'s inline value, e.g. `code-font-family`,
-    /// deliberately doesn't: no schema-driven comparison rule for it here).
-    /// Returns `None` when no CTR has that `legacyKey`, or neither path found
-    /// a usable value.
+    /// Tries the CTR's `$ref` target first, via [`Self::resolve_alias_key`].
+    /// When that misses, `$ref` may point at a *sibling* CTR's own
+    /// `uuid`/`setUuid` rather than a token (e.g. `avatar-group-size-100`'s
+    /// `$ref` targets `avatar-size-100`'s scale-set `setUuid`) — recurses
+    /// into that sibling's own `legacyKey` to follow the chain, which may run
+    /// several CTRs deep (e.g. `drop-zone-title-font-size` →
+    /// `illustrated-message-medium-title-font-size` → `body-size-s` → a
+    /// token's `set_uuid`) before landing on a token or an inline value.
+    /// Falls back to the CTR's own inline `value` when it carries one
+    /// directly (e.g. `avatar-size-100`'s dimension) — see
+    /// [`Self::reindex_relationship_tokens`] for which schemas qualify
+    /// (`font-family`'s inline value, e.g. `code-font-family`, deliberately
+    /// doesn't: no schema-driven comparison rule for it here, so a chain
+    /// that bottoms out there — e.g. `code-cjk-font-family` — stays
+    /// unresolved by design). Returns `None` when no CTR has that
+    /// `legacyKey`, or no path found a usable value.
     pub fn resolve_relationship_ref<'a>(&'a self, legacy_key: &str) -> Option<&'a TokenRecord> {
+        self.resolve_relationship_ref_inner(legacy_key, 0)
+    }
+
+    fn resolve_relationship_ref_inner<'a>(
+        &'a self,
+        legacy_key: &str,
+        depth: usize,
+    ) -> Option<&'a TokenRecord> {
+        // ponytail: depth cap guards a cyclic/malformed $ref chain; real
+        // chains observed so far are 3 hops deep at most.
+        if depth > 16 {
+            return None;
+        }
         let via_ref = self
             .relationships
             .iter()
             .find(|r| r.raw.get("legacyKey").and_then(|v| v.as_str()) == Some(legacy_key))
             .and_then(|rec| rec.raw.get("$ref").and_then(|v| v.as_str()))
-            .and_then(|target| self.resolve_alias_key(target));
+            .and_then(|target| {
+                self.resolve_alias_key(target).or_else(|| {
+                    let sibling_key = self
+                        .find_relationship_target(target)?
+                        .raw
+                        .get("legacyKey")
+                        .and_then(|v| v.as_str())?;
+                    self.resolve_relationship_ref_inner(sibling_key, depth + 1)
+                })
+            });
         via_ref.or_else(|| self.relationship_tokens.get(legacy_key))
     }
 
@@ -2467,6 +2506,125 @@ mod tests {
             .resolve_relationship_ref("alert-dialog-maximum-width")
             .expect("scale-less inline dimension CTR must resolve");
         assert_eq!(dialog.raw["value"], "480px");
+    }
+
+    #[test]
+    fn resolve_relationship_ref_follows_ref_to_sibling_ctr_uuid() {
+        // avatar-group-size-100's real shape: its $ref targets
+        // avatar-size-100's scale-set setUuid, which only exists on that
+        // sibling CTR — never in tokens/*.tokens.json.
+        let g = TokenGraph::default().with_relationships(vec![
+            RelationshipRecord {
+                file: PathBuf::from("relationships/avatar.json"),
+                index: 0,
+                uuid: Some("ffffffff-0000-0000-0000-000000000001".to_string()),
+                raw: json!({
+                    "scope": {"component": "avatar", "property": "size", "options": {"scale": "desktop", "scaleIndex": 100}},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "value": "24px",
+                    "uuid": "ffffffff-0000-0000-0000-000000000001",
+                    "setUuid": "ffffffff-0000-0000-0000-00000000000a",
+                    "legacyKey": "avatar-size-100"
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/avatar-group.json"),
+                index: 0,
+                uuid: Some("ffffffff-0000-0000-0000-000000000002".to_string()),
+                raw: json!({
+                    "scope": {"component": "avatar-group", "property": "size", "options": {"scaleIndex": 100}},
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+                    "$ref": "ffffffff-0000-0000-0000-00000000000a",
+                    "uuid": "ffffffff-0000-0000-0000-000000000002",
+                    "legacyKey": "avatar-group-size-100"
+                }),
+            },
+        ]);
+
+        let rec = g
+            .resolve_relationship_ref("avatar-group-size-100")
+            .expect("$ref to a sibling CTR's setUuid must resolve");
+        assert_eq!(rec.raw["value"], "24px");
+    }
+
+    #[test]
+    fn resolve_relationship_ref_follows_multi_hop_ctr_chain_to_token() {
+        // drop-zone-title-font-size's real shape: a 3-hop chain of $refs
+        // across CTRs before landing on a token's set_uuid.
+        let uuid = "11111111-0000-0000-0000-000000000099";
+        let g = cascade_graph_from(json!([{
+            "name": { "property": "font-size", "value": "l" },
+            "$schema": "https://example.com/font-size.json",
+            "value": "20px",
+            "set_uuid": uuid
+        }]))
+        .with_relationships(vec![
+            RelationshipRecord {
+                file: PathBuf::from("relationships/body.json"),
+                index: 0,
+                uuid: Some("11111111-0000-0000-0000-000000000001".to_string()),
+                raw: json!({
+                    "legacyKey": "body-size-s",
+                    "$ref": uuid
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/illustrated-message.json"),
+                index: 0,
+                uuid: Some("11111111-0000-0000-0000-000000000002".to_string()),
+                raw: json!({
+                    "legacyKey": "illustrated-message-medium-title-font-size",
+                    "$ref": "11111111-0000-0000-0000-000000000001"
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/drop-zone.json"),
+                index: 0,
+                uuid: Some("11111111-0000-0000-0000-000000000003".to_string()),
+                raw: json!({
+                    "legacyKey": "drop-zone-title-font-size",
+                    "setUuid": "11111111-0000-0000-0000-000000000002",
+                    "$ref": "11111111-0000-0000-0000-000000000002"
+                }),
+            },
+        ]);
+
+        let rec = g
+            .resolve_relationship_ref("drop-zone-title-font-size")
+            .expect("multi-hop CTR chain to a token must resolve");
+        assert_eq!(rec.raw["value"], "20px");
+    }
+
+    #[test]
+    fn resolve_relationship_ref_stays_unresolved_through_font_family_chain() {
+        // code-cjk-font-family's real shape: its $ref targets
+        // code-font-family, an inline font-family CTR deliberately excluded
+        // from INLINE_CTR_COMPARABLE_SCHEMAS. The chain must stay unresolved
+        // rather than surfacing that inline value.
+        let g = TokenGraph::default().with_relationships(vec![
+            RelationshipRecord {
+                file: PathBuf::from("relationships/code.json"),
+                index: 0,
+                uuid: Some("22222222-0000-0000-0000-000000000001".to_string()),
+                raw: json!({
+                    "legacyKey": "code-font-family",
+                    "value": "Source Code Pro",
+                    "uuid": "22222222-0000-0000-0000-000000000001"
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/code.json"),
+                index: 1,
+                uuid: Some("22222222-0000-0000-0000-000000000002".to_string()),
+                raw: json!({
+                    "legacyKey": "code-cjk-font-family",
+                    "$ref": "22222222-0000-0000-0000-000000000001",
+                    "uuid": "22222222-0000-0000-0000-000000000002"
+                }),
+            },
+        ]);
+
+        assert!(g.resolve_relationship_ref("code-cjk-font-family").is_none());
     }
 
     #[test]

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -2628,6 +2628,37 @@ mod tests {
     }
 
     #[test]
+    fn resolve_relationship_ref_terminates_on_cyclic_ctr_ref() {
+        // Malformed data: two CTRs whose $refs point at each other's uuid,
+        // forming a cycle. Must return None via the depth cap rather than
+        // recursing forever / overflowing the stack.
+        let g = TokenGraph::default().with_relationships(vec![
+            RelationshipRecord {
+                file: PathBuf::from("relationships/cycle.json"),
+                index: 0,
+                uuid: Some("33333333-0000-0000-0000-000000000001".to_string()),
+                raw: json!({
+                    "legacyKey": "cycle-a",
+                    "$ref": "33333333-0000-0000-0000-000000000002",
+                    "uuid": "33333333-0000-0000-0000-000000000001"
+                }),
+            },
+            RelationshipRecord {
+                file: PathBuf::from("relationships/cycle.json"),
+                index: 1,
+                uuid: Some("33333333-0000-0000-0000-000000000002".to_string()),
+                raw: json!({
+                    "legacyKey": "cycle-b",
+                    "$ref": "33333333-0000-0000-0000-000000000001",
+                    "uuid": "33333333-0000-0000-0000-000000000002"
+                }),
+            },
+        ]);
+
+        assert!(g.resolve_relationship_ref("cycle-a").is_none());
+    }
+
+    #[test]
     fn legacy_name_index_resolves_cascade_token_by_name() {
         // Cascade tokens are keyed file:index. resolve_alias_key must still find
         // them when given their human-readable legacy name.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`resolve_relationship_ref`'s `$ref` branch only checked token-side indexes
(`uuid_index` / `tokens` / `legacy_name_index`), so a CTR whose `$ref` targets
another CTR's own `uuid`/`setUuid` — never a `tokens/*.tokens.json` entry —
resolved to nothing and classified as `figma-only` in the diff. This recovers
those chains by recursing into the sibling CTR (up to 16 hops), until the
chain either lands on a real token or an inline CTR value.

Traced against the corpus:
- `drop-zone-body/title/cjk-title-font-size` → an `illustrated-message-medium-*`
  CTR's `setUuid` → a `body-*` CTR's `uuid` → a token's `set_uuid`. All 3 now
  resolve.
- `avatar-group-size-100` → `avatar-size-100`'s `setUuid` (1 hop, inline
  value). Also now resolves — a good regression check even though it wasn't
  in the original figma-only list.
- `code-cjk-font-family` → `code-font-family`'s `uuid`, an inline
  **font-family** CTR excluded from `INLINE_CTR_COMPARABLE_SCHEMAS` by design.
  This one stays unresolved, same as `code-font-family` itself — expected,
  not a regression.

## Related Issue

Closes spectrum-design-data-11k.10.9 (follow-up to #1411).

## Motivation and Context

`.Platform scale` CTRs that chain through another CTR's uuid instead of a
token were incorrectly reported `figma-only` in `figma diff`/`figma import`,
even though the underlying value exists in the dataset.

## How Has This Been Tested?

- New unit tests in `sdk/core/src/graph.rs`: a 1-hop sibling-`setUuid` case
  (avatar-group shape), a 3-hop CTR→CTR→CTR→token chain (drop-zone shape),
  and a negative case confirming a font-family-terminated chain stays
  unresolved.
- `cargo test -p design-data-core --features figma` — 800 passed, 0 failed
  (was 795 before this change; +5 new tests, no regressions — this also
  exercises SPEC-001/010/055, which call the refactored
  `relationship_target_exists`).
- `moon run sdk:test` — full workspace suite, passing.
- `cargo clippy --workspace --features design-data-core/figma -- -D warnings`
  — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passing.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
