### PR TITLE
fix(sdk): clean up pre-existing clippy needless_borrow errors in spec rule tests

### DIFF
--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -626,8 +626,8 @@ mod tests {
             "background-color",
             &[("unknownFoo".into(), "bar".into())],
             None,
-            &catalog,
-            &registry,
+            catalog,
+            registry,
         );
         assert!(result.is_err(), "unknown field key must be rejected");
         let msg = result.unwrap_err();
@@ -651,8 +651,8 @@ mod tests {
             "background-color",
             &[("colorFamily".into(), "not-a-real-family".into())],
             None,
-            &catalog,
-            &registry,
+            catalog,
+            registry,
         );
         assert!(result.is_ok(), "advisory out-of-vocab must not return Err");
         let diags = result.unwrap();
@@ -673,8 +673,8 @@ mod tests {
             "background-color",
             &[("variant".into(), "accent".into())],
             None,
-            &catalog,
-            &registry,
+            catalog,
+            registry,
         );
         assert!(result.is_ok());
         assert!(
@@ -695,8 +695,8 @@ mod tests {
             "background-color",
             &[("colorFamily".into(), "blue".into())],
             Some(typography_schema),
-            &catalog,
-            &registry,
+            catalog,
+            registry,
         );
         assert!(result.is_ok(), "SPEC-042 violation must not return Err");
         let diags = result.unwrap();
@@ -723,8 +723,8 @@ mod tests {
             "background-color",
             &[("colorFamily".into(), "blue".into())],
             Some(color_schema),
-            &catalog,
-            &registry,
+            catalog,
+            registry,
         );
         assert!(result.is_ok());
         let diags = result.unwrap();
@@ -743,7 +743,7 @@ mod tests {
         // An empty name_fields list with a valid property → clean.
         let catalog = FieldCatalog::embedded();
         let registry = RegistryData::embedded();
-        let result = validate_classification("background-color", &[], None, &catalog, &registry);
+        let result = validate_classification("background-color", &[], None, catalog, registry);
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
     }

--- a/sdk/core/src/cache/mod.rs
+++ b/sdk/core/src/cache/mod.rs
@@ -1147,12 +1147,12 @@ mod tests {
             "both fields should survive round-trip"
         );
         assert_eq!(graph.fields[0].name, "alignment");
-        assert_eq!(graph.fields[0].required, false);
+        assert!(!graph.fields[0].required);
         assert_eq!(
             graph.fields[0].description.as_deref(),
             Some("Alignment axis")
         );
         assert_eq!(graph.fields[1].name, "component");
-        assert_eq!(graph.fields[1].required, true);
+        assert!(graph.fields[1].required);
     }
 }

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -778,7 +778,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         fs::write(
             project.join(".design-data.toml"),
-            "[source]\ntype = \"path\"\nroot = \"../spectrum-repo\"\n".to_string(),
+            "[source]\ntype = \"path\"\nroot = \"../spectrum-repo\"\n",
         )
         .unwrap();
 

--- a/sdk/core/src/validate/rules/spec015.rs
+++ b/sdk/core/src/validate/rules/spec015.rs
@@ -276,7 +276,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec016.rs
+++ b/sdk/core/src/validate/rules/spec016.rs
@@ -144,7 +144,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec018.rs
+++ b/sdk/core/src/validate/rules/spec018.rs
@@ -127,7 +127,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec019.rs
+++ b/sdk/core/src/validate/rules/spec019.rs
@@ -122,7 +122,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec020.rs
+++ b/sdk/core/src/validate/rules/spec020.rs
@@ -133,7 +133,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec021.rs
+++ b/sdk/core/src/validate/rules/spec021.rs
@@ -123,7 +123,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec022.rs
+++ b/sdk/core/src/validate/rules/spec022.rs
@@ -141,7 +141,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec023.rs
+++ b/sdk/core/src/validate/rules/spec023.rs
@@ -126,7 +126,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec024.rs
+++ b/sdk/core/src/validate/rules/spec024.rs
@@ -97,7 +97,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec026.rs
+++ b/sdk/core/src/validate/rules/spec026.rs
@@ -111,7 +111,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec027.rs
+++ b/sdk/core/src/validate/rules/spec027.rs
@@ -126,7 +126,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec028.rs
+++ b/sdk/core/src/validate/rules/spec028.rs
@@ -138,7 +138,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)
@@ -151,7 +151,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec029.rs
+++ b/sdk/core/src/validate/rules/spec029.rs
@@ -135,7 +135,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)
@@ -148,7 +148,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec030.rs
+++ b/sdk/core/src/validate/rules/spec030.rs
@@ -91,7 +91,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec031.rs
+++ b/sdk/core/src/validate/rules/spec031.rs
@@ -96,7 +96,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec032.rs
+++ b/sdk/core/src/validate/rules/spec032.rs
@@ -123,7 +123,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec036.rs
+++ b/sdk/core/src/validate/rules/spec036.rs
@@ -137,7 +137,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec037.rs
+++ b/sdk/core/src/validate/rules/spec037.rs
@@ -231,7 +231,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec038.rs
+++ b/sdk/core/src/validate/rules/spec038.rs
@@ -96,7 +96,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec039.rs
+++ b/sdk/core/src/validate/rules/spec039.rs
@@ -83,7 +83,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: manifest.as_ref(),
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec040.rs
+++ b/sdk/core/src/validate/rules/spec040.rs
@@ -165,7 +165,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec041.rs
+++ b/sdk/core/src/validate/rules/spec041.rs
@@ -236,7 +236,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &graph,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         assert!(Rule.validate(&ctx).is_empty());
@@ -248,7 +248,7 @@ mod tests {
         let registry = RegistryData::embedded();
         let exceptions = HashSet::new();
         let manifest = json!({"specVersion": "1.0.0-draft", "foundationVersion": "1.0.0"});
-        let ctx = make_ctx(&graph, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&graph, &manifest, registry, &exceptions);
         assert!(Rule.validate(&ctx).is_empty());
     }
 
@@ -271,7 +271,7 @@ mod tests {
                 "colorScheme": { "allowed": ["light"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         assert!(
             Rule.validate(&ctx).is_empty(),
             "wildcard token covers the restriction"
@@ -303,7 +303,7 @@ mod tests {
                 "colorScheme": { "allowed": ["light"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         // t-light covers the group — no coverage gap even though t-dark is restricted.
         assert!(Rule.validate(&ctx).is_empty());
     }
@@ -327,7 +327,7 @@ mod tests {
                 "colorScheme": { "allowed": ["light"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         let diags = Rule.validate(&ctx);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Error);
@@ -367,7 +367,7 @@ mod tests {
                 "scale": { "allowed": ["desktop"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         let diags = Rule.validate(&ctx);
         // Must detect the gap even though each restriction individually had a survivor.
         assert_eq!(
@@ -399,7 +399,7 @@ mod tests {
                 "scale": { "allowed": ["desktop"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         assert!(Rule.validate(&ctx).is_empty());
     }
 
@@ -424,7 +424,7 @@ mod tests {
                 "colorScheme": { "allowed": ["dark"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         let diags = Rule.validate(&ctx);
         // Expect both a "default not in allowed" error AND a coverage gap (no wildcard/light token).
         let default_errs: Vec<_> = diags
@@ -450,7 +450,7 @@ mod tests {
                 "typoz": { "allowed": ["a"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         let diags = Rule.validate(&ctx);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
@@ -476,7 +476,7 @@ mod tests {
                 "typoz": { "allowed": ["a"] }
             }
         });
-        let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
+        let ctx = make_ctx(&g, &manifest, registry, &exceptions);
         let diags = Rule.validate(&ctx);
         // Only one warning, no coverage-gap errors.
         assert_eq!(diags.len(), 1);

--- a/sdk/core/src/validate/rules/spec045.rs
+++ b/sdk/core/src/validate/rules/spec045.rs
@@ -105,7 +105,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec046.rs
+++ b/sdk/core/src/validate/rules/spec046.rs
@@ -152,7 +152,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec048.rs
+++ b/sdk/core/src/validate/rules/spec048.rs
@@ -106,7 +106,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec051.rs
+++ b/sdk/core/src/validate/rules/spec051.rs
@@ -121,7 +121,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec052.rs
+++ b/sdk/core/src/validate/rules/spec052.rs
@@ -123,7 +123,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec053.rs
+++ b/sdk/core/src/validate/rules/spec053.rs
@@ -148,7 +148,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec054.rs
+++ b/sdk/core/src/validate/rules/spec054.rs
@@ -133,7 +133,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: &g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec055.rs
+++ b/sdk/core/src/validate/rules/spec055.rs
@@ -79,7 +79,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec056.rs
+++ b/sdk/core/src/validate/rules/spec056.rs
@@ -103,7 +103,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec057.rs
+++ b/sdk/core/src/validate/rules/spec057.rs
@@ -86,7 +86,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec058.rs
+++ b/sdk/core/src/validate/rules/spec058.rs
@@ -120,7 +120,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/src/validate/rules/spec059.rs
+++ b/sdk/core/src/validate/rules/spec059.rs
@@ -117,7 +117,7 @@ mod tests {
         let ctx = ValidationContext {
             graph: g,
             naming_exceptions: &exceptions,
-            registry: &registry,
+            registry,
             manifest: None,
         };
         Rule.validate(&ctx)

--- a/sdk/core/tests/integration.rs
+++ b/sdk/core/tests/integration.rs
@@ -130,7 +130,7 @@ mod naming {
             // deliberately breaks the general roundtrip (the thin-format path is
             // tested separately in naming.rs unit tests).
             prop_assume!(
-                component.as_ref().map_or(true, |c| !property.starts_with(c.as_str()))
+                component.as_ref().is_none_or(|c| !property.starts_with(c.as_str()))
             );
 
             let obj = NameObject {


### PR DESCRIPTION
## Description

`cargo clippy -p design-data-core --features figma --all-targets -- -D warnings`
was failing with ~60 `needless_borrow` / `redundant_field_names` /
`bool_assert_comparison` errors, all in test modules (`validate/rules/spec*.rs`,
`authoring/session.rs`, `cache/mod.rs`, `data_source/mod.rs`,
`tests/integration.rs`). Confirmed pre-existing on unmodified `main` via
`git stash` — unrelated to any current feature work, likely clippy-version
drift. `cargo clippy` without `--all-targets` (lib-only) was already clean.

Applied `cargo clippy --fix` to clear them. Test code only — no behavior
change, no changeset needed.

## Related Issue

Closes spectrum-design-data-p6ww.

## Motivation and Context

`--all-targets -D warnings` clippy (what CI/`moon run sdk:lint` full-strictness
would run) was blocked by this pre-existing backlog, unrelated to any feature.

## How Has This Been Tested?

- `cargo clippy -p design-data-core --features figma --all-targets -- -D warnings` — clean.
- `moon run sdk:lint` — clean.
- `moon run sdk:test` — full workspace suite, 0 failures.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] All new and existing tests passed.
