### PR TITLE
feat(design-data-core): SDK loader glob+merge for manifest extensions/ dir

### DIFF
--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -18,10 +18,23 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use serde_json::{Map, Value};
+
 use crate::data_source::ResolvedData;
+use crate::discovery::discover_json_files;
 use crate::graph::TokenGraph;
 use crate::schema::SchemaRegistry;
 use crate::CoreError;
+
+/// Category subdirectories concatenated verbatim (sorted path order) into the
+/// merged `extensions` object, keyed by directory name → manifest JSON key.
+/// `tokens/` and `relationships/` have their own handling below and aren't here.
+const CONCAT_CATEGORIES: &[(&str, &str)] = &[
+    ("components", "components"),
+    ("fields", "fields"),
+    ("guidelines", "guidelines"),
+    ("platform-extensions", "platformExtensions"),
+];
 
 /// Locate `packages/design-data-spec/schemas/manifest.schema.json` by walking up
 /// from `schemas_root`.
@@ -52,7 +65,7 @@ pub fn apply_configured(
             manifest_path.display()
         ))
     })?;
-    let manifest: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+    let mut manifest: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
         CoreError::ParseError(format!(
             "failed to parse platform manifest {}: {e}",
             manifest_path.display()
@@ -76,8 +89,115 @@ pub fn apply_configured(
         )));
     }
 
+    // Layer 2's `extensions/` directory (spec/manifest.md#extensions-directory) is
+    // glob+merged into the same `extensions` object shape the schema used to allow
+    // inline, then spliced in post-validation — the manifest.json on disk no longer
+    // carries `extensions` at all under the 26.1 schema, so validation above runs
+    // clean, and `apply_platform_manifest` below is none the wiser.
+    if let Some(ext) = build_extensions_value(manifest_path, &manifest)? {
+        manifest
+            .as_object_mut()
+            .expect("manifest.json root is a JSON object (enforced by Layer 1 schema)")
+            .insert("extensions".to_string(), ext);
+    }
+
     let outcome = graph.apply_platform_manifest(&manifest)?;
     Ok(outcome.mode_set_restrictions)
+}
+
+/// Glob+merge the Layer 2 manifest's `extensions/` directory (default name
+/// `"extensions"`, overridable via the manifest's `extensionsDir` field) into the
+/// merged `extensions` `Value` [`TokenGraph::apply_platform_manifest`] expects.
+///
+/// Returns `Ok(None)` when the directory doesn't exist (or exists but every
+/// category subdirectory is missing/empty) — this is not an error; a platform
+/// with no extensions simply omits the directory.
+///
+/// See `packages/design-data-spec/spec/manifest.md#extensions-directory` for the
+/// normative discovery/merge/precedence rules this implements.
+fn build_extensions_value(
+    manifest_path: &Path,
+    manifest: &Value,
+) -> Result<Option<Value>, CoreError> {
+    let dir_name = manifest
+        .get("extensionsDir")
+        .and_then(|v| v.as_str())
+        .unwrap_or("extensions");
+    let ext_root = manifest_path
+        .parent()
+        .map_or_else(|| PathBuf::from(dir_name), |p| p.join(dir_name));
+    if !ext_root.is_dir() {
+        return Ok(None);
+    }
+
+    let mut out = Map::new();
+
+    // tokens/ — *.tokens.json cascade-format files, concatenated in sorted path
+    // order into one array (cascade token files are themselves top-level arrays,
+    // which is exactly what `apply_platform_manifest` reads for `extensions.tokens`).
+    let tokens_dir = ext_root.join("tokens");
+    if tokens_dir.is_dir() {
+        let files: Vec<PathBuf> = discover_json_files(&tokens_dir)?
+            .into_iter()
+            .filter(|p| p.to_string_lossy().ends_with(".tokens.json"))
+            .collect();
+        let tokens = load_and_concat(&files)?;
+        if !tokens.is_empty() {
+            out.insert("tokens".to_string(), Value::Array(tokens));
+        }
+    }
+
+    // components/, fields/, guidelines/, platform-extensions/ — one artifact per
+    // file (though a file holding an array of several is tolerated too), all files
+    // in the subdirectory concatenated in sorted path order.
+    for (dir_name, key) in CONCAT_CATEGORIES {
+        let dir = ext_root.join(dir_name);
+        if !dir.is_dir() {
+            continue;
+        }
+        let items = load_and_concat(&discover_json_files(&dir)?)?;
+        if !items.is_empty() {
+            out.insert((*key).to_string(), Value::Array(items));
+        }
+    }
+
+    // relationships/ — plain adds (no "op") must precede override/remove ops, so
+    // that an override/remove in a later-sorted file can still target an add from
+    // an earlier one; `apply_platform_manifest` processes this array strictly in
+    // order. Partition is stable: within each group, sorted-path order is kept.
+    let rel_dir = ext_root.join("relationships");
+    if rel_dir.is_dir() {
+        let items = load_and_concat(&discover_json_files(&rel_dir)?)?;
+        if !items.is_empty() {
+            let (mut adds, ops): (Vec<Value>, Vec<Value>) =
+                items.into_iter().partition(|v| v.get("op").is_none());
+            adds.extend(ops);
+            out.insert("relationships".to_string(), Value::Array(adds));
+        }
+    }
+
+    Ok((!out.is_empty()).then_some(Value::Object(out)))
+}
+
+/// Read and parse each file in `files`, flattening top-level arrays (cascade
+/// token files, or a fragment file holding several entries) and pushing bare
+/// objects as-is, preserving `files`' order throughout.
+fn load_and_concat(files: &[PathBuf]) -> Result<Vec<Value>, CoreError> {
+    let mut out = Vec::new();
+    for f in files {
+        let text = std::fs::read_to_string(f)?;
+        let val: Value = serde_json::from_str(&text).map_err(|e| {
+            CoreError::ParseError(format!(
+                "failed to parse extension fragment {}: {e}",
+                f.display()
+            ))
+        })?;
+        match val {
+            Value::Array(items) => out.extend(items),
+            other => out.push(other),
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -141,6 +261,34 @@ mod tests {
                 }),
             ),
         ])
+    }
+
+    /// Write `manifest.json` (specVersion/foundationVersion plus any `extra`
+    /// top-level fields — e.g. `extensionsDir`) and, for each `(subdir, filename,
+    /// content)` triple, a fragment file under `<dir>/extensions/<subdir>/<filename>`.
+    /// Returns the manifest path. `content` is written as-is, so pass a JSON array
+    /// for `tokens/`/`relationships/` fixtures that need several entries in one file.
+    fn write_manifest_with_extensions(
+        dir: &Path,
+        extra: Value,
+        files: &[(&str, &str, Value)],
+    ) -> PathBuf {
+        let mut manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+        });
+        if let Value::Object(extra) = extra {
+            manifest.as_object_mut().unwrap().extend(extra);
+        }
+        let manifest_path = dir.join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+        for (subdir, filename, content) in files {
+            let sub = dir.join("extensions").join(subdir);
+            std::fs::create_dir_all(&sub).unwrap();
+            std::fs::write(sub.join(filename), content.to_string()).unwrap();
+        }
+        manifest_path
     }
 
     #[test]
@@ -234,24 +382,20 @@ mod tests {
     #[test]
     fn manifest_injects_platform_component() {
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "components": [{
-                        "$id": "tab-bar-ios",
-                        "name": "tab-bar-ios",
-                        "displayName": "Tab Bar (iOS)",
-                        "meta": {"category": "navigation", "documentationUrl": "https://example.com"}
-                    }]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "components",
+                "tab-bar-ios.json",
+                json!({
+                    "$id": "tab-bar-ios",
+                    "name": "tab-bar-ios",
+                    "displayName": "Tab Bar (iOS)",
+                    "meta": {"category": "navigation", "documentationUrl": "https://example.com"}
+                }),
+            )],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -267,23 +411,19 @@ mod tests {
     #[test]
     fn manifest_injects_platform_extension() {
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "platformExtensions": [{
-                        "platform": "iOS",
-                        "extends": "states",
-                        "extensions": [{"termId": "default", "platformTerm": "normal"}]
-                    }]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "platform-extensions",
+                "ios-states.json",
+                json!({
+                    "platform": "iOS",
+                    "extends": "states",
+                    "extensions": [{"termId": "default", "platformTerm": "normal"}]
+                }),
+            )],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -299,26 +439,22 @@ mod tests {
     #[test]
     fn manifest_injects_platform_field() {
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "fields": [{
-                        "name": "hapticStyle",
-                        "kind": "semantic",
-                        "registry": null,
-                        "validation": "none",
-                        "serialization": {"position": 9},
-                        "required": false
-                    }]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "fields",
+                "hapticStyle.json",
+                json!({
+                    "name": "hapticStyle",
+                    "kind": "semantic",
+                    "registry": null,
+                    "validation": "none",
+                    "serialization": {"position": 9},
+                    "required": false
+                }),
+            )],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -334,27 +470,23 @@ mod tests {
     #[test]
     fn manifest_injects_platform_guideline() {
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "guidelines": [{
-                        "$id": "https://example.com/guidelines/ios-haptics",
-                        "name": "ios-haptics",
-                        "title": "iOS Haptics",
-                        "category": "developing",
-                        "documentBlocks": [
-                            {"type": "purpose", "content": "When to use haptic feedback on iOS."}
-                        ]
-                    }]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "guidelines",
+                "ios-haptics.json",
+                json!({
+                    "$id": "https://example.com/guidelines/ios-haptics",
+                    "name": "ios-haptics",
+                    "title": "iOS Haptics",
+                    "category": "developing",
+                    "documentBlocks": [
+                        {"type": "purpose", "content": "When to use haptic feedback on iOS."}
+                    ]
+                }),
+            )],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -370,23 +502,19 @@ mod tests {
     #[test]
     fn manifest_injects_platform_relationship() {
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "relationships": [{
-                        "scope": {"component": "button", "property": "corner-radius"},
-                        "value": "4px",
-                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                    }]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "relationships",
+                "button.json",
+                json!({
+                    "scope": {"component": "button", "property": "corner-radius"},
+                    "value": "4px",
+                    "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                }),
+            )],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -401,35 +529,39 @@ mod tests {
 
     #[test]
     fn manifest_overrides_relationship_by_uuid() {
+        // The override file sorts *before* the add file alphabetically
+        // ("a-override.json" < "z-add.json"), which would misorder a naive
+        // sorted-path concat — the loader's adds-before-ops partition must
+        // still land the add ahead of its override regardless of file order.
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "relationships": [
-                        {
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[
+                (
+                    "relationships",
+                    "a-override.json",
+                    json!({
+                        "op": "override",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a",
+                        "value": {
                             "scope": {"component": "button", "property": "corner-radius"},
-                            "value": "4px",
+                            "value": "8px",
                             "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                        },
-                        {
-                            "op": "override",
-                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a",
-                            "value": {
-                                "scope": {"component": "button", "property": "corner-radius"},
-                                "value": "8px",
-                                "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                            }
                         }
-                    ]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+                    }),
+                ),
+                (
+                    "relationships",
+                    "z-add.json",
+                    json!({
+                        "scope": {"component": "button", "property": "corner-radius"},
+                        "value": "4px",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                    }),
+                ),
+            ],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -450,30 +582,30 @@ mod tests {
         // "op": "override" entry may replace. Regression for a bug where
         // colliding plain adds were routed through upsert-by-uuid.
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "relationships": [
-                        {
-                            "scope": {"component": "button", "property": "corner-radius"},
-                            "value": "4px",
-                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                        },
-                        {
-                            "scope": {"component": "slider", "property": "corner-radius"},
-                            "value": "2px",
-                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                        }
-                    ]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[
+                (
+                    "relationships",
+                    "button.json",
+                    json!({
+                        "scope": {"component": "button", "property": "corner-radius"},
+                        "value": "4px",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                    }),
+                ),
+                (
+                    "relationships",
+                    "slider.json",
+                    json!({
+                        "scope": {"component": "slider", "property": "corner-radius"},
+                        "value": "2px",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                    }),
+                ),
+            ],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -493,29 +625,29 @@ mod tests {
     #[test]
     fn manifest_removes_relationship_by_uuid() {
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "relationships": [
-                        {
-                            "scope": {"component": "button", "property": "corner-radius"},
-                            "value": "4px",
-                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                        },
-                        {
-                            "op": "remove",
-                            "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
-                        }
-                    ]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[
+                (
+                    "relationships",
+                    "button.json",
+                    json!({
+                        "scope": {"component": "button", "property": "corner-radius"},
+                        "value": "4px",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                    }),
+                ),
+                (
+                    "relationships",
+                    "remove-button.json",
+                    json!({
+                        "op": "remove",
+                        "uuid": "9c858f9c-1d90-4f1a-8c1a-1f1a1f1a1f1a"
+                    }),
+                ),
+            ],
+        );
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
@@ -528,51 +660,176 @@ mod tests {
 
     #[test]
     fn manifest_rejects_relationship_override_without_uuid() {
+        // Under the extensions/ directory layout, manifest.json itself no longer
+        // carries `extensions` (schema forbids it — see PR #1420), so there's no
+        // more inline-schema rejection path for this. It's now
+        // `apply_platform_manifest` (graph.rs) that rejects an override/remove
+        // entry missing "uuid", once the loader has spliced the fragment in.
         let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
-        std::fs::write(
-            &manifest_path,
-            json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "relationships": [{
-                        "op": "override",
-                        "value": {
-                            "scope": {"component": "button", "property": "corner-radius"},
-                            "value": "8px"
-                        }
-                    }]
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "relationships",
+                "bad-override.json",
+                json!({
+                    "op": "override",
+                    "value": {
+                        "scope": {"component": "button", "property": "corner-radius"},
+                        "value": "8px"
+                    }
+                }),
+            )],
+        );
 
-        // Layer 1 schema requires "uuid" alongside "op": "override", so this is
-        // rejected at schema validation, before graph.rs's own uuid check runs.
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
         let err = apply_configured(&mut graph, &resolved).unwrap_err();
-        assert!(err.to_string().contains("schema validation"));
+        assert!(err.to_string().contains("missing a \"uuid\""));
     }
 
     #[test]
     fn manifest_rejects_unknown_term_id() {
         let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "platform-extensions",
+                "ios-states.json",
+                json!({
+                    "platform": "iOS",
+                    "extends": "states",
+                    "extensions": [{"termId": "not-a-real-state"}]
+                }),
+            )],
+        );
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("not-a-real-state"));
+    }
+
+    #[test]
+    fn missing_extensions_dir_is_noop_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // No `extensions/` directory at all next to manifest.json.
+        let manifest_path = write_manifest_with_extensions(dir.path(), json!({}), &[]);
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let restrictions = apply_configured(&mut graph, &resolved).unwrap();
+        assert!(restrictions.is_empty());
+        assert_eq!(graph.tokens.len(), 3, "no extensions injected");
+    }
+
+    #[test]
+    fn tokens_dir_concatenates_multiple_tokens_json_files_in_sorted_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[
+                (
+                    "tokens",
+                    "a.tokens.json",
+                    json!([{
+                        "name": {"property": "elevation", "component": "card"},
+                        "value": "4dp",
+                        "uuid": "u-card-elev"
+                    }]),
+                ),
+                (
+                    "tokens",
+                    "b.tokens.json",
+                    json!([{
+                        "name": {"property": "elevation", "component": "sheet"},
+                        "value": "8dp",
+                        "uuid": "u-sheet-elev"
+                    }]),
+                ),
+            ],
+        );
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let injected: Vec<_> = graph
+            .tokens
+            .values()
+            .filter(|t| t.layer == crate::graph::Layer::Platform)
+            .collect();
+        assert_eq!(injected.len(), 2, "both tokens.json files injected");
+        assert!(injected
+            .iter()
+            .any(|t| t.uuid.as_deref() == Some("u-card-elev")));
+        assert!(injected
+            .iter()
+            .any(|t| t.uuid.as_deref() == Some("u-sheet-elev")));
+    }
+
+    #[test]
+    fn later_file_wins_on_duplicate_component_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[
+                (
+                    "components",
+                    "a-tab-bar-ios.json",
+                    json!({
+                        "$id": "tab-bar-ios",
+                        "name": "tab-bar-ios",
+                        "displayName": "First",
+                        "meta": {"category": "navigation", "documentationUrl": "https://example.com"}
+                    }),
+                ),
+                (
+                    "components",
+                    "b-tab-bar-ios.json",
+                    json!({
+                        "$id": "tab-bar-ios",
+                        "name": "tab-bar-ios",
+                        "displayName": "Second",
+                        "meta": {"category": "navigation", "documentationUrl": "https://example.com"}
+                    }),
+                ),
+            ],
+        );
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+        let matching: Vec<_> = graph
+            .components
+            .iter()
+            .filter(|c| c.name == "tab-bar-ios")
+            .collect();
+        assert_eq!(matching.len(), 1, "add-or-replace by name, not two entries");
+        assert_eq!(matching[0].raw["displayName"], "Second");
+    }
+
+    #[test]
+    fn extensions_dir_field_overrides_default_directory_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensionsDir": "platform-extras",
+        });
         let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+        let components_dir = dir.path().join("platform-extras").join("components");
+        std::fs::create_dir_all(&components_dir).unwrap();
         std::fs::write(
-            &manifest_path,
+            components_dir.join("tab-bar-ios.json"),
             json!({
-                "specVersion": "1.0.0-draft",
-                "foundationVersion": "1.0.0",
-                "extensions": {
-                    "platformExtensions": [{
-                        "platform": "iOS",
-                        "extends": "states",
-                        "extensions": [{"termId": "not-a-real-state"}]
-                    }]
-                }
+                "$id": "tab-bar-ios",
+                "name": "tab-bar-ios",
+                "displayName": "Tab Bar (iOS)",
+                "meta": {"category": "navigation", "documentationUrl": "https://example.com"}
             })
             .to_string(),
         )
@@ -580,7 +837,7 @@ mod tests {
 
         let mut graph = make_graph();
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
-        let err = apply_configured(&mut graph, &resolved).unwrap_err();
-        assert!(err.to_string().contains("not-a-real-state"));
+        apply_configured(&mut graph, &resolved).unwrap();
+        assert!(graph.components.iter().any(|c| c.name == "tab-bar-ios"));
     }
 }

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -16,7 +16,7 @@
 //! [`TokenGraph::apply_platform_manifest`](crate::graph::TokenGraph::apply_platform_manifest).
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::{Map, Value};
 
@@ -27,13 +27,21 @@ use crate::schema::SchemaRegistry;
 use crate::CoreError;
 
 /// Category subdirectories concatenated verbatim (sorted path order) into the
-/// merged `extensions` object, keyed by directory name → manifest JSON key.
+/// merged `extensions` object, keyed by directory name → manifest JSON key →
+/// fields an entry must have (checked here since full fragment-schema
+/// validation is h890.26.3, not yet landed — without this, an entry missing
+/// e.g. "name" would silently vanish in `apply_platform_manifest`'s own
+/// `let Some(name) = ... else { continue }`, instead of failing loudly).
 /// `tokens/` and `relationships/` have their own handling below and aren't here.
-const CONCAT_CATEGORIES: &[(&str, &str)] = &[
-    ("components", "components"),
-    ("fields", "fields"),
-    ("guidelines", "guidelines"),
-    ("platform-extensions", "platformExtensions"),
+const CONCAT_CATEGORIES: &[(&str, &str, &[&str])] = &[
+    ("components", "components", &["name"]),
+    ("fields", "fields", &["name"]),
+    ("guidelines", "guidelines", &["name"]),
+    (
+        "platform-extensions",
+        "platformExtensions",
+        &["platform", "extends"],
+    ),
 ];
 
 /// Locate `packages/design-data-spec/schemas/manifest.schema.json` by walking up
@@ -123,6 +131,16 @@ fn build_extensions_value(
         .get("extensionsDir")
         .and_then(|v| v.as_str())
         .unwrap_or("extensions");
+    if Path::new(dir_name).is_absolute()
+        || Path::new(dir_name)
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+    {
+        return Err(CoreError::ParseError(format!(
+            "manifest extensionsDir \"{dir_name}\" must be a relative path inside the \
+             platform directory (no absolute paths or \"..\" components)"
+        )));
+    }
     let ext_root = manifest_path
         .parent()
         .map_or_else(|| PathBuf::from(dir_name), |p| p.join(dir_name));
@@ -141,7 +159,7 @@ fn build_extensions_value(
             .into_iter()
             .filter(|p| p.to_string_lossy().ends_with(".tokens.json"))
             .collect();
-        let tokens = load_and_concat(&files)?;
+        let tokens = load_and_concat(&files, &[])?;
         if !tokens.is_empty() {
             out.insert("tokens".to_string(), Value::Array(tokens));
         }
@@ -150,12 +168,12 @@ fn build_extensions_value(
     // components/, fields/, guidelines/, platform-extensions/ — one artifact per
     // file (though a file holding an array of several is tolerated too), all files
     // in the subdirectory concatenated in sorted path order.
-    for (dir_name, key) in CONCAT_CATEGORIES {
+    for (dir_name, key, required) in CONCAT_CATEGORIES {
         let dir = ext_root.join(dir_name);
         if !dir.is_dir() {
             continue;
         }
-        let items = load_and_concat(&discover_json_files(&dir)?)?;
+        let items = load_and_concat(&discover_json_files(&dir)?, required)?;
         if !items.is_empty() {
             out.insert((*key).to_string(), Value::Array(items));
         }
@@ -167,7 +185,7 @@ fn build_extensions_value(
     // order. Partition is stable: within each group, sorted-path order is kept.
     let rel_dir = ext_root.join("relationships");
     if rel_dir.is_dir() {
-        let items = load_and_concat(&discover_json_files(&rel_dir)?)?;
+        let items = load_and_concat(&discover_json_files(&rel_dir)?, &[])?;
         if !items.is_empty() {
             let (mut adds, ops): (Vec<Value>, Vec<Value>) =
                 items.into_iter().partition(|v| v.get("op").is_none());
@@ -182,20 +200,45 @@ fn build_extensions_value(
 /// Read and parse each file in `files`, flattening top-level arrays (cascade
 /// token files, or a fragment file holding several entries) and pushing bare
 /// objects as-is, preserving `files`' order throughout.
-fn load_and_concat(files: &[PathBuf]) -> Result<Vec<Value>, CoreError> {
+///
+/// `required_fields` names non-empty-string fields every resulting entry must
+/// have; an entry missing one fails loudly here rather than silently vanishing
+/// in `apply_platform_manifest`'s own add-or-replace lookups (full
+/// fragment-schema validation is h890.26.3, not yet landed).
+fn load_and_concat(files: &[PathBuf], required_fields: &[&str]) -> Result<Vec<Value>, CoreError> {
     let mut out = Vec::new();
     for f in files {
-        let text = std::fs::read_to_string(f)?;
+        let text = std::fs::read_to_string(f).map_err(|e| {
+            CoreError::ParseError(format!(
+                "failed to read extension fragment {}: {e}",
+                f.display()
+            ))
+        })?;
         let val: Value = serde_json::from_str(&text).map_err(|e| {
             CoreError::ParseError(format!(
                 "failed to parse extension fragment {}: {e}",
                 f.display()
             ))
         })?;
-        match val {
-            Value::Array(items) => out.extend(items),
-            other => out.push(other),
+        let items: Vec<Value> = match val {
+            Value::Array(items) => items,
+            other => vec![other],
+        };
+        for item in &items {
+            for field in required_fields {
+                let present = item
+                    .get(*field)
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| !s.is_empty());
+                if !present {
+                    return Err(CoreError::ParseError(format!(
+                        "extension fragment {} has an entry missing required field \"{field}\"",
+                        f.display()
+                    )));
+                }
+            }
         }
+        out.extend(items);
     }
     Ok(out)
 }
@@ -839,5 +882,75 @@ mod tests {
         let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
         apply_configured(&mut graph, &resolved).unwrap();
         assert!(graph.components.iter().any(|c| c.name == "tab-bar-ios"));
+    }
+
+    #[test]
+    fn component_fragment_missing_name_fails_loudly() {
+        // Regression: with inline `extensions` schema validation gone
+        // (h890.26.1) and fragment-schema validation not yet landed
+        // (h890.26.3), a malformed fragment must not silently vanish via
+        // `apply_platform_manifest`'s own `let Some(name) = ... else continue`.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "components",
+                "broken.json",
+                json!({"displayName": "No name field"}),
+            )],
+        );
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("missing required field \"name\""));
+    }
+
+    #[test]
+    fn extensions_dir_rejects_parent_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path =
+            write_manifest_with_extensions(dir.path(), json!({"extensionsDir": "../escape"}), &[]);
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("extensionsDir"));
+    }
+
+    #[test]
+    fn extensions_dir_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path =
+            write_manifest_with_extensions(dir.path(), json!({"extensionsDir": "/etc"}), &[]);
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("extensionsDir"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_extension_fragment_error_names_the_file() {
+        // Regression: the read-error path must name the file, like the
+        // parse-error path just below it does, so failures are diagnosable
+        // among many `extensions/` files.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(dir.path(), json!({}), &[]);
+        let components_dir = dir.path().join("extensions").join("components");
+        std::fs::create_dir_all(&components_dir).unwrap();
+        let bogus = components_dir.join("unreadable.json");
+        std::fs::write(&bogus, "{}").unwrap();
+        std::fs::set_permissions(&bogus, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+
+        // Restore permissions so the tempdir can be cleaned up.
+        std::fs::set_permissions(&bogus, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(err.to_string().contains("unreadable.json"));
     }
 }

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -274,87 +274,18 @@ mod tests {
     }
 
     #[test]
-    fn validate_manifest_accepts_valid_extensions_tokens() {
+    fn validate_manifest_rejects_inline_extensions() {
+        // manifest.schema.json (spec/manifest.md#extensions-directory, h890.26.1)
+        // dropped the inline `extensions` property in favor of the sibling
+        // `extensions/` directory — additionalProperties:false now rejects it at
+        // the top level like any other unknown key. Per-fragment schema
+        // validation of what lives *in* that directory is h890.26.3; the loader
+        // that globs it (h890.26.2) reads fragments directly, not through this
+        // manifest-level schema.
         let manifest = json!({
             "specVersion": "1.0.0-draft",
             "foundationVersion": "1.0.0",
-            "extensions": {
-                "tokens": [
-                    {
-                        "name": {"property": "color"},
-                        "value": "#000"
-                    }
-                ]
-            }
-        });
-        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
-        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
-    }
-
-    #[test]
-    fn validate_manifest_rejects_malformed_extensions_tokens() {
-        // Missing the required `name` and has neither `value` nor `$ref`.
-        let manifest = json!({
-            "specVersion": "1.0.0-draft",
-            "foundationVersion": "1.0.0",
-            "extensions": {
-                "tokens": [
-                    {"bogus": true}
-                ]
-            }
-        });
-        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
-        assert!(!errors.is_empty());
-    }
-
-    #[test]
-    fn validate_manifest_accepts_valid_extensions_components_and_platform_extensions() {
-        let manifest = json!({
-            "specVersion": "1.0.0-draft",
-            "foundationVersion": "1.0.0",
-            "extensions": {
-                "components": [
-                    {
-                        "$id": "tab-bar-ios",
-                        "name": "tab-bar-ios",
-                        "displayName": "Tab Bar (iOS)",
-                        "meta": {"category": "navigation", "documentationUrl": "https://example.com"}
-                    }
-                ],
-                "platformExtensions": [
-                    {
-                        "platform": "iOS",
-                        "extends": "states",
-                        "extensions": [
-                            {"termId": "hover", "platformTerm": "highlighted"}
-                        ]
-                    }
-                ]
-            }
-        });
-        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
-        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
-    }
-
-    #[test]
-    fn validate_manifest_rejects_malformed_extensions_components() {
-        // Missing the required `name` (and `$id`/`displayName`/`meta`).
-        let manifest = json!({
-            "specVersion": "1.0.0-draft",
-            "foundationVersion": "1.0.0",
-            "extensions": { "components": [{"bogus": true}] }
-        });
-        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
-        assert!(!errors.is_empty());
-    }
-
-    #[test]
-    fn validate_manifest_rejects_malformed_platform_extensions() {
-        // Missing the required `extends`/`extensions`.
-        let manifest = json!({
-            "specVersion": "1.0.0-draft",
-            "foundationVersion": "1.0.0",
-            "extensions": { "platformExtensions": [{"platform": "iOS"}] }
+            "extensions": { "tokens": [{"name": {"property": "color"}, "value": "#000"}] }
         });
         let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
         assert!(!errors.is_empty());


### PR DESCRIPTION
## Description

Implements the Rust SDK loader half of `spectrum-design-data-h890.26.2`. After
parsing a Layer 2 platform `manifest.json`, the loader now resolves the
manifest's sibling `extensions/` directory (default name `extensions`,
overridable via `extensionsDir`), globs each category subdirectory
(`tokens/`, `components/`, `fields/`, `relationships/`, `guidelines/`,
`platform-extensions/`) with the existing `discover_json_files`, and merges
the fragments into the same `extensions` JSON shape
`TokenGraph::apply_platform_manifest` already consumes — that consumer is
unchanged.

Per-category merge rules (see
`packages/design-data-spec/spec/manifest.md#extensions-directory`,
h890.26.1, #1420):
- `tokens/`: `*.tokens.json` cascade files concatenated in sorted path order.
- `components/`, `fields/`, `guidelines/`, `platform-extensions/`: concatenated
  in sorted path order (later file wins downstream via existing add-or-replace
  logic).
- `relationships/`: plain "add" entries concatenated in sorted path order
  first, then `op:"override"`/`op:"remove"` entries applied by uuid — so an
  override in an earlier-sorted file still lands after its target add.

Also fixes a second, previously-undiscovered regression from h890.26.1's
schema tightening (`additionalProperties: false` removed the inline
`extensions` manifest property): 5 obsolete `schema.rs` tests asserting
inline `extensions` passes/fails Layer 1 validation, replaced with one
regression test asserting inline `extensions` is now rejected.

## Related Issue

spectrum-design-data-h890.26.2 (parent h890.26, initiative DNA-1741). Depends
on h890.26.1 (#1420, merged).

## Motivation and Context

A single inline `extensions` block in `manifest.json` doesn't scale — some
platform manifests already have 10+ components in one object. h890.26.1
moved platform extensions to a sibling `extensions/` directory (one file per
artifact) and tightened the manifest schema accordingly; this PR makes the
SDK loader actually read that directory.

## How Has This Been Tested?

- Migrated the ~9 existing `manifest.rs` unit tests (which embedded inline
  `extensions` in their manifest.json fixtures, now rejected by the stricter
  schema) to real directory fixtures via a new `write_manifest_with_extensions`
  test helper.
- Added new tests: missing `extensions/` dir is a no-op (not an error),
  multi-file `tokens/` concatenation in sorted order, later-file-wins on
  duplicate component name, and `extensionsDir` override to a non-default
  directory name.
- `moon run sdk:test` (cargo nextest, whole workspace): 1415 passed, 1 skipped.
- `cargo fmt --check` and `cargo clippy` clean for changed files (62
  pre-existing, unrelated clippy errors in `sdk/core/src/validate/rules/`
  confirmed via `git stash` comparison — not touched by this change).

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

No changeset included — deferred to `h890.26.6` per the task's parent bead scope.
