### PR TITLE
feat(sdk): platform-local mode sets via extensions/mode-sets/

### DIFF
--- a/.changeset/manifest-mode-sets.md
+++ b/.changeset/manifest-mode-sets.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-wasm": minor
+"@adobe/design-data-tui": minor
+---
+
+Platform manifests can now declare platform-local mode sets via `extensions/mode-sets/`,
+scoped to that platform's resolution (declare-or-replace by name, same as
+`extensions/fields/`).
+
+- **sdk/core/src/manifest.rs**: added `mode-sets` to `CONCAT_CATEGORIES`, wiring
+  per-fragment validation against `mode-set.schema.json`.
+- **sdk/core/src/graph.rs**: `apply_platform_manifest` now reads `extensions.modeSets`
+  and upserts each into `graph.mode_sets` (cascade and SPEC-005 already operate on it
+  generically).
+- **design-data-spec**: documented `extensions/mode-sets/` in `manifest.md` and
+  `mode-sets.md` (closes spectrum-design-data-h890.24).

--- a/packages/design-data-spec/conformance/manifest-extensions/README.md
+++ b/packages/design-data-spec/conformance/manifest-extensions/README.md
@@ -4,7 +4,7 @@ Exercises the Layer 2 platform manifest's `extensions/` **directory** loader
 (`packages/design-data-spec/spec/manifest.md#extensions-directory`): a sibling
 `extensions/` tree (or a custom name via the manifest's `extensionsDir` field)
 whose category subdirectories (`tokens/`, `components/`, `fields/`,
-`guidelines/`, `platform-extensions/`, `relationships/`) are discovered,
+`guidelines/`, `mode-sets/`, `platform-extensions/`, `relationships/`) are discovered,
 glob+merged in sorted path order, per-fragment schema-validated, and spliced
 into the manifest before it's applied to the graph.
 
@@ -23,6 +23,7 @@ into the manifest before it's applied to the graph.
     },
     "components": { "present": ["tab-bar-ios"] },
     "fields": { "present": ["hapticStyle"] },
+    "modeSets": { "present": ["interfaceLevel"] },
     "guidelines": { "present": ["ios-haptics"] },
     "tokens": { "orderByUuid": ["<uuid-1>", "<uuid-2>"] }
   }
@@ -42,6 +43,7 @@ Rust SDK drives these fixtures in `sdk/core/src/lib.rs` via the
 | `valid/injects-platform-extension`             | A `platform-extensions/` fragment is injected.                                                                           |
 | `valid/injects-field`                          | A `fields/` fragment is injected.                                                                                        |
 | `valid/injects-guideline`                      | A `guidelines/` fragment is injected.                                                                                    |
+| `valid/injects-mode-set`                       | A `mode-sets/` fragment is injected (declare-or-replace by name).                                                        |
 | `valid/injects-relationship`                   | A `relationships/` plain-add fragment is injected.                                                                       |
 | `valid/override-relationship-by-uuid`          | An `op: "override"` entry replaces a plain add sharing its `uuid`, regardless of file sort order.                        |
 | `valid/plain-add-uuid-collision-append`        | Two plain adds sharing a `uuid` both append rather than one overwriting the other.                                       |
@@ -55,6 +57,7 @@ Rust SDK drives these fixtures in `sdk/core/src/lib.rs` via the
 | `invalid/component-missing-name`               | A `components/` fragment missing `name` fails Layer 1 fragment schema validation.                                        |
 | `invalid/field-invalid-kind`                   | A `fields/` fragment with an invalid `kind` enum value fails schema validation.                                          |
 | `invalid/guideline-invalid-category`           | A `guidelines/` fragment with an invalid `category` enum value fails schema validation.                                  |
+| `invalid/mode-set-missing-default`             | A `mode-sets/` fragment missing the required `default` field fails Layer 1 fragment schema validation.                   |
 | `invalid/platform-extension-missing-extends`   | A `platform-extensions/` fragment missing `extends` fails schema validation.                                             |
 | `invalid/token-invalid-uuid`                   | A `tokens/*.tokens.json` fragment with a malformed `uuid` fails schema validation.                                       |
 | `invalid/relationship-missing-scope`           | A `relationships/` plain-add fragment missing `scope` fails schema validation.                                           |

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-missing-default/expected-errors.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-missing-default/expected-errors.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    { "message_pattern": "broken\\.json" },
+    { "message_pattern": "mode-set\\.schema\\.json" },
+    { "message_pattern": "\"default\"" }
+  ]
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-missing-default/extensions/mode-sets/broken.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-missing-default/extensions/mode-sets/broken.json
@@ -1,0 +1,1 @@
+{ "name": "interfaceLevel", "modes": ["base", "elevated"] }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-missing-default/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-missing-default/manifest.json
@@ -1,0 +1,4 @@
+{
+  "specVersion": "1.0.0-draft",
+  "foundationVersion": "1.0.0"
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/injects-mode-set/expected.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/injects-mode-set/expected.json
@@ -1,0 +1,1 @@
+{ "modeSets": { "present": ["interfaceLevel"] } }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/injects-mode-set/extensions/mode-sets/interface-level.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/injects-mode-set/extensions/mode-sets/interface-level.json
@@ -1,0 +1,5 @@
+{
+  "name": "interfaceLevel",
+  "modes": ["base", "elevated"],
+  "default": "base"
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/injects-mode-set/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/injects-mode-set/manifest.json
@@ -1,0 +1,4 @@
+{
+  "specVersion": "1.0.0-draft",
+  "foundationVersion": "1.0.0"
+}

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -18,6 +18,7 @@ The manifest supports a fixed, enumerated set of operations against the foundati
 | Add / replace components                           | Yes                                                          | `extensions/components/`          | Components            |
 | Add / replace field declarations                   | Yes                                                          | `extensions/fields/`              | Fields                |
 | Add / replace guideline documents                  | Yes                                                          | `extensions/guidelines/`          | Guidelines            |
+| Declare / replace platform-local mode set          | Yes                                                          | `extensions/mode-sets/`           | Mode sets             |
 | Add relationships/CTRs; override/remove by `uuid`  | Yes                                                          | `extensions/relationships/`       | Relationships (CTRs)  |
 | Add / remove naming exceptions                     | Yes                                                          | `namingExceptions`                | Naming validation     |
 | Annotate existing terminology (cannot add new ids) | Yes                                                          | `extensions/platform-extensions/` | Existing registry ids |
@@ -86,6 +87,7 @@ extensions/
   tokens/               *.tokens.json          cascade-format token files
   components/           <component>.json       one component per file
   fields/                <field>.json          one field declaration per file
+  mode-sets/             <mode-set>.json       one mode set per file
   relationships/         <component>.json      one CTR set per file
   guidelines/             <topic>.json         one guideline per file
   platform-extensions/   <platform>-<registry>.json
@@ -103,7 +105,7 @@ or empty subdirectory contributes nothing and is not an error.
   cascade token file) and **MUST** validate against `cascade-file.schema.json`. Files are
   **deep-merged** into one tokens object, in sorted path order. Entries **MAY** carry a `$ref`
   to alias an existing token instead of a literal value.
-* **`components/`, `fields/`, `guidelines/`, `platform-extensions/`** — one artifact per file.
+* **`components/`, `fields/`, `guidelines/`, `mode-sets/`, `platform-extensions/`** — one artifact per file.
   Entries across all files in the subdirectory are concatenated, in sorted path order, and
   injected into the corresponding catalog **add-or-replace by name** (for
   `platform-extensions/`, by `termId`; see below). When two files declare the same name,
@@ -115,6 +117,7 @@ load time — this is enforced reference-SDK behavior, not an aspirational goal:
 * **`components/`** → `component.schema.json`
 * **`fields/`** → `field.schema.json` (see [`extensions/fields/`](#extensionsfields) below)
 * **`guidelines/`** → `guideline.schema.json`
+* **`mode-sets/`** → `mode-set.schema.json` (see [`extensions/mode-sets/`](#extensionsmode-sets) below)
 * **`relationships/`** → `relationship.schema.json` (see the Add/Override/remove rules above)
 * **`platform-extensions/`** → `platform-extension.json` (see
   [`extensions/platform-extensions/`](#extensionsplatform-extensions) below)
@@ -142,6 +145,22 @@ Platform-local field declarations, injected into the field catalog. **NORMATIVE:
 declared) references field names by string — a platform that renames or removes a field it
 also references there is self-inconsistent; that is a manifest-authoring concern, not enforced
 by the reference SDK.
+
+#### `extensions/mode-sets/`
+
+Platform-local mode-set declarations, injected into the mode-set catalog for this platform's
+resolution. **NORMATIVE:** each file **MUST** validate against `mode-set.schema.json` (requiring
+`name`, `modes`, `default`); `default ∈ modes` is a Layer 2 concern, enforced by SPEC-005 against
+whichever mode sets end up in the resolved graph, foundation or platform-declared alike.
+
+Semantics are **declare-or-replace by name**, the same as `extensions/fields/`: a `name` not
+already in the foundation catalog is a clean new platform axis (e.g. `interfaceLevel: [base, elevated]`); a `name` matching a foundation mode set replaces it, for this platform only —
+the foundation catalog is untouched. Contrast with `modeSetRestrictions`
+([Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions)), a top-level manifest
+field that only *narrows* the allowed values of an existing mode set — it cannot add a mode value
+or declare a new axis. Redeclaring the full mode set here to add a value (rather than restricting
+it) means the platform restates the foundation's other values, which can drift from foundation; a
+future `op: "extend"` merge semantic may remove that restatement if a platform needs it.
 
 #### `extensions/platform-extensions/`
 

--- a/packages/design-data-spec/spec/mode-sets.md
+++ b/packages/design-data-spec/spec/mode-sets.md
@@ -45,6 +45,9 @@ The Spectrum foundation publishes mode set declarations as JSON files under `pac
 
 Additional mode sets (e.g. `language`, `motion`) **MAY** be declared in a dataset's mode set catalog. Token name objects **MAY** include keys matching declared mode set names.
 
+A platform manifest **MAY** also declare mode sets local to that platform, one per file under
+`extensions/mode-sets/` (see [Platform manifest — `extensions/` directory](manifest.md#extensions-directory)). Platform-declared mode sets are scoped to that platform's resolution and use the same **declare-or-replace-by-name** semantics as `extensions/fields/`: a new `name` adds a platform-local axis (e.g. `interfaceLevel`), while a `name` matching a foundation mode set replaces it for that platform only, leaving the foundation catalog untouched. This is distinct from `modeSetRestrictions` (below), which only *narrows* the allowed values of an existing mode set rather than declaring one.
+
 ## Defaults and specificity
 
 **NORMATIVE:** A token name object **omitting** a mode set field implies the token applies under the mode set's **`default`** mode for specificity and matching purposes unless the spec for that mode set states otherwise.

--- a/sdk/core/src/cascade.rs
+++ b/sdk/core/src/cascade.rs
@@ -909,4 +909,21 @@ mod tests {
             "double-specific token (specificity 2) should beat single-specific (specificity 1)"
         );
     }
+
+    // ── parse_resolve_context ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_resolve_context_accepts_arbitrary_mode_set_name() {
+        // parse_resolve_context has no fixed vocabulary of mode-set names — any
+        // `k=v` pair becomes a context entry — so a manifest-declared axis like
+        // `interfaceLevel` (not a foundation mode set) works with zero code
+        // changes, confirming no new CLI entry point is needed for it.
+        let (prop, ctx) =
+            parse_resolve_context("property=background-color,interfaceLevel=elevated").unwrap();
+        assert_eq!(prop, "background-color");
+        assert_eq!(
+            ctx.mode_sets.get("interfaceLevel").map(String::as_str),
+            Some("elevated")
+        );
+    }
 }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1039,6 +1039,42 @@ impl TokenGraph {
             }
         }
 
+        // 7b. extensions.modeSets — platform-local mode-set declarations,
+        // add-or-replace by name into `self.mode_sets`. New name = a clean new
+        // platform axis; existing name = the platform's version replaces it for
+        // this platform's resolution only (declare-or-replace, mirrors
+        // extensions.fields above). Cascade specificity/matching and SPEC-005
+        // (default ∈ modes) already operate on `graph.mode_sets` generically —
+        // no changes needed there.
+        if let Some(entries) = manifest
+            .get("extensions")
+            .and_then(|e| e.get("modeSets"))
+            .and_then(|v| v.as_array())
+        {
+            for entry in entries {
+                let Some(name) = entry.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let Some(modes) = entry.get("modes").and_then(|v| v.as_array()) else {
+                    continue;
+                };
+                let Some(default_mode) = entry.get("default").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let modes: Vec<String> = modes
+                    .iter()
+                    .filter_map(|m| m.as_str().map(String::from))
+                    .collect();
+                let record = ModeSetRecord {
+                    file: PathBuf::from("manifest.json"),
+                    name: name.to_string(),
+                    modes,
+                    default_mode: default_mode.to_string(),
+                };
+                upsert_by_key(&mut self.mode_sets, |m| m.name == name, record);
+            }
+        }
+
         // 8. extensions.guidelines — platform-local guideline docs, add-or-replace
         // by name into the guideline catalog.
         if let Some(entries) = manifest
@@ -2550,6 +2586,58 @@ mod tests {
             .find(|t| t.uuid.as_deref() == Some("u-card-elev"))
             .expect("extension token present");
         assert_eq!(ext.layer, Layer::Platform);
+    }
+
+    #[test]
+    fn manifest_mode_set_resolves_via_cascade() {
+        use crate::cascade::{resolve, ResolutionContext};
+
+        // Two same-layer candidates for the same slot, one authored against a
+        // platform-local mode axis (`interfaceLevel`) that isn't a foundation
+        // mode set at all — only `apply_platform_manifest` below teaches the
+        // graph about it.
+        let mut g = TokenGraph::from_pairs(vec![
+            (
+                "btn-bg".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "background-color", "component": "button"}, "value": "#aaa", "uuid": "u-btn-bg"}),
+            ),
+            (
+                "btn-bg-elevated".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "background-color", "component": "button", "interfaceLevel": "elevated"}, "value": "#ccc", "uuid": "u-btn-bg-elevated"}),
+            ),
+        ]);
+
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [
+                    {"name": "interfaceLevel", "modes": ["base", "elevated"], "default": "base"}
+                ]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+
+        let declared = g
+            .mode_sets
+            .iter()
+            .find(|m| m.name == "interfaceLevel")
+            .expect("manifest-declared mode set present");
+        assert_eq!(declared.default_mode, "base");
+
+        // With `interfaceLevel: elevated` requested, the elevated-specific
+        // token outranks the base one on specificity.
+        let ctx = ResolutionContext::new().with("interfaceLevel", "elevated");
+        let winner = resolve(&g, &ctx).expect("should find a winner");
+        assert_eq!(winner.uuid.as_deref(), Some("u-btn-bg-elevated"));
+
+        // Explicitly requesting `interfaceLevel: base` rules the elevated
+        // candidate out via `matches_context`, so the base token wins.
+        let base_ctx = ResolutionContext::new().with("interfaceLevel", "base");
+        let base_winner = resolve(&g, &base_ctx).expect("should find a winner");
+        assert_eq!(base_winner.uuid.as_deref(), Some("u-btn-bg"));
     }
 
     #[test]

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -197,6 +197,25 @@ mod relational_conformance {
         assert!(!diagnostics_for_rule(&g, "SPEC-005").is_empty());
     }
 
+    /// A manifest-declared mode set (`extensions.modeSets`) is validated by SPEC-005
+    /// the same as a foundation one — the rule just walks `graph.mode_sets`
+    /// regardless of how a record got there.
+    #[test]
+    fn spec005_catches_manifest_declared_mode_set_bad_default() {
+        let mut g = TokenGraph::default();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [
+                    {"name": "interfaceLevel", "modes": ["base", "elevated"], "default": "raised"}
+                ]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        assert!(!diagnostics_for_rule(&g, "SPEC-005").is_empty());
+    }
+
     /// Regression for P1 Bug 1: duplicate UUIDs in a cascade file must be detected
     /// by SPEC-004, not silently dropped during graph construction.
     #[test]
@@ -1215,6 +1234,14 @@ mod manifest_extensions_behavior {
                         .guidelines
                         .iter()
                         .map(|g| g.name.clone())
+                        .collect::<Vec<_>>(),
+                ),
+                (
+                    "modeSets",
+                    &graph
+                        .mode_sets
+                        .iter()
+                        .map(|m| m.name.clone())
                         .collect::<Vec<_>>(),
                 ),
             ] {

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -37,6 +37,7 @@ const CONCAT_CATEGORIES: &[(&str, &str, &str)] = &[
     ("components", "components", "component.schema.json"),
     ("fields", "fields", "field.schema.json"),
     ("guidelines", "guidelines", "guideline.schema.json"),
+    ("mode-sets", "modeSets", "mode-set.schema.json"),
     (
         "platform-extensions",
         "platformExtensions",
@@ -528,6 +529,32 @@ mod tests {
         let restrictions = apply_configured(&mut graph, &resolved).unwrap();
         assert!(restrictions.is_empty());
         assert_eq!(graph.tokens.len(), 3, "no extensions injected");
+    }
+
+    #[test]
+    fn extensions_mode_sets_directory_is_injected_into_graph() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "mode-sets",
+                "interface-level.json",
+                json!({"name": "interfaceLevel", "modes": ["base", "elevated"], "default": "base"}),
+            )],
+        );
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+
+        let declared = graph
+            .mode_sets
+            .iter()
+            .find(|m| m.name == "interfaceLevel")
+            .expect("manifest-declared mode set present");
+        assert_eq!(declared.modes, vec!["base", "elevated"]);
+        assert_eq!(declared.default_mode, "base");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Description

Platform manifests can now declare their own mode sets, scoped to that
platform's resolution, via `extensions/mode-sets/` — one file per mode set,
declare-or-replace-by-name (same semantics as `extensions/fields/`). Previously
a platform could only *narrow* an existing mode set (`modeSetRestrictions`) or
*annotate* registry ids (`platform-extensions`); it couldn't add a whole new
mode axis (e.g. `interfaceLevel`) without editing shared foundation data.

- **sdk/core/src/manifest.rs**: added `mode-sets` to `CONCAT_CATEGORIES`,
  wiring per-fragment schema validation against `mode-set.schema.json` and
  auto-registering it in the known-subdirs allowlist.
- **sdk/core/src/graph.rs**: `apply_platform_manifest` reads
  `extensions.modeSets` and upserts each into `graph.mode_sets` by name.
  Cascade specificity/matching and SPEC-005 already operate on
  `graph.mode_sets` generically, so no further code changes were needed there.
- **packages/design-data-spec**: documented `extensions/mode-sets/` in
  `manifest.md` (capability matrix, directory tree, schema list, new
  normative subsection contrasted with `modeSetRestrictions`) and
  `mode-sets.md`; added valid/invalid conformance fixtures.
- Changeset: minor bump for `@adobe/design-data-wasm` and
  `@adobe/design-data-tui` (matches the precedent set for `sdk/core`-only
  changes).

## Related Issue

Closes spectrum-design-data-h890.24 (epic) and its children h890.24.1–.4.

## Motivation and Context

A platform-specific UI concept (e.g. iOS's "elevated" surface level) shouldn't
require editing the shared foundation dataset just to get a mode axis. This
gives platforms an isolated extension point that mirrors the existing
`extensions/fields/` pattern.

## How Has This Been Tested?

- `moon run sdk:test` — full Rust workspace suite, 0 failures.
- `moon run sdk:lint` — clippy clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset lints clean.
- New tests: graph inject + cascade specificity resolution, directory-loader
  end-to-end injection, SPEC-005 reject via a manifest-declared mode set,
  valid/invalid conformance fixtures, and a `parse_resolve_context` test
  confirming arbitrary manifest-declared mode names work with no CLI changes.
- Manual end-to-end sanity check in a scratch directory: an
  `extensions/mode-sets/` fragment validates cleanly via
  `design-data validate-manifest`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
