### PR TITLE
fix(sdk): route $ref-backed color-set CTRs through diff_multimode

### DIFF
--- a/.changeset/figma-diff-ref-backed-color-set.md
+++ b/.changeset/figma-diff-ref-backed-color-set.md
@@ -13,4 +13,3 @@ variables diff's per-mode comparison instead of reporting them
   (`graph.has_relationship_record`), not only one carrying a `conceptId`/`setUuid`
   directly on its resolved record — the link a `$ref`-backed color-set CTR carries
   only on its `RelationshipRecord`, never on the resolved `TokenRecord`.
-</content>

--- a/.changeset/figma-diff-ref-backed-color-set.md
+++ b/.changeset/figma-diff-ref-backed-color-set.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-wasm": minor
+"@adobe/design-data-tui": minor
+---
+
+Route `$ref`-backed color-set CTR tokens (e.g. `action-bar-border-color`,
+`popover-border-color`, `card-selection-background-color`) through the Figma
+variables diff's per-mode comparison instead of reporting them
+`skipped-uncovered` (closes spectrum-design-data-2god).
+
+- **sdk/core/src/figma/import.rs**: `diff_values`'s multi-mode routing gate
+  now also accepts a variable whose design-data token is CTR/relationship-backed
+  (`graph.has_relationship_record`), not only one carrying a `conceptId`/`setUuid`
+  directly on its resolved record — the link a `$ref`-backed color-set CTR carries
+  only on its `RelationshipRecord`, never on the resolved `TokenRecord`.
+</content>

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -555,7 +555,10 @@ pub fn diff_values(
         // of requiring universal agreement. Single-mode variables and
         // tokens with no set to align to (ordinary single-value tokens) fall
         // through unchanged to the existing collapse-and-compare path.
-        if variable.values_by_mode.len() > 1 && record_concept_id(&record.raw).is_some() {
+        if variable.values_by_mode.len() > 1
+            && (record_concept_id(&record.raw).is_some()
+                || graph.has_relationship_record(&legacy_key))
+        {
             let class = diff_multimode(variable, meta, graph, &legacy_key, record, leaf);
             match &class {
                 DiffClass::Match => counts.matched += 1,
@@ -2613,6 +2616,131 @@ mod tests {
                         assert_eq!(figma, &json!("55px"));
                     }
                     other => panic!("expected ValueMismatch for Mobile, got {other:?}"),
+                }
+            }
+            other => panic!("expected MultiModeMismatch, got {other:?}"),
+        }
+    }
+
+    /// Bead `spectrum-design-data-2god`: the real `action-bar-border-color`
+    /// shape — a `$ref`-backed CTR (not the inline-value shape covered by
+    /// `ctr_only_multimode_variable_routes_through_diff_multimode` above).
+    /// Each mode's relationship record has no inline `value`, just a `$ref`
+    /// into a plain palette color token (no `conceptId`), so
+    /// `reindex_relationship_tokens` skips it entirely (only inline-value
+    /// CTRs get a synthesized `TokenRecord`) and `resolve_relationship_ref`
+    /// returns the *palette* token's record — which never carries `setUuid`
+    /// (that field lives only on the `RelationshipRecord`, never merged onto
+    /// a resolved `TokenRecord.raw`). Before the fix, `record_concept_id`
+    /// found neither `conceptId` nor `setUuid` and the variable silently
+    /// fell through to the old collapse-and-give-up path even though Dark
+    /// genuinely diverges from Light/Wireframe here.
+    #[test]
+    fn ref_backed_ctr_color_set_routes_through_diff_multimode() {
+        use crate::graph::RelationshipRecord;
+
+        let var = mock_variable(
+            "colorTheme/action-bar-border-color",
+            "COLOR",
+            vec![
+                ("m-light", json!({"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.25})),
+                ("m-dark", json!({"r": 0.0, "g": 0.0, "b": 0.0, "a": 1.0})),
+                (
+                    "m-wireframe",
+                    json!({"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.25}),
+                ),
+            ],
+        );
+        let meta = mock_meta_color_theme(var);
+
+        // Plain palette color tokens — no `conceptId`, no owning set — the
+        // real shape of `transparent-white-25` / `gray-400`, referenced by
+        // `$ref` rather than holding the per-mode value inline.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!([
+                {
+                    "$schema": "https://example.com/color.json",
+                    "name": {"colorFamily": "transparent-white", "scaleIndex": 25},
+                    "value": "#ffffff40",
+                    "uuid": "u-transparent-white-25",
+                },
+                {
+                    "$schema": "https://example.com/color.json",
+                    "name": {"colorFamily": "gray", "scaleIndex": 400},
+                    "value": "#bcbcbc",
+                    "uuid": "u-gray-400",
+                },
+            ])
+        )
+        .unwrap();
+        let graph = TokenGraph::from_json_dir(dir.path())
+            .unwrap()
+            .with_relationships(vec![
+                RelationshipRecord {
+                    file: PathBuf::from("relationships/action-bar.json"),
+                    index: 0,
+                    uuid: Some("e242c2e1-0000-0000-0000-000000000001".to_string()),
+                    raw: json!({
+                        "scope": {"options": {"colorScheme": "light"}},
+                        "$schema": "https://example.com/alias.json",
+                        "$ref": "u-transparent-white-25",
+                        "legacyKey": "action-bar-border-color",
+                        "setUuid": "su-action-bar-border-color",
+                    }),
+                },
+                RelationshipRecord {
+                    file: PathBuf::from("relationships/action-bar.json"),
+                    index: 1,
+                    uuid: Some("e242c2e1-0000-0000-0000-000000000002".to_string()),
+                    raw: json!({
+                        "scope": {"options": {"colorScheme": "dark"}},
+                        "$schema": "https://example.com/alias.json",
+                        "$ref": "u-gray-400",
+                        "legacyKey": "action-bar-border-color",
+                        "setUuid": "su-action-bar-border-color",
+                    }),
+                },
+                RelationshipRecord {
+                    file: PathBuf::from("relationships/action-bar.json"),
+                    index: 2,
+                    uuid: Some("e242c2e1-0000-0000-0000-000000000003".to_string()),
+                    raw: json!({
+                        "scope": {"options": {"colorScheme": "wireframe"}},
+                        "$schema": "https://example.com/alias.json",
+                        "$ref": "u-transparent-white-25",
+                        "legacyKey": "action-bar-border-color",
+                        "setUuid": "su-action-bar-border-color",
+                    }),
+                },
+            ]);
+        let graph = with_real_mode_sets(graph);
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.multi_mode_mismatch, 1);
+        assert_eq!(report.counts.skipped_uncovered, 0);
+
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "colorTheme/action-bar-border-color")
+            .expect("$ref-backed color-set CTR must be reported");
+        match &entry.class {
+            DiffClass::MultiModeMismatch { modes } => {
+                let by_mode: HashMap<&str, &DiffClass> =
+                    modes.iter().map(|m| (m.mode.as_str(), &m.class)).collect();
+                assert!(matches!(by_mode["Light"], DiffClass::Match));
+                assert!(matches!(by_mode["Wireframe"], DiffClass::Match));
+                match by_mode["Dark"] {
+                    DiffClass::ValueMismatch { design_data, figma } => {
+                        assert_eq!(design_data, &json!("#bcbcbc"));
+                        assert_eq!(figma, &json!("#000000"));
+                    }
+                    other => panic!("expected ValueMismatch for Dark, got {other:?}"),
                 }
             }
             other => panic!("expected MultiModeMismatch, got {other:?}"),


### PR DESCRIPTION
## Description

`figma diff`'s `diff_multimode` routing gate only compared a Figma variable
mode-by-mode when the resolved design-data record carried `conceptId` or
`setUuid` directly on its own JSON. For a `$ref`-backed color-set CTR —
`action-bar-border-color`, `popover-border-color`,
`card-selection-background-color` — that link exists only on the
`RelationshipRecord` in `packages/design-data/relationships/*.json`, and
never survives onto the resolved `TokenRecord`:
`resolve_relationship_ref` follows the CTR's `$ref` straight to the
underlying palette color token (no `setUuid`), and
`reindex_relationship_tokens` only synthesizes a `setUuid`-carrying record
for inline-value CTRs — explicitly skipping `$ref`-backed ones. So these
genuinely per-mode-divergent tokens (e.g. action-bar border is
`transparent-white-25` in light, `gray-400` in dark) fell through to the
single-value collapse path and were misreported `skipped-uncovered`.

The gate now also accepts a `legacy_key` with a CTR/relationship record at
all (`graph.has_relationship_record`), independent of what
`conceptId`/`setUuid` ends up on the resolved record —
`diff_multimode`'s own per-mode resolution already handles this shape
correctly via `resolve_relationship_ref_in_context`, so widening the gate
is the whole fix.

## Related Issue

Closes bead `spectrum-design-data-2god`. Reported by Nate Baldwin in
#Design Data and Figma Vars Comparison (Slack thread ts 1788882886.952429).

## Motivation and Context

`figma diff` was silently under-reporting real Figma/design-data
divergence for color-set component tokens, hiding genuine mismatches
behind an incorrect "skipped, not mode-set-backed" reason.

## How Has This Been Tested?

- New unit test `ref_backed_ctr_color_set_routes_through_diff_multimode`
  reproduces the real `action-bar-border-color` shape end-to-end
  (`$ref`-backed CTR siblings, no `conceptId` anywhere) and asserts a
  `MultiModeMismatch` with correct per-mode `Match`/`ValueMismatch`
  classification. Confirmed it fails pre-fix (falls to
  `skipped-uncovered`) and passes post-fix.
- `moon run sdk:test` — 1418 tests pass, no regressions.
- `moon run sdk:lint` — clippy clean.
- Checked whether `base-padding-horizontal-{large,extra-large,2x-large}`
  (a related report) shared this root cause: they don't — their
  design-data records already carry `conceptId` directly, a different
  shape. No fix needed there.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
