### PR TITLE
fix(design-data): route opacity tokens to Color theme, not Platform scale, in figma exporter/diff

### DIFF
--- a/.changeset/figma-opacity-collection-routing.md
+++ b/.changeset/figma-opacity-collection-routing.md
@@ -1,0 +1,17 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Route opacity tokens to the `.Color theme` collection in the Figma variables
+exporter and diff (they were misrouted to `.Platform scale` despite being a
+FLOAT), and resolve `S2.Color-theme`'s bare-named alias variables through
+their `.Color theme` targets instead of reporting them `figma-only`
+(closes DNA-1953).
+
+- **sdk/core/src/figma/mapping.rs**: opacity tokens now route to `.Color
+  theme` (`colorTheme/*`) in both the alias-target pre-pass and the flat-token
+  dispatch; `process_color_set_token`'s FLOAT/COLOR type inference now checks
+  all `sets` members instead of only the first.
+- **sdk/core/src/figma/import.rs**: `diff_values` now falls back to
+  `resolve_alias_target` for bare (slash-less) Figma names, recovering all 35
+  `S2.Color-theme` opacity variables as matches.

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -510,36 +510,38 @@ pub fn diff_values(
             counts.renamed += 1;
         }
 
-        let Some(legacy_key) = invert_name(&variable.name, reversed.as_ref()) else {
+        // A bare (slash-less) Figma name — e.g. the single-mode
+        // `S2.Color-theme` collection's opacity variables, which are all
+        // `VARIABLE_ALIAS`es into `.Color theme` — never inverts via
+        // `invert_name`'s `{prefix}/{legacyKey}` convention, so it can't
+        // reach the alias-target fallback below unless that fallback runs
+        // even when inversion itself fails outright (not just when it
+        // inverts to something the graph can't resolve).
+        let inverted = invert_name(&variable.name, reversed.as_ref());
+        let resolved = inverted
+            .as_ref()
+            .and_then(|legacy_key| {
+                graph
+                    .resolve_alias_key(legacy_key)
+                    .or_else(|| graph.resolve_relationship_ref(legacy_key))
+                    .map(|record| (legacy_key.clone(), record))
+                    // A naive name inversion can coincidentally land on a real but
+                    // wrong-shaped token: a multi-layer composite (e.g. `drop-shadow-
+                    // dragged`'s array of shadow layers) has `value: [...]`, which no
+                    // scalar Figma variable (COLOR/FLOAT/STRING) can hold — so a
+                    // Figma alias named e.g. `Alias/drop-shadow/dragged` whose
+                    // inverted name happens to equal that composite's own key isn't
+                    // actually a match for it. Treat it as unresolved so the
+                    // alias-target fallback below can find the real (flat) sibling
+                    // token instead (e.g. `drop-shadow-dragged-color`).
+                    .filter(|(_, record)| !record.raw.get("value").is_some_and(Value::is_array))
+            })
+            .or_else(|| resolve_alias_target(variable, meta, graph, reversed.as_ref()));
+        let Some((legacy_key, record)) = resolved else {
             counts.figma_only += 1;
             entries.push(DiffEntry {
                 name: variable.name.clone(),
-                legacy_key: None,
-                renamed,
-                class: DiffClass::FigmaOnly,
-            });
-            continue;
-        };
-        let Some((legacy_key, record)) = graph
-            .resolve_alias_key(&legacy_key)
-            .or_else(|| graph.resolve_relationship_ref(&legacy_key))
-            .map(|record| (legacy_key.clone(), record))
-            // A naive name inversion can coincidentally land on a real but
-            // wrong-shaped token: a multi-layer composite (e.g. `drop-shadow-
-            // dragged`'s array of shadow layers) has `value: [...]`, which no
-            // scalar Figma variable (COLOR/FLOAT/STRING) can hold — so a
-            // Figma alias named e.g. `Alias/drop-shadow/dragged` whose
-            // inverted name happens to equal that composite's own key isn't
-            // actually a match for it. Treat it as unresolved so the
-            // alias-target fallback below can find the real (flat) sibling
-            // token instead (e.g. `drop-shadow-dragged-color`).
-            .filter(|(_, record)| !record.raw.get("value").is_some_and(Value::is_array))
-            .or_else(|| resolve_alias_target(variable, meta, graph, reversed.as_ref()))
-        else {
-            counts.figma_only += 1;
-            entries.push(DiffEntry {
-                name: variable.name.clone(),
-                legacy_key: Some(legacy_key),
+                legacy_key: inverted,
                 renamed,
                 class: DiffClass::FigmaOnly,
             });
@@ -555,7 +557,10 @@ pub fn diff_values(
         // of requiring universal agreement. Single-mode variables and
         // tokens with no set to align to (ordinary single-value tokens) fall
         // through unchanged to the existing collapse-and-compare path.
-        if variable.values_by_mode.len() > 1 && record_concept_id(&record.raw).is_some() {
+        if variable.values_by_mode.len() > 1
+            && (record_concept_id(&record.raw).is_some()
+                || graph.has_relationship_record(&legacy_key))
+        {
             let class = diff_multimode(variable, meta, graph, &legacy_key, record, leaf);
             match &class {
                 DiffClass::Match => counts.matched += 1,
@@ -1772,6 +1777,106 @@ mod tests {
         }
     }
 
+    /// `S2.Color-theme` is a single-mode collection whose variables are bare
+    /// names (no `/`) that are `VARIABLE_ALIAS`es into `.Color theme`.
+    /// `invert_name` can't invert a bare name, so it must not short-circuit
+    /// straight to `FigmaOnly` — the alias-target fallback has to run anyway
+    /// and resolve through the aliased `colorTheme/*` variable.
+    #[test]
+    fn bare_named_alias_variable_resolves_via_target() {
+        use super::super::types::{FigmaMode, FigmaVariableCollection};
+
+        let target = mock_variable(
+            "colorTheme/background-opacity-default",
+            "FLOAT",
+            vec![("m-light", json!(10.0))],
+        );
+        let target_id = target.id.clone();
+        let alias_var = mock_variable(
+            "background-opacity-default",
+            "FLOAT",
+            vec![(
+                "m-single",
+                json!({"type": "VARIABLE_ALIAS", "id": target_id}),
+            )],
+        );
+
+        let mut meta = mock_meta(vec![target, alias_var]);
+        meta.variable_collections.insert(
+            "col-1".to_string(),
+            FigmaVariableCollection {
+                id: "col-1".to_string(),
+                name: ".Color theme".to_string(),
+                key: "k1".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: "m-light".to_string(),
+                    name: "Light".to_string(),
+                }],
+                default_mode_id: "m-light".to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        meta.variable_collections.insert(
+            "col-2".to_string(),
+            FigmaVariableCollection {
+                id: "col-2".to_string(),
+                name: "S2.Color-theme".to_string(),
+                key: "k2".to_string(),
+                modes: vec![FigmaMode {
+                    mode_id: "m-single".to_string(),
+                    name: "Mode 1".to_string(),
+                }],
+                default_mode_id: "m-single".to_string(),
+                remote: false,
+                hidden_from_publishing: false,
+                variable_ids: vec![],
+            },
+        );
+        for v in meta.variables.values_mut() {
+            v.variable_collection_id = if v.name.starts_with("colorTheme/") {
+                "col-1".to_string()
+            } else {
+                "col-2".to_string()
+            };
+        }
+
+        let graph = mock_graph_with_schema(
+            "background-opacity-default",
+            "u-bod",
+            json!("0.1"),
+            "https://example.com/opacity.json",
+        );
+        let tokens = vec![(
+            "background-opacity-default".to_string(),
+            PathBuf::from("test.json"),
+            json!({
+                "$schema": "https://example.com/opacity.json",
+                "name": "background-opacity-default",
+                "value": "0.1",
+                "uuid": "u-bod",
+            }),
+        )];
+
+        let report = diff_values(&meta, &graph, &tokens, None).unwrap();
+        assert_eq!(
+            report.counts.figma_only, 0,
+            "bare-named alias var must not be classified FigmaOnly: {:?}",
+            report.entries
+        );
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "background-opacity-default")
+            .expect("bare-named alias variable must be reported");
+        assert!(
+            matches!(entry.class, DiffClass::Match),
+            "expected Match, got {:?}",
+            entry.class
+        );
+    }
+
     /// A design-data-only token that's covered by `--mapping` must report its
     /// real legacy key, not whatever comes after the last `/` in the mapped
     /// Figma name (which can differ, e.g. `spacing-100` -> `Layout/spacing-100-real`).
@@ -2613,6 +2718,131 @@ mod tests {
                         assert_eq!(figma, &json!("55px"));
                     }
                     other => panic!("expected ValueMismatch for Mobile, got {other:?}"),
+                }
+            }
+            other => panic!("expected MultiModeMismatch, got {other:?}"),
+        }
+    }
+
+    /// Bead `spectrum-design-data-2god`: the real `action-bar-border-color`
+    /// shape — a `$ref`-backed CTR (not the inline-value shape covered by
+    /// `ctr_only_multimode_variable_routes_through_diff_multimode` above).
+    /// Each mode's relationship record has no inline `value`, just a `$ref`
+    /// into a plain palette color token (no `conceptId`), so
+    /// `reindex_relationship_tokens` skips it entirely (only inline-value
+    /// CTRs get a synthesized `TokenRecord`) and `resolve_relationship_ref`
+    /// returns the *palette* token's record — which never carries `setUuid`
+    /// (that field lives only on the `RelationshipRecord`, never merged onto
+    /// a resolved `TokenRecord.raw`). Before the fix, `record_concept_id`
+    /// found neither `conceptId` nor `setUuid` and the variable silently
+    /// fell through to the old collapse-and-give-up path even though Dark
+    /// genuinely diverges from Light/Wireframe here.
+    #[test]
+    fn ref_backed_ctr_color_set_routes_through_diff_multimode() {
+        use crate::graph::RelationshipRecord;
+
+        let var = mock_variable(
+            "colorTheme/action-bar-border-color",
+            "COLOR",
+            vec![
+                ("m-light", json!({"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.25})),
+                ("m-dark", json!({"r": 0.0, "g": 0.0, "b": 0.0, "a": 1.0})),
+                (
+                    "m-wireframe",
+                    json!({"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.25}),
+                ),
+            ],
+        );
+        let meta = mock_meta_color_theme(var);
+
+        // Plain palette color tokens — no `conceptId`, no owning set — the
+        // real shape of `transparent-white-25` / `gray-400`, referenced by
+        // `$ref` rather than holding the per-mode value inline.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!([
+                {
+                    "$schema": "https://example.com/color.json",
+                    "name": {"colorFamily": "transparent-white", "scaleIndex": 25},
+                    "value": "#ffffff40",
+                    "uuid": "u-transparent-white-25",
+                },
+                {
+                    "$schema": "https://example.com/color.json",
+                    "name": {"colorFamily": "gray", "scaleIndex": 400},
+                    "value": "#bcbcbc",
+                    "uuid": "u-gray-400",
+                },
+            ])
+        )
+        .unwrap();
+        let graph = TokenGraph::from_json_dir(dir.path())
+            .unwrap()
+            .with_relationships(vec![
+                RelationshipRecord {
+                    file: PathBuf::from("relationships/action-bar.json"),
+                    index: 0,
+                    uuid: Some("e242c2e1-0000-0000-0000-000000000001".to_string()),
+                    raw: json!({
+                        "scope": {"options": {"colorScheme": "light"}},
+                        "$schema": "https://example.com/alias.json",
+                        "$ref": "u-transparent-white-25",
+                        "legacyKey": "action-bar-border-color",
+                        "setUuid": "su-action-bar-border-color",
+                    }),
+                },
+                RelationshipRecord {
+                    file: PathBuf::from("relationships/action-bar.json"),
+                    index: 1,
+                    uuid: Some("e242c2e1-0000-0000-0000-000000000002".to_string()),
+                    raw: json!({
+                        "scope": {"options": {"colorScheme": "dark"}},
+                        "$schema": "https://example.com/alias.json",
+                        "$ref": "u-gray-400",
+                        "legacyKey": "action-bar-border-color",
+                        "setUuid": "su-action-bar-border-color",
+                    }),
+                },
+                RelationshipRecord {
+                    file: PathBuf::from("relationships/action-bar.json"),
+                    index: 2,
+                    uuid: Some("e242c2e1-0000-0000-0000-000000000003".to_string()),
+                    raw: json!({
+                        "scope": {"options": {"colorScheme": "wireframe"}},
+                        "$schema": "https://example.com/alias.json",
+                        "$ref": "u-transparent-white-25",
+                        "legacyKey": "action-bar-border-color",
+                        "setUuid": "su-action-bar-border-color",
+                    }),
+                },
+            ]);
+        let graph = with_real_mode_sets(graph);
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.multi_mode_mismatch, 1);
+        assert_eq!(report.counts.skipped_uncovered, 0);
+
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "colorTheme/action-bar-border-color")
+            .expect("$ref-backed color-set CTR must be reported");
+        match &entry.class {
+            DiffClass::MultiModeMismatch { modes } => {
+                let by_mode: HashMap<&str, &DiffClass> =
+                    modes.iter().map(|m| (m.mode.as_str(), &m.class)).collect();
+                assert!(matches!(by_mode["Light"], DiffClass::Match));
+                assert!(matches!(by_mode["Wireframe"], DiffClass::Match));
+                match by_mode["Dark"] {
+                    DiffClass::ValueMismatch { design_data, figma } => {
+                        assert_eq!(design_data, &json!("#bcbcbc"));
+                        assert_eq!(figma, &json!("#000000"));
+                    }
+                    other => panic!("expected ValueMismatch for Dark, got {other:?}"),
                 }
             }
             other => panic!("expected MultiModeMismatch, got {other:?}"),

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -213,11 +213,15 @@ fn build_export_payload_with_specs(
         if SKIP_SCHEMAS.iter().any(|s| schema.ends_with(s)) || schema.ends_with(ALIAS) {
             continue;
         }
-        let kind = if schema.ends_with(COLOR_SET) || schema.ends_with(COLOR) {
+        let kind = if schema.ends_with(COLOR_SET)
+            || schema.ends_with(COLOR)
+            || schema.ends_with(OPACITY)
+        {
+            // Opacity lives in the Color theme collection in the manual
+            // library, not Platform scale, despite being a FLOAT.
             TokenKind::Color
         } else if schema.ends_with(SCALE_SET)
             || schema.ends_with(DIMENSION)
-            || schema.ends_with(OPACITY)
             || schema.ends_with(FONT_FAMILY)
             || schema.ends_with(FONT_SIZE)
             || schema.ends_with(FONT_STYLE)
@@ -336,8 +340,28 @@ fn build_export_payload_with_specs(
                 &mut mode_values,
                 &mut summary,
             );
+        } else if schema.ends_with(OPACITY) {
+            // Flat opacity token → Color theme collection (matches the manual
+            // library, which files all opacity under .Color theme), default mode.
+            let Some(rc) = pick_collection(&resolved, TokenKind::Color, token_file) else {
+                summary.skipped_unknown_schema.push(token_name.clone());
+                continue;
+            };
+            process_flat_token(
+                token_name,
+                token_entry,
+                rc.collection_id,
+                rc.spec.default_prefix,
+                "FLOAT",
+                rc.default_mode_id,
+                &value_index,
+                &existing_var_index,
+                overrides,
+                &mut variables,
+                &mut mode_values,
+                &mut summary,
+            );
         } else if schema.ends_with(DIMENSION)
-            || schema.ends_with(OPACITY)
             || schema.ends_with(FONT_FAMILY)
             || schema.ends_with(FONT_SIZE)
             || schema.ends_with(FONT_STYLE)
@@ -756,18 +780,18 @@ fn process_color_set_token(
         None => return,
     };
 
-    // Determine the inner type from first mode entry.
-    let inner_schema = sets
-        .values()
-        .next()
-        .and_then(|v| v.get("$schema"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let figma_type = if inner_schema.ends_with(OPACITY) {
-        "FLOAT"
-    } else {
-        "COLOR"
-    };
+    // Determine the inner type from any mode entry — not just the first —
+    // since a set's first member can be an `alias.json` pointer (no
+    // `$schema` of its own) while a sibling member carries the real
+    // `opacity.json`/`color.json` schema. Inferring from the first member
+    // only would misclassify such a set as COLOR, making its opacity
+    // values fail `parse_color` and get silently dropped.
+    let is_opacity = sets.values().any(|v| {
+        v.get("$schema")
+            .and_then(|s| s.as_str())
+            .is_some_and(|s| s.ends_with(OPACITY))
+    });
+    let figma_type = if is_opacity { "FLOAT" } else { "COLOR" };
 
     let desc = entry.get("description").and_then(|v| v.as_str());
     let (va, var_id) = make_variable_action(
@@ -816,9 +840,7 @@ fn process_color_set_token(
         });
 
         if let Some(val_str) = resolved {
-            if let Some(figma_val) =
-                value_to_figma(val_str, figma_type, inner_schema.ends_with(OPACITY))
-            {
+            if let Some(figma_val) = value_to_figma(val_str, figma_type, is_opacity) {
                 mode_values.push(ModeValueAction {
                     variable_id: var_id.clone(),
                     mode_id: mode_id.clone(),
@@ -1302,13 +1324,52 @@ mod tests {
         let tokens = load_all_tokens(dir.path()).unwrap();
         let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
         assert_eq!(summary.variables_created, 1);
-        assert_eq!(
-            body.variables[0].name,
-            "platformScale/background-opacity-down"
-        );
+        // Opacity is a FLOAT, but lives in the Color theme collection in the
+        // manual library, not Platform scale — see COLLECTION_SPECS routing.
+        assert_eq!(body.variables[0].name, "colorTheme/background-opacity-down");
         assert_eq!(body.variables[0].resolved_type, "FLOAT");
         let val = &body.variable_mode_values[0].value;
         assert_eq!(val.as_f64(), Some(10.0));
+    }
+
+    #[test]
+    fn color_set_with_opacity_members_produces_float_not_color() {
+        // Defensive coverage for process_color_set_token's any-member type
+        // inference: even if the alias/first member weren't opacity, any
+        // member being opacity.json must still yield FLOAT, not COLOR.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("opacity-set.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "test-opacity-set": {
+                    "$schema": "https://example.com/color-set.json",
+                    "sets": {
+                        "light": { "$schema": "https://example.com/opacity.json", "value": "0.1", "uuid": "u1" },
+                        "dark": { "$schema": "https://example.com/opacity.json", "value": "0.2", "uuid": "u2" },
+                        "wireframe": { "$schema": "https://example.com/opacity.json", "value": "0.3", "uuid": "u3" }
+                    },
+                    "uuid": "u0"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let tokens = load_all_tokens(dir.path()).unwrap();
+        let (body, summary) = build_export_payload(&tokens, &meta, None).unwrap();
+        assert_eq!(summary.variables_created, 1);
+        assert_eq!(body.variables[0].resolved_type, "FLOAT");
+        assert_eq!(body.variable_mode_values.len(), 3);
+        for mv in &body.variable_mode_values {
+            assert!(
+                mv.value.as_f64().is_some(),
+                "expected flattened FLOAT, got {mv:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Opacity tokens are typed FLOAT but were classified `TokenKind::Scale` in the
Figma variables exporter's alias pre-pass and flat dispatch, so they were
emitted into `.Platform scale` (`platformScale/*`) instead of `.Color theme`
(`colorTheme/*`) — the collection the hand-built "S2 - Web" library actually
uses for them. This made ~62 opacity tokens show up as missing/`figma-only`
in `design-data figma diff` even though generated equivalents existed under
the wrong name.

- Route opacity to `.Color theme` in both the alias-target pre-pass and the
  flat-token dispatch branch (`mapping.rs`)
- `process_color_set_token` now infers FLOAT/COLOR from any `sets` member
  instead of only the first, fixing a latent (currently harmless)
  misclassification risk
- `diff_values` now falls back to `resolve_alias_target` when `invert_name`
  returns `None` (bare, slash-less Figma names), recovering all 35
  `S2.Color-theme` opacity variables, which are `VARIABLE_ALIAS`es into
  `.Color theme` with no `/` in their own name (`import.rs`)

## Related Issue

Closes spectrum-design-data-11k.18 (DNA-1953).

## Motivation and Context

Flagged by Nate Baldwin on the Design Data / Figma Vars comparison Canvas —
opacity tokens were reported as missing from the generated Figma variables,
blocking parity verification against the manual S2 Web library.

## How Has This Been Tested?

- Added unit tests for the new collection routing, the any-member color-set
  type inference, and the bare-name alias fallback
- `moon run sdk:test` — 1417/1417 passed, no regressions
- `design-data figma diff --snapshot core/tests/fixtures/figma/s2-web-variables.baseline.json`:
  all 27 `.Color theme` + 35 `S2.Color-theme` previously-flagged opacity
  entries now resolve out of `figma-only`
- Confirmed (out of scope, unfixed) that ~20 remaining `figma-only` opacity
  tokens belong to legacy component files (`card.json`, `menu.json`,
  `table.json`, etc.) entirely absent from the resolved token graph — a
  pre-existing legacy-source-discovery gap unrelated to Figma routing, not a
  corpus migration this task covers

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
