### PR TITLE
feat(ios-override-importer): emit extensions/ directory tree

### DIFF
--- a/.changeset/ios-importer-extensions-dir.md
+++ b/.changeset/ios-importer-extensions-dir.md
@@ -1,0 +1,15 @@
+---
+"ios-override-importer": minor
+---
+
+Emit the platform manifest's `extensions/` directory layout instead of an inline
+`extensions` object, matching the Layer 1 schema change (closes spectrum-design-data-h890.26.5).
+
+- **src/cli.js**: writes net-new extension tokens to `extensions/tokens/imported.tokens.json`
+  instead of an inline `manifest.extensions` object; `formatting` moves to a top-level field.
+- **src/emit-manifest.js**: extension token records use `$valueType:
+  "value-types/color.schema.json"` instead of the now-rejected `$schema` key.
+- **src/parse-colorset.js**: normalizes rgba alpha (`1.0` → `1`) to satisfy the color value-type's
+  pattern.
+- **src/resolve-target.js**: palette-slug names now include `property: "color"` and a string
+  `scaleIndex`, satisfying `token.schema.json`'s name-object validation.

--- a/.changeset/ios-importer-extensions-dir.md
+++ b/.changeset/ios-importer-extensions-dir.md
@@ -7,6 +7,7 @@ Emit the platform manifest's `extensions/` directory layout instead of an inline
 
 - **src/cli.js**: writes net-new extension tokens to `extensions/tokens/imported.tokens.json`
   instead of an inline `manifest.extensions` object; `formatting` moves to a top-level field.
+  A re-run producing zero extension tokens removes a stale fragment left by a prior run.
 - **src/emit-manifest.js**: extension token records use `$valueType:
   "value-types/color.schema.json"` instead of the now-rejected `$schema` key.
 - **src/parse-colorset.js**: normalizes rgba alpha (`1.0` → `1`) to satisfy the color value-type's

--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -16,7 +16,8 @@
     "root:test",
     "s2-docs-to-document-blocks:test",
     "design-data:validate-guidelines",
-    "token-mapping-analyzer:test"
+    "token-mapping-analyzer:test",
+    "ios-override-importer:test"
   ],
   "rust": [
     "sdk:fmt-check",
@@ -65,6 +66,7 @@
     "token-mapping-analyzer:analyze",
     "token-naming-audit:lint",
     "tokens:build",
+    "ios-override-importer:import",
     "viewer:clean",
     "viewer:convert",
     "viewer:export",

--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -16,8 +16,7 @@
     "root:test",
     "s2-docs-to-document-blocks:test",
     "design-data:validate-guidelines",
-    "token-mapping-analyzer:test",
-    "ios-override-importer:test"
+    "token-mapping-analyzer:test"
   ],
   "rust": [
     "sdk:fmt-check",
@@ -26,6 +25,7 @@
     "sdk:test-doc",
     "sdk-wasm:ci",
     "tokens:test",
+    "ios-override-importer:test",
     "tokens:validateDesignData",
     "design-data:validate",
     "design-data:roundtrip-verify",

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -31,5 +31,6 @@ projects:
   design-data-glue: "tools/design-data"
   design-data-skill: "tools/design-data-skill"
   s2-docs-to-document-blocks: "tools/s2-docs-to-document-blocks"
+  ios-override-importer: "tools/ios-override-importer"
 vcs:
   defaultBranch: "main"

--- a/tools/ios-override-importer/moon.yml
+++ b/tools/ios-override-importer/moon.yml
@@ -18,3 +18,5 @@ tasks:
     command:
       - pnpm
       - ava
+    deps:
+      - sdk:build

--- a/tools/ios-override-importer/src/cli.js
+++ b/tools/ios-override-importer/src/cli.js
@@ -9,7 +9,8 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { parseCsv } from "./parse-csv.js";
 import { emitManifest } from "./emit-manifest.js";
 import { buildGapsReport } from "./gaps-report.js";
@@ -67,14 +68,24 @@ export function run(argv) {
     include: existing.include ?? DEFAULT_INCLUDE,
     exclude: existing.exclude ?? DEFAULT_EXCLUDE,
     overrides,
-    extensions: {
-      tokens: extensionTokens,
-      formatting: { casing: "camelCase" },
-    },
+    formatting: { casing: "camelCase" },
   };
 
   writeFileSync(args.out, `${JSON.stringify(manifest, null, 2)}\n`);
   writeFileSync(args.gaps, buildGapsReport(unresolved));
+
+  // Extension tokens live in a sibling extensions/ directory fragment
+  // (packages/design-data-spec/spec/manifest.md#extensions-directory), not
+  // inline in manifest.json. Skip writing it when there's nothing to emit —
+  // a missing extensions/ dir is a valid no-op for the SDK loader.
+  if (extensionTokens.length) {
+    const tokensDir = join(dirname(args.out), "extensions", "tokens");
+    mkdirSync(tokensDir, { recursive: true });
+    writeFileSync(
+      join(tokensDir, "imported.tokens.json"),
+      `${JSON.stringify(extensionTokens, null, 2)}\n`,
+    );
+  }
 
   console.log(
     `wrote ${args.out} (${overrides.length} overrides, ${extensionTokens.length} extension tokens) ` +

--- a/tools/ios-override-importer/src/cli.js
+++ b/tools/ios-override-importer/src/cli.js
@@ -9,7 +9,13 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { parseCsv } from "./parse-csv.js";
 import { emitManifest } from "./emit-manifest.js";
@@ -78,13 +84,22 @@ export function run(argv) {
   // (packages/design-data-spec/spec/manifest.md#extensions-directory), not
   // inline in manifest.json. Skip writing it when there's nothing to emit —
   // a missing extensions/ dir is a valid no-op for the SDK loader.
+  const importedTokensPath = join(
+    dirname(args.out),
+    "extensions",
+    "tokens",
+    "imported.tokens.json",
+  );
   if (extensionTokens.length) {
-    const tokensDir = join(dirname(args.out), "extensions", "tokens");
-    mkdirSync(tokensDir, { recursive: true });
+    mkdirSync(dirname(importedTokensPath), { recursive: true });
     writeFileSync(
-      join(tokensDir, "imported.tokens.json"),
+      importedTokensPath,
       `${JSON.stringify(extensionTokens, null, 2)}\n`,
     );
+  } else if (existsSync(importedTokensPath)) {
+    // A prior run may have written this fragment; a re-run with zero
+    // extension tokens must remove it, not leave a stale one behind.
+    rmSync(importedTokensPath);
   }
 
   console.log(

--- a/tools/ios-override-importer/src/emit-manifest.js
+++ b/tools/ios-override-importer/src/emit-manifest.js
@@ -13,8 +13,7 @@ import { resolveTarget, splitAliases } from "./resolve-target.js";
 import { findTokenUuid, loadLegacyKeyIndex } from "./find-token-uuid.js";
 import { isFontSizeValue, parseFontSize } from "./parse-scale.js";
 
-const COLOR_SCHEMA =
-  "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json";
+const COLOR_VALUE_TYPE = "value-types/color.schema.json";
 
 /**
  * Resolve a font-size row directly by uuid existence at the `mobile` scale
@@ -53,10 +52,10 @@ function emitFontSizeRow(row, legacyKeyIndex) {
  *   target, and legacy-key string matching is the only reliable lookup).
  *   A mode whose uuid can't be found is dropped into `unresolved` for the
  *   gap report rather than emitted with a broken target.
- * - `extensionModes` → one `extensions.tokens[]` entry per mode, reusing the
- *   resolved name fields (mirrors the color-set member shape — same
- *   identity, different colorScheme/contrast). These are new records, so no
- *   existence check is needed.
+ * - `extensionModes` → one `extensions/tokens/` fragment entry per mode,
+ *   reusing the resolved name fields (mirrors the color-set member shape —
+ *   same identity, different colorScheme/contrast). These are new records,
+ *   so no existence check is needed.
  * - `out-of-scope` (letter-spacing, non-color/font-size sizing) → no manifest
  *   fragment.
  *
@@ -111,7 +110,7 @@ export function emitRow(row, options) {
       ...(m.variant ? { variant: m.variant } : {}),
       ...(m.contrast ? { contrast: m.contrast } : {}),
     },
-    $schema: COLOR_SCHEMA,
+    $valueType: COLOR_VALUE_TYPE,
     value: m.value,
   }));
 
@@ -124,8 +123,8 @@ export function emitRow(row, options) {
 
 /**
  * Run `emitRow` over every row, merging into one manifest's `overrides`/
- * `extensions.tokens`, sorted for deterministic output (the SDK reads with
- * `serde_json` `preserve_order`, so insertion order is what ships).
+ * `extensions/tokens/` fragment, sorted for deterministic output (the SDK
+ * reads with `serde_json` `preserve_order`, so insertion order is what ships).
  */
 export function emitManifest(rows, options) {
   const overrides = [];

--- a/tools/ios-override-importer/src/parse-colorset.js
+++ b/tools/ios-override-importer/src/parse-colorset.js
@@ -69,5 +69,8 @@ function colorToRgba(literal) {
     throw new Error(`not a Color literal: ${literal}`);
   }
   const [r, g, b, a] = args.split(",").map((s) => s.trim());
-  return `rgba(${r}, ${g}, ${b}, ${a})`;
+  // Strip a trailing ".0" (e.g. "1.0" -> "1") — value-types/color.schema.json's
+  // alpha pattern accepts "0" | "1" | "0.x", not "1.0". Non-integer alphas
+  // (e.g. "0.5") pass through unchanged.
+  return `rgba(${r}, ${g}, ${b}, ${String(Number(a))})`;
 }

--- a/tools/ios-override-importer/src/resolve-target.js
+++ b/tools/ios-override-importer/src/resolve-target.js
@@ -27,13 +27,23 @@ function loadColorFamilies() {
 
 const PALETTE_RE = /^(.+)-(\d+)$/;
 
-/** `{colorFamily, scaleIndex}` if `slug` is a recognized palette slug, else null. */
+/**
+ * `{property, colorFamily, scaleIndex}` if `slug` is a recognized palette
+ * slug, else null. `property: "color"` matches the real corpus's palette
+ * tokens (packages/design-data/tokens/color-palette.tokens.json) and
+ * satisfies token.schema.json's nameObject (`required: ["property"]`).
+ * `scaleIndex` stays the regex's string capture rather than `Number(index)`
+ * — colorFamily/scaleIndex aren't declared nameObject properties, so they
+ * fall under `additionalProperties: {"type": "string"}`, which rejects a
+ * numeric value (only enforced for extensions/ fragments today, not yet for
+ * the foundation corpus — see sdk/core/src/manifest.rs's FragmentValidation).
+ */
 export function matchPaletteSlug(slug, colorFamilies) {
   const m = PALETTE_RE.exec(slug);
   if (!m) return null;
   const [, family, index] = m;
   if (!colorFamilies.has(family)) return null;
-  return { colorFamily: family, scaleIndex: Number(index) };
+  return { property: "color", colorFamily: family, scaleIndex: index };
 }
 
 /**

--- a/tools/ios-override-importer/test/categorize.test.js
+++ b/tools/ios-override-importer/test/categorize.test.js
@@ -41,7 +41,7 @@ test("true-value-change: base light value replaced", (t) => {
   });
   t.is(category, "true-value-change");
   t.deepEqual(overrideModes, [
-    { colorScheme: "light", value: "rgba(9, 9, 9, 1.0)" },
+    { colorScheme: "light", value: "rgba(9, 9, 9, 1)" },
   ]);
   t.deepEqual(extensionModes, []);
 });
@@ -56,10 +56,10 @@ test("true-value-change row can also add a genuinely new contrast mode", (t) => 
   // light base value changed (override) AND a new light/high slot appeared
   // (extension) — one row, both fragment types.
   t.deepEqual(overrideModes, [
-    { colorScheme: "light", value: "rgba(9, 9, 9, 1.0)" },
+    { colorScheme: "light", value: "rgba(9, 9, 9, 1)" },
   ]);
   t.deepEqual(extensionModes, [
-    { colorScheme: "light", contrast: "high", value: "rgba(3, 3, 3, 1.0)" },
+    { colorScheme: "light", contrast: "high", value: "rgba(3, 3, 3, 1)" },
   ]);
 });
 
@@ -80,13 +80,13 @@ test("elevated slots are extension modes, not mistaken for the plain dark base v
     {
       variant: "elevated",
       colorScheme: "dark",
-      value: "rgba(3, 3, 3, 1.0)",
+      value: "rgba(3, 3, 3, 1)",
     },
     {
       variant: "elevated",
       colorScheme: "dark",
       contrast: "high",
-      value: "rgba(4, 4, 4, 1.0)",
+      value: "rgba(4, 4, 4, 1)",
     },
   ]);
 });

--- a/tools/ios-override-importer/test/cli.test.js
+++ b/tools/ios-override-importer/test/cli.test.js
@@ -93,6 +93,38 @@ test("writes an extensions/tokens/ fragment when the run produces extension toke
   ]);
 });
 
+test("removes a stale extensions/tokens/ fragment when a re-run produces zero extension tokens", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "ios-importer-cli-"));
+  const csvPath = join(dir, "override-log.csv");
+  const outPath = join(dir, "manifest.json");
+  const gapsPath = join(dir, "gaps.md");
+  const fragmentPath = join(
+    dir,
+    "extensions",
+    "tokens",
+    "imported.tokens.json",
+  );
+
+  writeFileSync(
+    csvPath,
+    "Token Name,Old Value,New Value,Aliases,Override Source\n" +
+      'blue-100,"Custom token","ColorSet(light: Color(1, 2, 3, 1.0), dark: none)",,palette.json\n',
+  );
+  run(["--csv", csvPath, "--out", outPath, "--gaps", gapsPath]);
+  t.true(existsSync(fragmentPath));
+
+  // Re-run with a CSV that no longer produces any extension tokens — the
+  // prior run's fragment must be removed, not left stale.
+  writeFileSync(
+    csvPath,
+    "Token Name,Old Value,New Value,Aliases,Override Source\n" +
+      'letter-spacing-font-size-10,"Custom token",Measurement(0.433),,letter-spacing.json\n',
+  );
+  run(["--csv", csvPath, "--out", outPath, "--gaps", gapsPath]);
+
+  t.false(existsSync(fragmentPath));
+});
+
 test("rejects missing required flags", (t) => {
   t.throws(() => run(["--csv", "x.csv"]), { message: /usage:/ });
 });

--- a/tools/ios-override-importer/test/cli.test.js
+++ b/tools/ios-override-importer/test/cli.test.js
@@ -9,7 +9,7 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { run } from "../src/cli.js";
@@ -37,10 +37,60 @@ test("writes a manifest and gap report from a CSV", (t) => {
   const manifest = JSON.parse(readFileSync(outPath, "utf8"));
   t.is(manifest.specVersion, "1.0.0-draft");
   t.deepEqual(manifest.overrides, []);
-  t.deepEqual(manifest.extensions.tokens, []);
+  t.is(manifest.extensions, undefined);
+  t.is(manifest.formatting.casing, "camelCase");
+
+  // No extension tokens for this out-of-scope-only fixture, so the sibling
+  // extensions/ directory is never written (a missing extensions/ dir is a
+  // valid no-op for the SDK loader).
+  t.false(existsSync(join(dir, "extensions")));
 
   const gaps = readFileSync(gapsPath, "utf8");
   t.true(gaps.includes("Unresolved rows (0)"));
+});
+
+// A net-new palette-slug row: `resolveTarget` matches it via
+// `matchPaletteSlug` (a static registry lookup) before ever trying the CLI
+// decompose oracle, and net-new rows have no overrideModes, so
+// `loadLegacyKeyIndex` is never invoked either — this stays dependency-free
+// while exercising the extensions/tokens/ fragment-writing branch.
+test("writes an extensions/tokens/ fragment when the run produces extension tokens", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "ios-importer-cli-"));
+  const csvPath = join(dir, "override-log.csv");
+  const outPath = join(dir, "manifest.json");
+  const gapsPath = join(dir, "gaps.md");
+
+  writeFileSync(
+    csvPath,
+    "Token Name,Old Value,New Value,Aliases,Override Source\n" +
+      'blue-100,"Custom token","ColorSet(light: Color(1, 2, 3, 1.0), dark: none)",,palette.json\n',
+  );
+
+  run(["--csv", csvPath, "--out", outPath, "--gaps", gapsPath]);
+
+  const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+  t.is(manifest.extensions, undefined);
+
+  const fragmentPath = join(
+    dir,
+    "extensions",
+    "tokens",
+    "imported.tokens.json",
+  );
+  t.true(existsSync(fragmentPath));
+  const fragment = JSON.parse(readFileSync(fragmentPath, "utf8"));
+  t.deepEqual(fragment, [
+    {
+      name: {
+        property: "color",
+        colorFamily: "blue",
+        scaleIndex: "100",
+        colorScheme: "light",
+      },
+      $valueType: "value-types/color.schema.json",
+      value: "rgba(1, 2, 3, 1)",
+    },
+  ]);
 });
 
 test("rejects missing required flags", (t) => {

--- a/tools/ios-override-importer/test/emit-manifest.test.js
+++ b/tools/ios-override-importer/test/emit-manifest.test.js
@@ -36,7 +36,7 @@ test("true-value-change emits uuid-targeted overrides, one per changed mode", (t
     legacyKeyIndex,
   });
   t.deepEqual(result.overrides, [
-    { target: "uuid-light", value: "rgba(9, 9, 9, 1.0)" },
+    { target: "uuid-light", value: "rgba(9, 9, 9, 1)" },
   ]);
   t.deepEqual(result.extensionTokens, []);
   t.is(result.unresolved, undefined);
@@ -76,9 +76,8 @@ test("net-new emits one extension token per parsed mode", (t) => {
         state: ["default"],
         colorScheme: "light",
       },
-      $schema:
-        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
-      value: "rgba(1, 2, 3, 1.0)",
+      $valueType: "value-types/color.schema.json",
+      value: "rgba(1, 2, 3, 1)",
     },
     {
       name: {
@@ -86,9 +85,8 @@ test("net-new emits one extension token per parsed mode", (t) => {
         state: ["default"],
         colorScheme: "dark",
       },
-      $schema:
-        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
-      value: "rgba(4, 5, 6, 1.0)",
+      $valueType: "value-types/color.schema.json",
+      value: "rgba(4, 5, 6, 1)",
     },
   ]);
 });
@@ -111,9 +109,8 @@ test("contrast-addition includes contrast:high in the extension token's name", (
         colorScheme: "light",
         contrast: "high",
       },
-      $schema:
-        "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
-      value: "rgba(3, 3, 3, 1.0)",
+      $valueType: "value-types/color.schema.json",
+      value: "rgba(3, 3, 3, 1)",
     },
   ]);
 });
@@ -137,9 +134,8 @@ test("elevated/elevatedIncreased slots emit extension tokens with variant:elevat
           colorScheme: "dark",
           variant: "elevated",
         },
-        $schema:
-          "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
-        value: "rgba(7, 7, 7, 1.0)",
+        $valueType: "value-types/color.schema.json",
+        value: "rgba(7, 7, 7, 1)",
       },
       {
         name: {
@@ -149,9 +145,8 @@ test("elevated/elevatedIncreased slots emit extension tokens with variant:elevat
           variant: "elevated",
           contrast: "high",
         },
-        $schema:
-          "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
-        value: "rgba(8, 8, 8, 1.0)",
+        $valueType: "value-types/color.schema.json",
+        value: "rgba(8, 8, 8, 1)",
       },
     ],
   );
@@ -263,7 +258,7 @@ test("emitManifest merges rows and sorts output deterministically", (t) => {
   });
   t.deepEqual(
     result.extensionTokens.map((t) => t.name.scaleIndex),
-    [100, 200],
+    ["100", "200"],
   );
   t.deepEqual(result.unresolved, []);
 });

--- a/tools/ios-override-importer/test/parse-colorset.test.js
+++ b/tools/ios-override-importer/test/parse-colorset.test.js
@@ -22,8 +22,8 @@ test("parses light/dark slots to rgba", (t) => {
     "ColorSet(light: Color(59, 99, 251, 1.0), dark: Color(64, 105, 253, 1.0), elevated: none, lightIncreased: none, darkIncreased: none, elevatedIncreased: none)",
   );
   t.deepEqual(modes, [
-    { colorScheme: "light", value: "rgba(59, 99, 251, 1.0)" },
-    { colorScheme: "dark", value: "rgba(64, 105, 253, 1.0)" },
+    { colorScheme: "light", value: "rgba(59, 99, 251, 1)" },
+    { colorScheme: "dark", value: "rgba(64, 105, 253, 1)" },
   ]);
   t.deepEqual(skipped, []);
 });
@@ -33,10 +33,10 @@ test("maps *Increased slots to contrast:high", (t) => {
     "ColorSet(light: Color(1, 1, 1, 1.0), dark: Color(2, 2, 2, 1.0), elevated: none, lightIncreased: Color(3, 3, 3, 1.0), darkIncreased: Color(4, 4, 4, 1.0), elevatedIncreased: none)",
   );
   t.deepEqual(modes, [
-    { colorScheme: "light", value: "rgba(1, 1, 1, 1.0)" },
-    { colorScheme: "dark", value: "rgba(2, 2, 2, 1.0)" },
-    { colorScheme: "light", contrast: "high", value: "rgba(3, 3, 3, 1.0)" },
-    { colorScheme: "dark", contrast: "high", value: "rgba(4, 4, 4, 1.0)" },
+    { colorScheme: "light", value: "rgba(1, 1, 1, 1)" },
+    { colorScheme: "dark", value: "rgba(2, 2, 2, 1)" },
+    { colorScheme: "light", contrast: "high", value: "rgba(3, 3, 3, 1)" },
+    { colorScheme: "dark", contrast: "high", value: "rgba(4, 4, 4, 1)" },
   ]);
 });
 
@@ -48,13 +48,13 @@ test("maps elevated/elevatedIncreased to variant:elevated at colorScheme:dark", 
     {
       variant: "elevated",
       colorScheme: "dark",
-      value: "rgba(5, 5, 5, 1.0)",
+      value: "rgba(5, 5, 5, 1)",
     },
     {
       variant: "elevated",
       colorScheme: "dark",
       contrast: "high",
-      value: "rgba(6, 6, 6, 1.0)",
+      value: "rgba(6, 6, 6, 1)",
     },
   ]);
   t.deepEqual(skipped, []);

--- a/tools/ios-override-importer/test/resolve-target.test.js
+++ b/tools/ios-override-importer/test/resolve-target.test.js
@@ -15,8 +15,9 @@ const FAMILIES = new Set(["blue", "static-blue"]);
 
 test("matchPaletteSlug recognizes a known family + numeric index", (t) => {
   t.deepEqual(matchPaletteSlug("blue-1000", FAMILIES), {
+    property: "color",
     colorFamily: "blue",
-    scaleIndex: 1000,
+    scaleIndex: "1000",
   });
 });
 
@@ -51,7 +52,7 @@ test("resolveTarget falls back through the Aliases chain in order", (t) => {
   // decompose() returns null, so it falls through to "blue-1000".
   t.deepEqual(result, {
     slug: "blue-1000",
-    name: { colorFamily: "blue", scaleIndex: 1000 },
+    name: { property: "color", colorFamily: "blue", scaleIndex: "1000" },
   });
 });
 


### PR DESCRIPTION
## Description

Migrates `tools/ios-override-importer`'s manifest generation off the removed
inline `extensions` object to the new `extensions/` directory cascade landed
in #1423 (per-fragment schema validation + conformance fixtures for manifest
`extensions/`).

- `src/cli.js`: writes net-new extension tokens to
  `extensions/tokens/imported.tokens.json` instead of `manifest.extensions`;
  `formatting` moves to a top-level manifest field.
- `src/emit-manifest.js`: extension token records use
  `$valueType: "value-types/color.schema.json"` instead of the now-rejected
  `$schema` key.
- `src/parse-colorset.js`: normalizes rgba alpha (`1.0` → `1`) to satisfy the
  color value-type's schema pattern.
- `src/resolve-target.js`: `matchPaletteSlug` now emits a schema-valid `name`
  object (`property: "color"`, string `scaleIndex`) — the previous shape
  (missing `property`, numeric `scaleIndex`) failed `token.schema.json`'s
  name-object validation, a real bug only surfaced by round-tripping through
  the SDK's `validate-manifest` command, not by the JS unit tests.
- `.moon/workspace.yml`: registers `ios-override-importer` — it had a
  `moon.yml` but was never wired into the workspace projects map, so
  `moon run :test` was silently skipping it.

The `design-data init` repo-template scaffold (spectrum-design-data-h890.7) is
still greenfield; per a prior decision it's deferred rather than built here.
The extensions/-layout requirement for it is recorded as a note on that bead.
Regenerating the external `GarthDB/spectrum-ios-design-data` repo's manifest
is a separate out-of-repo follow-up.

## Related Issue

Closes spectrum-design-data-h890.26.5. Unblocks spectrum-design-data-h890.26.6
(docs + changeset for the extensions/ split), tracked separately.

## Motivation and Context

h890.26.1–.4 replaced the Platform Manifest's inline `extensions` object with
a sibling `extensions/` directory cascade (schema, SDK loader, conformance
fixtures — #1423). ios-override-importer was the last producer still emitting
the old inline shape; without this change it would generate schema-invalid
manifests.

## How Has This Been Tested?

- `moon run ios-override-importer:test` (and full `moon run :test`) — all
  passing, 48/48 for this package.
- Round-tripped the importer against a real color-override CSV and validated
  the produced manifest + `extensions/tokens/imported.tokens.json` with the
  real SDK binary (`design-data validate-manifest`) — confirms `$valueType`,
  normalized alpha, and the `name` object all pass real schema validation, not
  just the JS test fixtures.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
