### PR TITLE
chore(sdk): add changeset for extensions/ directory loader change

### DIFF
--- a/.changeset/sdk-loader-extensions-dir.md
+++ b/.changeset/sdk-loader-extensions-dir.md
@@ -1,0 +1,15 @@
+---
+"@adobe/design-data-wasm": minor
+"@adobe/design-data-tui": minor
+---
+
+Load platform-manifest extensions from the sibling `extensions/` directory
+(glob-discovered, per-fragment schema-validated, merged at load time) instead of an
+inline `extensions` object, matching the Layer 1 format change in design-data-spec@4.0.0
+(closes spectrum-design-data-h890.26.6).
+
+- **sdk/core manifest loader (surfaced via wasm/tui)**: glob-discovers
+  `extensions/{tokens,components,fields,guidelines,relationships,platform-extensions}/`,
+  validates each fragment against its category schema, and merges them at load time
+  (deep-merge for `tokens/`, sorted-path-order/last-wins otherwise); manifests using the
+  old inline `extensions` object are now rejected (#1422, #1423).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a missing changeset for `@adobe/design-data-wasm` and `@adobe/design-data-tui`
covering the manifest `extensions/` directory loader change.

## Related Issue

Part of epic `h890.26` (manifest extensions split). Closes bead `spectrum-design-data-h890.26.6`.

## Motivation and Context

`#1422`/`#1423` shipped the SDK loader's glob-discover + per-fragment schema
validation + merge for the platform manifest's `extensions/` directory, but landed
without a changeset for `design-data-wasm`/`design-data-tui` — even though `#1388`
set precedent with a minor bump for a comparable extensions-related change. This
closes that gap so the next release correctly reflects the loader behavior change.

No other h890.26.6 doc/changeset work was needed:
- Canonical `packages/design-data-spec/spec/manifest.md` was already updated for the
  `extensions/` directory layout in `#1420`.
- The breaking major changeset for `@adobe/design-data-spec` already shipped in
  `#1420` (now `4.0.0`); a second major changeset would double-bump.
- `@adobe/spectrum-tokens` is unaffected (no `extensions` key in its manifest).
- `packages/design-data/PLATFORM_EXTENSIONS.md` already disambiguates itself from the
  manifest `extensions/` mechanism.
- `docs/site/src/spec/manifest.md` (generated by `moon run site:copySpec`) was
  regenerated and confirmed already current — no diff.

## How Has This Been Tested?

- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — 3 valid
  changesets, 0 warnings/errors.
- `moon run sdk:test` — 1411 passed, 1 skipped.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (changeset-only change; no code behavior change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (verified existing docs already correct; no edits needed).
- [x] I have added tests to cover my changes (N/A — changeset-only; existing `sdk:test` suite covers the loader behavior itself).
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
