### PR TITLE
fix(demo): update verify-demo.sh A3 for post-CTR token shape

### DIFF
--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -30,7 +30,7 @@ design-data component button --components-dir packages/design-data/components
 **Find all tokens used by a component:**
 
 ```bash
-design-data query packages/design-data/tokens --filter "component=button"
+design-data query packages/design-data/tokens --filter "property=component-height-100"
 ```
 
 **Validate a change to the dataset:**

--- a/tools/demo/demo-commands.sh
+++ b/tools/demo/demo-commands.sh
@@ -17,8 +17,10 @@ design-data component button \
   --components-dir packages/design-data/components
 
 # A3. Query the design system
-# Say: "A designer asks 'what tokens does the button use?' One CLI call. Same answer for the engineer."
-design-data query packages/design-data/tokens --filter "component=button"
+# Say: "A designer asks 'what token backs the button's minimum height?' The relationship
+# binds it to component-height-100. One CLI call resolves it across scale. Same answer
+# for the engineer."
+design-data query packages/design-data/tokens --filter "property=component-height-100"
 
 # A4. (no command — switch to Claude Code, ask the question from agent-questions.md)
 

--- a/tools/demo/scenarios.md
+++ b/tools/demo/scenarios.md
@@ -39,10 +39,10 @@ design-data component button \
 ### A3. Filter the design system by query
 
 ```bash
-design-data query packages/design-data/tokens --filter "component=button"
+design-data query packages/design-data/tokens --filter "property=component-height-100"
 ```
 
-* **Say**: "A designer asks 'what tokens does the button use?' This used to be a code-archaeology task. Now it's one CLI call. Same answer for the engineer."
+* **Say**: "A designer asks 'what token backs the button's minimum height?' The component/token relationship binds it to `component-height-100`. One CLI call resolves it across desktop and mobile scale. Same answer for the engineer."
 
 ### A4. Agent answers a real question
 

--- a/tools/demo/verify-demo.sh
+++ b/tools/demo/verify-demo.sh
@@ -55,8 +55,15 @@ output=$("$CLI" component button \
 [[ "$output" == *"button"* ]] || fail "Expected 'button' in component output."
 ok
 
-step "A3: design-data query --filter component=button"
-"$CLI" query packages/design-data/tokens --filter "component=button" > /dev/null
+step "A3: design-data query --filter property=component-height-100"
+# Post-CTR-migration (#1330), component associations live in
+# relationships/*.json (scope.component), not in a token's own name object —
+# "component=button" no longer matches anything (spectrum-design-data-2d8z).
+# component-height-100 is one of the tokens relationships/button.json binds
+# to button (scope.property), so it's a real button-associated query target.
+a3_output=$("$CLI" query packages/design-data/tokens --filter "property=component-height-100" 2>&1)
+[[ "$a3_output" == *"component-height-100"* ]] \
+  || fail "Expected component-height-100 in query output."
 ok
 
 # ─── Demo B — Blank design system ────────────────────────────────────────────

--- a/tools/demo/verify-demo.sh
+++ b/tools/demo/verify-demo.sh
@@ -61,7 +61,7 @@ step "A3: design-data query --filter property=component-height-100"
 # "component=button" no longer matches anything (spectrum-design-data-2d8z).
 # component-height-100 is one of the tokens relationships/button.json binds
 # to button (scope.property), so it's a real button-associated query target.
-a3_output=$("$CLI" query packages/design-data/tokens --filter "property=component-height-100" 2>&1)
+a3_output=$("$CLI" query packages/design-data/tokens --filter "property=component-height-100" 2>&1 || true)
 [[ "$a3_output" == *"component-height-100"* ]] \
   || fail "Expected component-height-100 in query output."
 ok


### PR DESCRIPTION
## Description

`tools/demo/verify-demo.sh` step A3 ran `design-data query packages/design-data/tokens
--filter "component=button"`, which returns "No matching tokens." (exit 1) and kills the
script under `set -euo pipefail`. This fails the `demo:verify` moon task — a dependency
of `demo:ci`, one of `.github/ci-targets.json`'s `rust[]` entries — so every PR's "Rust"
CI job currently shows 1 failed / 1 skipped task, even PRs unrelated to demo/token data.

Root cause: the Component/Token Relationships (CTR) migration (#1330) moved component
associations out of a token's own `name` object and into
`packages/design-data/relationships/*.json` (`scope.component`). No token in the corpus
has `name.component == "button"` anymore, so `query.rs`'s `component=` filter (correct,
unit-tested, and unchanged by this PR) correctly reports no matches — the demo's
assumption was stale, not the CLI.

Fix: point A3 at `property=component-height-100`, a token
`relationships/button.json` still binds to button (`scope.property`, context "Minimum
height"). It has 2 real matches (desktop/mobile scale), so the demo's "what token backs
the button?" story stays true. Also replaced the `> /dev/null` discard with a real
assertion on the query output, so this regresses loudly instead of silently next time.
Updated the matching narration in `tools/demo/scenarios.md`, `tools/demo/demo-commands.sh`,
and `docs/scenarios.md` to stay in sync with the script.

`sdk/core/src/query.rs`'s filter semantics are untouched — changing them would be a
breaking change to the query spec affecting every other `component=` filter user, not
just this demo.

## Related Issue

Closes bead `spectrum-design-data-2d8z` (discovered while investigating a failed "Rust"
CI check on PR #1424).

## Motivation and Context

Every PR in the repo currently shows a spuriously failing "Rust" CI job because of this
stale demo assumption — this restores a green signal without touching validated query
semantics.

## How Has This Been Tested?

- `bash tools/demo/verify-demo.sh` — exits 0
- `moon run demo:verify` and `moon run demo:ci` — both pass
- `moon ci sdk:fmt-check sdk:lint sdk:test sdk:test-doc sdk-wasm:ci tokens:test
  tokens:validateDesignData design-data:validate design-data:roundtrip-verify
  design-data:legacy-output design-data-glue:ci demo:ci design-data-mcp:test
  design-data-agent-mcp:test design-data-skill:test s2-docs-mcp:test
  token-naming-audit:ci` (the full `rust[]` CI-target list from
  `.github/ci-targets.json`, i.e. the same set the "Rust" GitHub Actions job runs) — 36
  tasks completed, exit code 0

## Screenshots (if appropriate):

N/A — shell script and markdown narration changes only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
