### PR TITLE
chore(tokens): add missed changeset for base-padding-horizontal fix

### DIFF
--- a/.changeset/spectrum-tokens-padding-horizontal.md
+++ b/.changeset/spectrum-tokens-padding-horizontal.md
@@ -1,0 +1,11 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Correct desktop `base-padding-horizontal` values for large/extra-large/2x-large
+to match the design decision confirmed in Figma/Tokens Studio (closes DNA-1926).
+
+- **packages/tokens/src/layout.json**: `base-padding-horizontal-large` 14px→16px,
+  `base-padding-horizontal-extra-large` 16px→18px, `base-padding-horizontal-2x-large`
+  18px→20px (desktop scale only; mobile unchanged). Regenerated from the cascade
+  source fixed in #1438, which shipped without a changeset for this package.


### PR DESCRIPTION
## Description

Adds a missing changeset for `@adobe/spectrum-tokens`. No source change — the
data fix already merged in #1438.

## Related Issue

Follow-up to #1438. Relates to DNA-1926.

## Motivation and Context

#1438 fixed the desktop `base-padding-horizontal` (L/XL/2xL) values and, after
CI's `roundtrip-verify` guard caught it, regenerated the legacy mirror
`packages/tokens/src/layout.json` — which is the source for the separately
published `@adobe/spectrum-tokens` package. That commit only carried a
changeset for `@adobe/spectrum-design-data`, so `Version Packages` (#1439)
released `@adobe/spectrum-design-data` but left `@adobe/spectrum-tokens` at
15.3.0 with no record that its data had changed.

This adds the missing changeset so the next release bumps
`@adobe/spectrum-tokens` and reflects the corrected values in its changelog.

## How Has This Been Tested?

- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.
- No source files touched; `packages/tokens/src/layout.json` already carries
  the correct 16/18/20px values from #1438 on `main`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
