### PR TITLE
feat(design-data-spec): manifest extensions/ directory layout (spec+schema)

### DIFF
--- a/.changeset/manifest-extensions-directory.md
+++ b/.changeset/manifest-extensions-directory.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-spec": major
+---
+
+Redefine platform-manifest `extensions` as a sibling `extensions/` directory (one file
+per artifact) instead of a single inline object, so per-platform additions can scale
+past a handful of components; the reference SDK loader is not yet updated (tracked
+separately), so this change is spec+schema only in this release.
+
+- **schemas/manifest.schema.json**: removed the inline `extensions` object; a manifest
+  using the old inline shape now fails Layer 1 validation. Added optional
+  `extensionsDir` (default `"extensions"`) and promoted `namingExceptions`/`formatting`
+  to top-level manifest fields.
+- **spec/manifest.md**: documents the `extensions/` directory layout, glob discovery,
+  and merge/precedence rules (deep-merge for `tokens/`, sorted-path-order/last-wins for
+  the other catalogs, override/remove-by-uuid for `relationships/`).

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -86,7 +86,7 @@
     "extensionsDir": {
       "type": "string",
       "minLength": 1,
-      "description": "Path (relative to the manifest) to the platform's extensions directory, holding platform-local tokens/components/fields/relationships/guidelines/platform-extensions as one file per artifact (see spec/manifest.md#extensions). Default: \"extensions\"."
+      "description": "Path (relative to the manifest) to the platform's extensions directory, holding platform-local tokens/components/fields/relationships/guidelines/platform-extensions as one file per artifact (see spec/manifest.md#extensions-directory). Default: \"extensions\"."
     },
     "namingExceptions": {
       "type": "object",

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -83,122 +83,64 @@
         "additionalProperties": false
       }
     },
-    "extensions": {
+    "extensionsDir": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path (relative to the manifest) to the platform's extensions directory, holding platform-local tokens/components/fields/relationships/guidelines/platform-extensions as one file per artifact (see spec/manifest.md#extensions). Default: \"extensions\"."
+    },
+    "namingExceptions": {
       "type": "object",
-      "description": "Platform-local tokens, mode sets, and formatting rules.",
+      "description": "Platform-local overlay on the base naming-exceptions set: names to add and/or remove for this platform's naming validation.",
       "properties": {
-        "tokens": {
-          "$ref": "cascade-file.schema.json",
-          "description": "Platform-local token definitions, in cascade-format (same shape as a cascade token file)."
-        },
-        "components": {
+        "add": {
           "type": "array",
-          "items": { "$ref": "component.schema.json" },
-          "description": "Platform-local component specs, injected into the component catalog (add-or-replace by name)."
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Token names to add to the naming-exceptions set for this platform."
         },
-        "fields": {
+        "remove": {
           "type": "array",
-          "items": { "$ref": "field.schema.json" },
-          "description": "Platform-local field declarations, injected into the field catalog (add-or-replace by name)."
-        },
-        "relationships": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              { "$ref": "relationship.schema.json#/$defs/relationship" },
-              {
-                "type": "object",
-                "required": ["op", "uuid", "value"],
-                "properties": {
-                  "op": { "const": "override" },
-                  "uuid": { "type": "string", "format": "uuid" },
-                  "value": {
-                    "$ref": "relationship.schema.json#/$defs/relationship"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "required": ["op", "uuid"],
-                "properties": {
-                  "op": { "const": "remove" },
-                  "uuid": { "type": "string", "format": "uuid" }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
-          "description": "Platform-local Component/Token Relationship (CTR) add/override/remove. Entries without \"op\" are added positionally; \"override\"/\"remove\" require a \"uuid\" to target an existing relationship."
-        },
-        "platformExtensions": {
-          "type": "array",
-          "items": {
-            "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/platform-extension.json"
-          },
-          "description": "Platform-local terminology extensions (e.g. iOS state vocabulary), annotating ids in an existing base registry."
-        },
-        "guidelines": {
-          "type": "array",
-          "items": { "$ref": "guideline.schema.json" },
-          "description": "Platform-local guideline docs, injected into the guideline catalog (add-or-replace by name)."
-        },
-        "namingExceptions": {
-          "type": "object",
-          "description": "Platform-local overlay on the base naming-exceptions set: names to add and/or remove for this platform's naming validation.",
-          "properties": {
-            "add": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 },
-              "description": "Token names to add to the naming-exceptions set for this platform."
-            },
-            "remove": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 },
-              "description": "Token names to remove from the base naming-exceptions set for this platform."
-            }
-          },
-          "additionalProperties": false
-        },
-        "formatting": {
-          "type": "object",
-          "description": "Rules for serializing structured name objects into platform-specific token name strings.",
-          "properties": {
-            "conceptOrder": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "uniqueItems": true,
-              "description": "Ordered list of field names for serialization. Values must match declared field names from the design system's field catalog (field.schema.json declarations). Replaces the default serialization.position order from each field declaration."
-            },
-            "casing": {
-              "type": "string",
-              "enum": [
-                "kebab-case",
-                "camelCase",
-                "PascalCase",
-                "SCREAMING_SNAKE_CASE"
-              ],
-              "description": "Casing style for serialized token names. Default: kebab-case."
-            },
-            "delimiter": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Character(s) separating concepts in the serialized string. Default: -."
-            },
-            "abbreviations": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Map of full term to abbreviated form, applied after ordering and before casing."
-            }
-          },
-          "additionalProperties": false
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Token names to remove from the base naming-exceptions set for this platform."
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "formatting": {
+      "type": "object",
+      "description": "Rules for serializing structured name objects into platform-specific token name strings.",
+      "properties": {
+        "conceptOrder": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "Ordered list of field names for serialization. Values must match declared field names from the design system's field catalog (field.schema.json declarations). Replaces the default serialization.position order from each field declaration."
+        },
+        "casing": {
+          "type": "string",
+          "enum": [
+            "kebab-case",
+            "camelCase",
+            "PascalCase",
+            "SCREAMING_SNAKE_CASE"
+          ],
+          "description": "Casing style for serialized token names. Default: kebab-case."
+        },
+        "delimiter": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Character(s) separating concepts in the serialized string. Default: -."
+        },
+        "abbreviations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of full term to abbreviated form, applied after ordering and before casing."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/packages/design-data-spec/spec/manifest-schema-override-spike.md
+++ b/packages/design-data-spec/spec/manifest-schema-override-spike.md
@@ -24,9 +24,12 @@ schemas for its own data?
 3. **No concrete need surfaced.** Nothing in the h890.22/h890.23 work (iOS
    externalization, or the guidelines/fields/relationships/naming-exceptions cascade
    additions) needed schema relaxation — every platform-local addition validates fine
-   against the existing schemas via `extensions.*`. The `extensions` object is already
-   `additionalProperties: true`, which covers "the platform wants to attach data the
-   schema doesn't know about" without touching the schema itself.
+   against the existing per-artifact schemas via the `extensions/` directory (see
+   [Manifest — `extensions/` directory](manifest.md#extensions-directory)). Each fragment
+   file there is checked against the same `component.schema.json` /
+   `field.schema.json` / `guideline.schema.json` / etc. as the foundation dataset, which
+   already covers "the platform wants to attach data the schema knows how to validate"
+   without touching the schema itself.
 
 ## Decision
 

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -8,23 +8,23 @@ This document defines the **platform manifest**: how a platform implementation r
 
 The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; translations and schemas have no manifest-level override mechanism at all.
 
-| Operation                                          | Supported?                                                   | Field                           | Applies to            |
-| -------------------------------------------------- | ------------------------------------------------------------ | ------------------------------- | --------------------- |
-| Remove / exclude                                   | Yes                                                          | `exclude`                       | Tokens only           |
-| Include / whitelist                                | Yes                                                          | `include`                       | Tokens only           |
-| Override value (type-preserving)                   | Yes                                                          | `overrides[].value`             | Tokens only           |
-| Override → re-alias                                | Yes                                                          | `overrides[].$ref`              | Tokens only           |
-| Add new tokens (may alias via `$ref`)              | Yes                                                          | `extensions.tokens`             | Tokens                |
-| Add / replace components                           | Yes                                                          | `extensions.components`         | Components            |
-| Add / replace field declarations                   | Yes                                                          | `extensions.fields`             | Fields                |
-| Add / replace guideline documents                  | Yes                                                          | `extensions.guidelines`         | Guidelines            |
-| Add relationships/CTRs; override/remove by `uuid`  | Yes                                                          | `extensions.relationships`      | Relationships (CTRs)  |
-| Add / remove naming exceptions                     | Yes                                                          | `extensions.namingExceptions`   | Naming validation     |
-| Annotate existing terminology (cannot add new ids) | Yes                                                          | `extensions.platformExtensions` | Existing registry ids |
-| Restrict allowed mode-set values                   | Yes                                                          | `modeSetRestrictions`           | Mode sets             |
-| Reformat name serialization                        | Schema-declared only, not yet applied by the reference SDK   | `extensions.formatting`         | Token name strings    |
-| Override/remove/alias translations                 | No                                                           | —                               | —                     |
-| Override Layer-1 schemas                           | No (decided; see [spike](manifest-schema-override-spike.md)) | —                               | —                     |
+| Operation                                          | Supported?                                                   | Field                             | Applies to            |
+| -------------------------------------------------- | ------------------------------------------------------------ | --------------------------------- | --------------------- |
+| Remove / exclude                                   | Yes                                                          | `exclude`                         | Tokens only           |
+| Include / whitelist                                | Yes                                                          | `include`                         | Tokens only           |
+| Override value (type-preserving)                   | Yes                                                          | `overrides[].value`               | Tokens only           |
+| Override → re-alias                                | Yes                                                          | `overrides[].$ref`                | Tokens only           |
+| Add new tokens (may alias via `$ref`)              | Yes                                                          | `extensions/tokens/`              | Tokens                |
+| Add / replace components                           | Yes                                                          | `extensions/components/`          | Components            |
+| Add / replace field declarations                   | Yes                                                          | `extensions/fields/`              | Fields                |
+| Add / replace guideline documents                  | Yes                                                          | `extensions/guidelines/`          | Guidelines            |
+| Add relationships/CTRs; override/remove by `uuid`  | Yes                                                          | `extensions/relationships/`       | Relationships (CTRs)  |
+| Add / remove naming exceptions                     | Yes                                                          | `namingExceptions`                | Naming validation     |
+| Annotate existing terminology (cannot add new ids) | Yes                                                          | `extensions/platform-extensions/` | Existing registry ids |
+| Restrict allowed mode-set values                   | Yes                                                          | `modeSetRestrictions`             | Mode sets             |
+| Reformat name serialization                        | Schema-declared only, not yet applied by the reference SDK   | `formatting`                      | Token name strings    |
+| Override/remove/alias translations                 | No                                                           | —                                 | —                     |
+| Override Layer-1 schemas                           | No (decided; see [spike](manifest-schema-override-spike.md)) | —                                 | —                     |
 
 ## Manifest document
 
@@ -39,13 +39,15 @@ A manifest **MUST** conform to [`manifest.schema.json`](../schemas/manifest.sche
 
 ## Optional fields
 
-| Field                 | Type            | Description                                                                                                                                                                                                       |
-| --------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                                                                       |
-| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                                                                    |
-| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                                                                  |
-| `extensions`          | object          | Platform-local additions layered on top of foundation — `tokens`, `components`, `fields`, `guidelines`, `relationships`, `namingExceptions`, `platformExtensions`, `formatting` (see `extensions` section below). |
-| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                                                                             |
+| Field                 | Type            | Description                                                                                                                                                     |
+| --------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `include`             | array of string | Semantic **queries** selecting subsets of foundation tokens to materialize.                                                                                     |
+| `exclude`             | array of string | Queries removing tokens from the included set.                                                                                                                  |
+| `overrides`           | array of object | Typed overrides; each entry **MUST** preserve the target token’s **value type**.                                                                                |
+| `extensionsDir`       | string          | Path (relative to the manifest) to the platform's `extensions/` directory. Default: `"extensions"`. See [`extensions/` directory](#extensions-directory) below. |
+| `namingExceptions`    | object          | Platform-local overlay on the base naming-exceptions set: names to add and/or remove for this platform's naming validation.                                     |
+| `formatting`          | object          | Rules for serializing structured name objects into platform-specific token name strings.                                                                        |
+| `modeSetRestrictions` | object          | Mode set restrictions for this platform; see [Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions).                                           |
 
 ### `include` / `exclude`
 
@@ -71,41 +73,68 @@ apply `Foundation < Platform < Product` precedence to select a single winner. To
 counts "tokens a platform ships" from `query` output should resolve first, or it will
 double-count overridden tokens.
 
-### `extensions`
+### `extensions/` directory
 
-**RECOMMENDED:** `extensions` follows the same structural conventions as foundation token files (tokens, mode sets) and **SHOULD** be validated with the same Layer 1 and Layer 2 rules.
+**NORMATIVE:** Platform-local additions are declared as a sibling **directory** next to
+`manifest.json` (default name `extensions/`; override with the top-level `extensionsDir`
+field), not as an inline object in the manifest. This mirrors how the foundation dataset
+(`packages/design-data/`) splits its own catalogs into one file per artifact, and lets a
+platform's extension set grow without every addition colliding in one JSON object.
 
-#### `extensions.tokens`
+```
+extensions/
+  tokens/               *.tokens.json          cascade-format token files
+  components/           <component>.json       one component per file
+  fields/                <field>.json          one field declaration per file
+  relationships/         <component>.json      one CTR set per file
+  guidelines/             <topic>.json         one guideline per file
+  platform-extensions/   <platform>-<registry>.json
+```
 
-Platform-local token definitions, in cascade-file format. Inserted at the platform layer alongside (not replacing) foundation tokens; entries **MAY** carry a `$ref` to alias an existing token instead of a literal value.
+**NORMATIVE:** Each subdirectory is discovered by a recursive glob for `*.json` files (for
+`tokens/`, `**/*.tokens.json`), with no index file — the same convention used by
+`discover_json_files` in `sdk/core/src/discovery.rs` for the foundation dataset. Matched files
+are processed in **sorted path order**; this is the sole basis for precedence below. A missing
+or empty subdirectory contributes nothing and is not an error.
 
-#### `extensions.components`
+**NORMATIVE:** Merge semantics by subdirectory:
 
-Platform-local component specs, injected into the component catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by component `name` at the platform layer.
+* **`tokens/`** — every `*.tokens.json` file is cascade-format (same shape as a foundation
+  cascade token file). Files are **deep-merged** into one tokens object, in sorted path order.
+  Entries **MAY** carry a `$ref` to alias an existing token instead of a literal value.
+* **`components/`, `fields/`, `guidelines/`, `platform-extensions/`** — one artifact per file.
+  Entries across all files in the subdirectory are concatenated, in sorted path order, and
+  injected into the corresponding catalog **add-or-replace by name** (for
+  `platform-extensions/`, by `termId`; see below). When two files declare the same name,
+  **the entry from the later file (in sorted path order) wins.**
+* **`relationships/`** — Component/Token Relationship (CTR) entries. Relationships have no
+  inherent stable key — only an optional `uuid` — so add and override/remove use different
+  identity rules:
+  * **Add:** an entry with no `op` field is a full relationship object (validated against
+    `relationship.schema.json`), appended at the platform layer, in sorted path order.
+  * **Override / remove:** targeting an existing relationship **MUST** carry a `uuid`.
+    **NORMATIVE:** an entry with `"op": "override"` or `"op": "remove"` that omits `uuid` is a
+    manifest error — the reference SDK rejects it rather than silently skipping it. `"op":
+    "override"` also carries a `value` (the replacement relationship object); `"op": "remove"`
+    drops the matching record. Override/remove ops apply, in sorted path order, against the
+    accumulated set of added relationships (across all files, foundation and platform-local).
 
-#### `extensions.fields`
+#### `extensions/fields/`
 
-Platform-local field declarations, injected into the field catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by field `name` at the platform layer; each entry **MUST** validate against `field.schema.json`. Note: `extensions.formatting.conceptOrder` (if declared) references field names by string — a platform that renames or removes a field it also references there is self-inconsistent; that is a manifest-authoring concern, not enforced by the reference SDK.
+Platform-local field declarations, injected into the field catalog. **NORMATIVE:** each file
+**MUST** validate against `field.schema.json`. Note: a top-level `formatting.conceptOrder` (if
+declared) references field names by string — a platform that renames or removes a field it
+also references there is self-inconsistent; that is a manifest-authoring concern, not enforced
+by the reference SDK.
 
-#### `extensions.guidelines`
+#### `extensions/platform-extensions/`
 
-Platform-local guideline documents, injected into the guideline catalog. **NORMATIVE:** the reference SDK applies these add-or-replace by guideline `name` at the platform layer; each entry **MUST** validate against `guideline.schema.json`.
+Platform terminology annotations layered onto **existing** foundation registry entries (for
+example, platform-specific state names). **NORMATIVE:** every `termId` **MUST** already exist
+in the referenced foundation registry — this mechanism annotates existing ids, it does **NOT**
+introduce new ones.
 
-#### `extensions.relationships`
-
-Platform-local Component/Token Relationship (CTR) entries. Relationships have no inherent
-stable key — only an optional `uuid` — so add and override/remove use different identity
-rules:
-
-* **Add:** an entry with no `op` field is a full relationship object (validated against
-  `relationship.schema.json`), appended at the platform layer.
-* **Override / remove:** relationships have no other stable identity, so targeting one
-  **MUST** carry a `uuid`. **NORMATIVE:** an `extensions.relationships` entry with `"op":
-  "override"` or `"op": "remove"` that omits `uuid` is a manifest error — the reference SDK
-  rejects it rather than silently skipping it. `"op": "override"` also carries a `value` (the
-  replacement relationship object); `"op": "remove"` drops the matching record.
-
-#### `extensions.namingExceptions`
+### `namingExceptions`
 
 Platform-local overlay on the base naming-exceptions set used by naming validation.
 **NORMATIVE:** the reference SDK applies `remove` before `add`, so a name listed in both
@@ -117,11 +146,7 @@ ends up present (add wins) rather than silently dropped. Absent this key, the ba
 | `add`    | array of string | Names to add to the naming-exceptions set for this platform. |
 | `remove` | array of string | Names to remove from the base naming-exceptions set.         |
 
-#### `extensions.platformExtensions`
-
-Platform terminology annotations layered onto **existing** foundation registry entries (for example, platform-specific state names). **NORMATIVE:** every `termId` **MUST** already exist in the referenced foundation registry — this mechanism annotates existing ids, it does **NOT** introduce new ones.
-
-#### `extensions.formatting`
+### `formatting`
 
 A platform **MAY** declare formatting rules that control how structured name objects are serialized into flat token name strings for that platform. See [Taxonomy — Platform formatting configuration](taxonomy.md#platform-formatting-configuration) for motivation and examples.
 
@@ -132,9 +157,9 @@ A platform **MAY** declare formatting rules that control how structured name obj
 | `delimiter`     | string          | Character(s) separating concepts in the serialized string (e.g. `-`, `_`, `.`, `/`). Default: `-`.                                                                                                                                                                                                                                                                                                                                     |
 | `abbreviations` | object          | Map of full term → abbreviated form (e.g. `{ "background": "bg" }`). Abbreviations are applied after concept ordering and before casing.                                                                                                                                                                                                                                                                                               |
 
-**NORMATIVE:** When `extensions.formatting` is absent, the default serialization defined in [Taxonomy](taxonomy.md#default-serialization-legacy-format) is used.
+**NORMATIVE:** When `formatting` is absent, the default serialization defined in [Taxonomy](taxonomy.md#default-serialization-legacy-format) is used.
 
-**NORMATIVE:** A formatter applying `extensions.formatting` **MUST** produce deterministic output — the same name object and formatting configuration **MUST** always yield the same string.
+**NORMATIVE:** A formatter applying `formatting` **MUST** produce deterministic output — the same name object and formatting configuration **MUST** always yield the same string.
 
 ## Validation
 

--- a/packages/design-data-spec/spec/product-context.md
+++ b/packages/design-data-spec/spec/product-context.md
@@ -98,7 +98,7 @@ The `extensions` object contains net-new tokens and components that do not exist
 **RECOMMENDED:** Agent tools that create or modify product-layer tokens (`write_token`, `write_component`) **SHOULD** capture a `rationale` from session context and record it in:
 
 1. The token's inline `rationale` field (see [Token format — rationale](token-format.md#lifecycle-and-metadata)).
-2. The product context document's `overrides[].rationale` (for overrides) or an `extensions/tokens/` entry's `rationale` (for new tokens).
+2. The product context document's `overrides[].rationale` (for overrides) or `extensions.tokens[].rationale` (for new tokens).
 
 This makes the product context document self-maintaining during agent-assisted authoring sessions.
 

--- a/packages/design-data-spec/spec/product-context.md
+++ b/packages/design-data-spec/spec/product-context.md
@@ -98,7 +98,7 @@ The `extensions` object contains net-new tokens and components that do not exist
 **RECOMMENDED:** Agent tools that create or modify product-layer tokens (`write_token`, `write_component`) **SHOULD** capture a `rationale` from session context and record it in:
 
 1. The token's inline `rationale` field (see [Token format — rationale](token-format.md#lifecycle-and-metadata)).
-2. The product context document's `overrides[].rationale` (for overrides) or `extensions.tokens[].rationale` (for new tokens).
+2. The product context document's `overrides[].rationale` (for overrides) or an `extensions/tokens/` entry's `rationale` (for new tokens).
 
 This makes the product context document self-maintaining during agent-assisted authoring sessions.
 

--- a/packages/design-data-spec/spec/taxonomy.md
+++ b/packages/design-data-spec/spec/taxonomy.md
@@ -282,7 +282,7 @@ This ordering is preserved for backward compatibility with the current `@adobe/s
 
 ## Platform formatting configuration
 
-A platform [manifest](manifest.md) **MAY** declare formatting rules in its [`extensions.formatting`](manifest.md#extensionsformatting) section to control concept ordering, casing, delimiters, and abbreviations. The normative contract for these fields is defined in [Manifest — `extensions.formatting`](manifest.md#extensionsformatting).
+A platform [manifest](manifest.md) **MAY** declare formatting rules in its top-level [`formatting`](manifest.md#formatting) field to control concept ordering, casing, delimiters, and abbreviations. The normative contract for these fields is defined in [Manifest — `formatting`](manifest.md#formatting).
 
 When no platform formatting is declared, the default serialization above is used.
 
@@ -338,5 +338,5 @@ node tools/token-corpus-migrate/src/cli.js \
 * [#806 — Token Taxonomy, Vocabulary, and Formatting](https://github.com/adobe/spectrum-design-data/discussions/806)
 * [#661 — Spectrum Design System Glossary](https://github.com/adobe/spectrum-design-data/discussions/661)
 * [#646 — Token Schema Structure and Validation System](https://github.com/adobe/spectrum-design-data/discussions/646)
-* [Manifest — `extensions.formatting`](manifest.md#extensionsformatting) — normative contract for platform formatting rules
+* [Manifest — `formatting`](manifest.md#formatting) — normative contract for platform formatting rules
 * Nate Baldwin, "Naming conventions & shared taxonomy" — Design Data & Platforms onsite, April 1, 2026


### PR DESCRIPTION
## Description

Redefines the platform-manifest `extensions` from a single inline object in
`manifest.json` into a sibling `extensions/` directory, mirroring how the
foundation dataset (`packages/design-data/`) splits its own catalogs into one
file per artifact.

Spec + schema changes only — split-only/breaking per team decision (no dual
inline+directory support).

## Related Issue

Part of spectrum-design-data-h890.26 (Manifest: allow extensions split across
multiple files). Closes spectrum-design-data-h890.26.1.

## Motivation and Context

A single inline `extensions` object doesn't scale — `spectrum-ios-design-data`
already has fewer than 10 components crammed into one object. Decided in a
Slack thread with Josh Johnson (2026-09-04) to split extensions across
multiple files, patterned off how the foundation dataset itself is organized.

## How Has This Been Tested?

- `node -e "JSON.parse(...)"` confirms `manifest.schema.json` is still valid JSON.
- `moon run design-data-spec:check` (the package's only check/test task — no
  AVA suite exists in this package) passes.
- Grepped the repo for stray `extensions.tokens` / `.components` / `.fields` /
  `.guidelines` / `.relationships` / `.namingExceptions` / `.platformExtensions`
  / `.formatting` references and fixed the two that were stale
  (`taxonomy.md`, `product-context.md`).

Not yet updated (tracked in separate blocked beads):
- `sdk/core/src/manifest.rs` / `graph.rs` loader (spectrum-design-data-h890.26.2)
- Conformance fixtures / Rust unit tests exercising the old inline shape
  (spectrum-design-data-h890.26.4)
- ios-override-importer + repo template migration (spectrum-design-data-h890.26.5)
- Changeset (spectrum-design-data-h890.26.6, once the full split lands)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
