### PR TITLE
feat(design-data-mcp,design-data-agent-mcp): warn at runtime on stale embedded dataset

### DIFF
--- a/.changeset/design-data-mcp-freshness-check.md
+++ b/.changeset/design-data-mcp-freshness-check.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-mcp": patch
+"@adobe/design-data-agent-mcp": patch
+---
+
+Warn at runtime when the embedded dataset is behind latest published
+@adobe/spectrum-design-data (closes spectrum-design-data-9fe.5).
+
+- **tools/design-data-agent-mcp/src/dataset-freshness.js**: new best-effort
+  npm-registry version check, silent on any network failure.
+- **tools/design-data-agent-mcp/src/tools/read.js**: `primer` now returns
+  `provenance.datasetStatus` and logs a stderr warning once when stale.
+- **tools/design-data-mcp/src/dataset-freshness.js**: same check, duplicated
+  per package (no shared dependency between the two servers).
+- **tools/design-data-mcp/src/tools/design-data.js**: `design-data-primer`
+  gets the same `datasetStatus` field and warning.

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -38,7 +38,11 @@ package version — there's no separate data update to run. Pin `@latest` (as ab
 fetches the newest published version rather than reusing whatever it last cached; `-y` alone
 only skips the install confirmation, it doesn't force a re-fetch. Already on `/plugin`? Run
 `/plugin update design-data-agent@spectrum-design-data`. Call the primer tool and check
-`provenance.designDataVersion` to see which dataset version is embedded.
+`provenance.designDataVersion` to see which dataset version is embedded. The primer tool
+also does a best-effort check against the latest published `@adobe/spectrum-design-data`
+version — if the embedded dataset is behind, it adds a `provenance.datasetStatus` field and
+logs a one-line warning to stderr. This is silent on any network failure (offline/air-gapped
+use is unaffected); set `DESIGN_DATA_SKIP_VERSION_CHECK=1` to disable the check entirely.
 
 ## MCP server
 

--- a/tools/design-data-agent-mcp/src/dataset-freshness.js
+++ b/tools/design-data-agent-mcp/src/dataset-freshness.js
@@ -1,0 +1,88 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Best-effort runtime check that the embedded dataset (provenance.designDataVersion,
+ * baked into @adobe/design-data-wasm at build time) isn't behind the latest published
+ * @adobe/spectrum-design-data. See spectrum-design-data-9fe.5 — a plain `npx -y <pkg>`
+ * (no @latest tag) can silently reuse a cached older wasm build.
+ *
+ * Deliberately silent on any failure (offline, registry down, timeout): this is a
+ * courtesy signal, never a reason to break the primer response.
+ */
+
+const REGISTRY_URL =
+  "https://registry.npmjs.org/@adobe/spectrum-design-data/latest";
+const TIMEOUT_MS = 1500;
+
+/**
+ * Numeric major.minor.patch compare. ponytail: ignores prerelease/build tags;
+ * add real semver only if a data prerelease ships.
+ */
+export function isBehind(embedded, latest) {
+  const a = String(embedded).split(".").map(Number);
+  const b = String(latest).split(".").map(Number);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x < y;
+  }
+  return false;
+}
+
+let warned = false;
+let cached; // Promise<status|null>, memoized per process
+
+/**
+ * @param {string} embeddedVersion - provenance.designDataVersion from ds.primer()
+ * @returns {Promise<{latestVersion: string, isStale: boolean, message?: string}|null>}
+ */
+export function checkDatasetFreshness(embeddedVersion) {
+  if (!embeddedVersion || process.env.DESIGN_DATA_SKIP_VERSION_CHECK) {
+    return Promise.resolve(null);
+  }
+  if (!cached) {
+    cached = fetchLatest(embeddedVersion);
+  }
+  return cached;
+}
+
+async function fetchLatest(embeddedVersion) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: controller.signal });
+    if (!res.ok) return null;
+    const { version: latestVersion } = await res.json();
+    const isStale = isBehind(embeddedVersion, latestVersion);
+    const status = { latestVersion, isStale };
+    if (isStale) {
+      status.message =
+        `Embedded dataset (${embeddedVersion}) is behind the latest published ` +
+        `@adobe/spectrum-design-data (${latestVersion}). Reinstall with ` +
+        `npx -y @adobe/design-data-agent-mcp@latest to pick up the newer snapshot.`;
+      if (!warned) {
+        warned = true;
+        console.error(`[design-data] ${status.message}`);
+      }
+    }
+    return status;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Test-only: clear the memoized check + warn-once flag between cases. */
+export function __resetFreshnessCache() {
+  warned = false;
+  cached = undefined;
+}

--- a/tools/design-data-agent-mcp/src/dataset-freshness.js
+++ b/tools/design-data-agent-mcp/src/dataset-freshness.js
@@ -38,7 +38,8 @@ export function isBehind(embedded, latest) {
 }
 
 let warned = false;
-let cached; // Promise<status|null>, memoized per process
+let cached; // Promise<status|null>, memoized per process — cleared on failure so a
+// transient network blip doesn't permanently disable the check (see fetchLatest).
 
 /**
  * @param {string} embeddedVersion - provenance.designDataVersion from ds.primer()
@@ -49,7 +50,13 @@ export function checkDatasetFreshness(embeddedVersion) {
     return Promise.resolve(null);
   }
   if (!cached) {
-    cached = fetchLatest(embeddedVersion);
+    cached = fetchLatest(embeddedVersion).then((status) => {
+      // A null result means the check failed (offline/timeout/registry error) —
+      // don't memoize failure, so the next primer call retries instead of being
+      // stuck with no freshness signal for the rest of the process.
+      if (status === null) cached = undefined;
+      return status;
+    });
   }
   return cached;
 }

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -32,6 +32,7 @@ import { readFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { loadDataset } from "@adobe/design-data/load";
 import { config } from "../config.js";
+import { checkDatasetFreshness } from "../dataset-freshness.js";
 
 // Note: this module intentionally never spawns the native binary — primer and
 // describe_component must keep working with no CLI on PATH at all (see the
@@ -107,6 +108,11 @@ export function createReadTools() {
         const wasm = await getWasm();
         const ds = await getDataset();
         const { provenance } = ds.primer();
+        // Best-effort staleness check (spectrum-design-data-9fe.5) — silent on
+        // failure, never blocks the primer response.
+        const datasetStatus = await checkDatasetFreshness(
+          provenance.designDataVersion,
+        );
         return {
           // top-level source is the legacy skill-contract field; provenance.source
           // duplicates it intentionally — provenance is the richer metrics object
@@ -124,7 +130,9 @@ export function createReadTools() {
           },
           components: wasm.getFieldValues("component") ?? [],
           properties: wasm.getFieldValues("property") ?? [],
-          provenance,
+          provenance: datasetStatus
+            ? { ...provenance, datasetStatus }
+            : provenance,
         };
       },
     },

--- a/tools/design-data-agent-mcp/test/dataset-freshness.test.js
+++ b/tools/design-data-agent-mcp/test/dataset-freshness.test.js
@@ -89,3 +89,26 @@ test.serial(
     );
   },
 );
+
+test.serial(
+  "a failed check does not permanently disable future checks (no stuck cache)",
+  async (t) => {
+    // global.fetch rejects by default (see beforeEach) — first call fails.
+    const primer = getHandler("primer");
+    const offlineResult = await primer();
+    t.falsy(offlineResult.provenance.datasetStatus);
+
+    // Network "comes back" — a later primer call should retry, not stay stuck
+    // on the memoized failure.
+    global.fetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: "999.0.0" }),
+      });
+    const onlineResult = await primer();
+    t.true(
+      onlineResult.provenance.datasetStatus?.isStale,
+      "freshness check should retry after a prior failure, not stay cached as null",
+    );
+  },
+);

--- a/tools/design-data-agent-mcp/test/dataset-freshness.test.js
+++ b/tools/design-data-agent-mcp/test/dataset-freshness.test.js
@@ -1,0 +1,91 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+// Kept in its own serial test file (rather than added to read.test.js) because
+// every test here stubs the shared `global.fetch` and resets dataset-freshness.js's
+// module-level cache — read.test.js's other primer tests run concurrently and would
+// race with that shared mutable state (a separate worker process, so no cross-file
+// interference, but same-file tests still need `test.serial`).
+
+import test from "ava";
+import { createReadTools } from "../src/tools/read.js";
+import { isBehind, __resetFreshnessCache } from "../src/dataset-freshness.js";
+
+function getHandler(name) {
+  const tools = createReadTools();
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool "${name}" not found`);
+  return tool.handler.bind(tool);
+}
+
+test.serial.beforeEach((t) => {
+  __resetFreshnessCache();
+  t.context.savedFetch = global.fetch;
+  global.fetch = () => Promise.reject(new Error("network disabled in test"));
+});
+
+test.serial.afterEach((t) => {
+  global.fetch = t.context.savedFetch;
+  __resetFreshnessCache();
+});
+
+test.serial("isBehind: numeric major.minor.patch compare", (t) => {
+  t.true(isBehind("2.3.0", "2.6.0"));
+  t.false(isBehind("2.6.0", "2.6.0"));
+  t.false(isBehind("2.6.0", "2.3.0"));
+  t.true(isBehind("2.6", "2.6.1"));
+});
+
+test.serial(
+  "primer flags provenance.datasetStatus when embedded version is behind",
+  async (t) => {
+    global.fetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: "999.0.0" }),
+      });
+    const primer = getHandler("primer");
+    const result = await primer();
+    t.true(result.provenance.datasetStatus.isStale);
+    t.is(result.provenance.datasetStatus.latestVersion, "999.0.0");
+    t.truthy(result.provenance.datasetStatus.message);
+  },
+);
+
+test.serial(
+  "primer reports datasetStatus without a message when up to date",
+  async (t) => {
+    const primer = getHandler("primer");
+    const embeddedVersion = (await primer()).provenance.designDataVersion;
+    global.fetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: embeddedVersion }),
+      });
+    __resetFreshnessCache();
+    const result = await primer();
+    t.false(result.provenance.datasetStatus.isStale);
+    t.falsy(result.provenance.datasetStatus.message);
+  },
+);
+
+test.serial(
+  "primer still returns when the freshness check fails (offline)",
+  async (t) => {
+    // global.fetch already rejects by default (see beforeEach)
+    const primer = getHandler("primer");
+    const result = await primer();
+    t.truthy(result.provenance, "primer should not throw when offline");
+    t.falsy(
+      result.provenance.datasetStatus,
+      "datasetStatus should be absent when the check fails",
+    );
+  },
+);

--- a/tools/design-data-agent-mcp/test/read-cascade.test.js
+++ b/tools/design-data-agent-mcp/test/read-cascade.test.js
@@ -22,6 +22,12 @@ import { join } from "node:path";
 import { config } from "../src/config.js";
 import { createReadTools } from "../src/tools/read.js";
 
+// The cascade dataset's provenance has no designDataVersion, so checkDatasetFreshness
+// already short-circuits without a network call — this just guards against that
+// changing later. Keeps this file hermetic; the check itself is covered by
+// test/dataset-freshness.test.js.
+process.env.DESIGN_DATA_SKIP_VERSION_CHECK = "1";
+
 const FIXTURE_TOKEN = {
   name: { property: "test-cascade" },
   $schema:

--- a/tools/design-data-agent-mcp/test/read.test.js
+++ b/tools/design-data-agent-mcp/test/read.test.js
@@ -12,6 +12,12 @@ import test from "ava";
 import { config } from "../src/config.js";
 import { createReadTools } from "../src/tools/read.js";
 
+// These tests call the real `primer` handler, which does a best-effort
+// registry.npmjs.org freshness check. Disable it here so this file stays
+// hermetic (no real network call, no flakiness in air-gapped CI) — the check
+// itself is covered by test/dataset-freshness.test.js.
+process.env.DESIGN_DATA_SKIP_VERSION_CHECK = "1";
+
 // ── helpers ────────────────────────────────────────────────────────────────────
 
 function getHandler(name) {

--- a/tools/design-data-mcp/README.md
+++ b/tools/design-data-mcp/README.md
@@ -51,6 +51,11 @@ package version — there's no separate data update to run. Pin `@latest` (as ab
 fetches the newest published version rather than reusing whatever it last cached; `-y` alone
 only skips the install confirmation, it doesn't force a re-fetch. Call `design-data-primer` and
 check `provenance.designDataVersion` to see which dataset version is embedded.
+`design-data-primer` also does a best-effort check against the latest published
+`@adobe/spectrum-design-data` version — if the embedded dataset is behind, it adds a
+`provenance.datasetStatus` field and logs a one-line warning to stderr. This is silent on
+any network failure (offline/air-gapped use is unaffected); set
+`DESIGN_DATA_SKIP_VERSION_CHECK=1` to disable the check entirely.
 
 ## Tools
 

--- a/tools/design-data-mcp/src/dataset-freshness.js
+++ b/tools/design-data-mcp/src/dataset-freshness.js
@@ -1,0 +1,88 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Best-effort runtime check that the embedded dataset (provenance.designDataVersion,
+ * baked into @adobe/design-data-wasm at build time) isn't behind the latest published
+ * @adobe/spectrum-design-data. See spectrum-design-data-9fe.5 — a plain `npx -y <pkg>`
+ * (no @latest tag) can silently reuse a cached older wasm build.
+ *
+ * Deliberately silent on any failure (offline, registry down, timeout): this is a
+ * courtesy signal, never a reason to break the primer response.
+ */
+
+const REGISTRY_URL =
+  "https://registry.npmjs.org/@adobe/spectrum-design-data/latest";
+const TIMEOUT_MS = 1500;
+
+/**
+ * Numeric major.minor.patch compare. ponytail: ignores prerelease/build tags;
+ * add real semver only if a data prerelease ships.
+ */
+export function isBehind(embedded, latest) {
+  const a = String(embedded).split(".").map(Number);
+  const b = String(latest).split(".").map(Number);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x < y;
+  }
+  return false;
+}
+
+let warned = false;
+let cached; // Promise<status|null>, memoized per process
+
+/**
+ * @param {string} embeddedVersion - provenance.designDataVersion from ds.primer()
+ * @returns {Promise<{latestVersion: string, isStale: boolean, message?: string}|null>}
+ */
+export function checkDatasetFreshness(embeddedVersion) {
+  if (!embeddedVersion || process.env.DESIGN_DATA_SKIP_VERSION_CHECK) {
+    return Promise.resolve(null);
+  }
+  if (!cached) {
+    cached = fetchLatest(embeddedVersion);
+  }
+  return cached;
+}
+
+async function fetchLatest(embeddedVersion) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: controller.signal });
+    if (!res.ok) return null;
+    const { version: latestVersion } = await res.json();
+    const isStale = isBehind(embeddedVersion, latestVersion);
+    const status = { latestVersion, isStale };
+    if (isStale) {
+      status.message =
+        `Embedded dataset (${embeddedVersion}) is behind the latest published ` +
+        `@adobe/spectrum-design-data (${latestVersion}). Reinstall with ` +
+        `npx -y @adobe/design-data-mcp@latest to pick up the newer snapshot.`;
+      if (!warned) {
+        warned = true;
+        console.error(`[design-data] ${status.message}`);
+      }
+    }
+    return status;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Test-only: clear the memoized check + warn-once flag between cases. */
+export function __resetFreshnessCache() {
+  warned = false;
+  cached = undefined;
+}

--- a/tools/design-data-mcp/src/dataset-freshness.js
+++ b/tools/design-data-mcp/src/dataset-freshness.js
@@ -38,7 +38,8 @@ export function isBehind(embedded, latest) {
 }
 
 let warned = false;
-let cached; // Promise<status|null>, memoized per process
+let cached; // Promise<status|null>, memoized per process — cleared on failure so a
+// transient network blip doesn't permanently disable the check (see fetchLatest).
 
 /**
  * @param {string} embeddedVersion - provenance.designDataVersion from ds.primer()
@@ -49,7 +50,13 @@ export function checkDatasetFreshness(embeddedVersion) {
     return Promise.resolve(null);
   }
   if (!cached) {
-    cached = fetchLatest(embeddedVersion);
+    cached = fetchLatest(embeddedVersion).then((status) => {
+      // A null result means the check failed (offline/timeout/registry error) —
+      // don't memoize failure, so the next primer call retries instead of being
+      // stuck with no freshness signal for the rest of the process.
+      if (status === null) cached = undefined;
+      return status;
+    });
   }
   return cached;
 }

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -20,6 +20,8 @@ import { createRequire } from "module";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname, resolve, sep } from "path";
 
+import { checkDatasetFreshness } from "../dataset-freshness.js";
+
 let _wasm;
 /** Lazy-load and cache the wasm module (nodejs target, no init() required). */
 async function getWasm() {
@@ -136,6 +138,11 @@ export function createDesignDataTools() {
         // Provenance carries source + designDataVersion (the @adobe/spectrum-design-data
         // package version baked into the wasm at build time via EMBEDDED_DATA_VERSION).
         const { provenance } = ds.primer();
+        // Best-effort staleness check (spectrum-design-data-9fe.5) — silent on
+        // failure, never blocks the primer response.
+        const datasetStatus = await checkDatasetFreshness(
+          provenance.designDataVersion,
+        );
 
         return {
           // top-level source is the legacy skill-contract field; provenance.source
@@ -155,7 +162,9 @@ export function createDesignDataTools() {
           components: wasm.getFieldValues("component") ?? [],
           properties: wasm.getFieldValues("property") ?? [],
           guidelines: guidelinesSummary,
-          provenance,
+          provenance: datasetStatus
+            ? { ...provenance, datasetStatus }
+            : provenance,
         };
       },
     },

--- a/tools/design-data-mcp/test/bundle-smoke.test.js
+++ b/tools/design-data-mcp/test/bundle-smoke.test.js
@@ -48,7 +48,9 @@ function runBundleSmoke() {
     const child = spawn("node", ["src/cli.js"], {
       cwd: stagingDir,
       // Deliberately minimal env: no NODE_PATH or pnpm store — bundle must be self-contained.
-      env: { PATH: process.env.PATH },
+      // DESIGN_DATA_SKIP_VERSION_CHECK keeps this an offline test even if a future test
+      // here calls the primer tool handler (currently only initialize + tools/list run).
+      env: { PATH: process.env.PATH, DESIGN_DATA_SKIP_VERSION_CHECK: "1" },
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/tools/design-data-mcp/test/dataset-freshness.test.js
+++ b/tools/design-data-mcp/test/dataset-freshness.test.js
@@ -86,3 +86,25 @@ test.serial(
     );
   },
 );
+
+test.serial(
+  "a failed check does not permanently disable future checks (no stuck cache)",
+  async (t) => {
+    // global.fetch rejects by default (see beforeEach) — first call fails.
+    const offlineResult = await getTools()["design-data-primer"].handler({});
+    t.falsy(offlineResult.provenance.datasetStatus);
+
+    // Network "comes back" — a later primer call should retry, not stay stuck
+    // on the memoized failure.
+    global.fetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: "999.0.0" }),
+      });
+    const onlineResult = await getTools()["design-data-primer"].handler({});
+    t.true(
+      onlineResult.provenance.datasetStatus?.isStale,
+      "freshness check should retry after a prior failure, not stay cached as null",
+    );
+  },
+);

--- a/tools/design-data-mcp/test/dataset-freshness.test.js
+++ b/tools/design-data-mcp/test/dataset-freshness.test.js
@@ -1,0 +1,88 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+// Kept in its own serial test file (rather than added to design-data.test.js) because
+// every test here stubs the shared `global.fetch` and resets dataset-freshness.js's
+// module-level cache — design-data.test.js's other primer tests run concurrently and
+// would race with that shared mutable state (a separate worker process, so no
+// cross-file interference, but same-file tests still need `test.serial`).
+
+import test from "ava";
+import { createDesignDataTools } from "../src/tools/design-data.js";
+import { isBehind, __resetFreshnessCache } from "../src/dataset-freshness.js";
+
+function getTools() {
+  return Object.fromEntries(
+    createDesignDataTools().map((tool) => [tool.name, tool]),
+  );
+}
+
+test.serial.beforeEach((t) => {
+  __resetFreshnessCache();
+  t.context.savedFetch = global.fetch;
+  global.fetch = () => Promise.reject(new Error("network disabled in test"));
+});
+
+test.serial.afterEach((t) => {
+  global.fetch = t.context.savedFetch;
+  __resetFreshnessCache();
+});
+
+test.serial("isBehind: numeric major.minor.patch compare", (t) => {
+  t.true(isBehind("2.3.0", "2.6.0"));
+  t.false(isBehind("2.6.0", "2.6.0"));
+  t.false(isBehind("2.6.0", "2.3.0"));
+  t.true(isBehind("2.6", "2.6.1"));
+});
+
+test.serial(
+  "design-data-primer flags provenance.datasetStatus when embedded version is behind",
+  async (t) => {
+    global.fetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: "999.0.0" }),
+      });
+    const result = await getTools()["design-data-primer"].handler({});
+    t.true(result.provenance.datasetStatus.isStale);
+    t.is(result.provenance.datasetStatus.latestVersion, "999.0.0");
+    t.truthy(result.provenance.datasetStatus.message);
+  },
+);
+
+test.serial(
+  "design-data-primer reports datasetStatus without a message when up to date",
+  async (t) => {
+    const embeddedVersion = (await getTools()["design-data-primer"].handler({}))
+      .provenance.designDataVersion;
+    global.fetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: embeddedVersion }),
+      });
+    __resetFreshnessCache();
+    const result = await getTools()["design-data-primer"].handler({});
+    t.false(result.provenance.datasetStatus.isStale);
+    t.falsy(result.provenance.datasetStatus.message);
+  },
+);
+
+test.serial(
+  "design-data-primer still returns when the freshness check fails (offline)",
+  async (t) => {
+    // global.fetch already rejects by default (see beforeEach)
+    const result = await getTools()["design-data-primer"].handler({});
+    t.truthy(result.provenance, "primer should not throw when offline");
+    t.falsy(
+      result.provenance.datasetStatus,
+      "datasetStatus should be absent when the check fails",
+    );
+  },
+);

--- a/tools/design-data-mcp/test/design-data.test.js
+++ b/tools/design-data-mcp/test/design-data.test.js
@@ -15,6 +15,12 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { createDesignDataTools } from "../src/tools/design-data.js";
 
+// These tests call the real design-data-primer handler, which does a
+// best-effort registry.npmjs.org freshness check. Disable it here so this
+// file stays hermetic (no real network call, no flakiness in air-gapped CI)
+// — the check itself is covered by test/dataset-freshness.test.js.
+process.env.DESIGN_DATA_SKIP_VERSION_CHECK = "1";
+
 const EXPECTED_TOOLS = [
   "design-data-primer",
   "design-data-query",


### PR DESCRIPTION
## Description

Both `@adobe/design-data-mcp` and `@adobe/design-data-agent-mcp` now do a best-effort
runtime check against the npm registry each time their `primer` tool is called. If the
embedded dataset (`provenance.designDataVersion`, baked into `@adobe/design-data-wasm` at
build time) is behind the latest published `@adobe/spectrum-design-data`, the primer
response gets a `provenance.datasetStatus { latestVersion, isStale, message }` field and a
one-line warning is logged to stderr (once per process).

The check is deliberately silent on any failure — offline/air-gapped use, registry
timeouts, or errors all just result in no `datasetStatus` field, never a thrown error. Set
`DESIGN_DATA_SKIP_VERSION_CHECK=1` to disable it entirely.

- **tools/design-data-agent-mcp/src/dataset-freshness.js**: new helper — `isBehind`
  (numeric major.minor.patch compare) and `checkDatasetFreshness` (cached, 1.5s-timeout
  registry lookup, warn-once on stderr).
- **tools/design-data-agent-mcp/src/tools/read.js**: `primer` handler wires in the check.
- **tools/design-data-mcp/src/dataset-freshness.js**: same helper, duplicated (no shared
  dependency between the two servers — matches the existing duplicated primer-shape
  pattern from #1395).
- **tools/design-data-mcp/src/tools/design-data.js**: `design-data-primer` handler wires
  in the check.
- Both READMEs: document the new `datasetStatus` field and the opt-out env var.

## Related Issue

Closes spectrum-design-data-9fe.5 (follow-up to spectrum-design-data-9fe.3 / #1395, which
shipped the docs-only mitigation).

## Motivation and Context

The embedded dataset version travels with the wasm build, not the running process — a
plain `npx -y <pkg>` (no `@latest` tag) can silently reuse a cached older build with no
signal to the agent or operator (e.g. Protopack Web ran 0.16.0 while latest was 2.3.0).
#1395 mitigated this with docs/instructions; this bead builds the stronger runtime check
the team deferred in that discussion (Slack thread linked on 9fe.5).

## How Has This Been Tested?

- New unit tests for `isBehind`, and integration tests for `primer`/`design-data-primer`
  covering: stale detection, up-to-date (no message), and network failure (primer still
  returns, no `datasetStatus`). Kept in dedicated serial test files
  (`dataset-freshness.test.js`, one per package) since they stub the shared `global.fetch`
  and reset the module-level cache — following the existing `read-cascade.test.js`
  same-file-race convention.
- `moon run design-data-agent-mcp:test design-data-mcp:test` — 102 tests pass.
- Manual: ran both servers and confirmed the embedded version (2.6.0, built via moon) is
  correctly flagged as behind the latest published version (2.7.0) during the real test
  run, including the stderr warning line.

## Screenshots (if appropriate):

N/A (no UI change)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
