### PR TITLE
fix(design-data): resolve inline-value opacity CTRs in figma diff

### DIFF
--- a/.changeset/figma-opacity-ctr-resolution.md
+++ b/.changeset/figma-opacity-ctr-resolution.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Resolve inline-value opacity CTRs in `figma diff`.
+
+- **sdk/core/src/graph.rs**: added `opacity.json` to `INLINE_CTR_COMPARABLE_SCHEMAS`
+  so component-level opacity CTRs (e.g. `table-row-hover-opacity`) index into
+  `relationship_tokens` and resolve during diff, matching the existing
+  dimension/multiplier/gradient-stop handling.

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1472,8 +1472,12 @@ impl TokenGraph {
     /// shared enum between them. Adding a schema here that isn't actually
     /// FLOAT/STRING-comparable on the Figma side needs a matching look at
     /// `diff_against_source`.
-    const INLINE_CTR_COMPARABLE_SCHEMAS: [&'static str; 3] =
-        ["dimension.json", "multiplier.json", "gradient-stop.json"];
+    const INLINE_CTR_COMPARABLE_SCHEMAS: [&'static str; 4] = [
+        "dimension.json",
+        "multiplier.json",
+        "gradient-stop.json",
+        "opacity.json",
+    ];
 
     /// Rebuild `relationship_tokens` from `self.relationships`: for every CTR
     /// `legacyKey` with no `$ref`-backed entry, synthesize a leaf `TokenRecord`
@@ -2915,6 +2919,29 @@ mod tests {
             .resolve_relationship_ref("alert-dialog-maximum-width")
             .expect("scale-less inline dimension CTR must resolve");
         assert_eq!(dialog.raw["value"], "480px");
+    }
+
+    #[test]
+    fn resolve_relationship_ref_resolves_inline_opacity_ctrs() {
+        // table-row-hover-opacity's real shape: an inline opacity value (no
+        // $ref), as seen in packages/design-data/relationships/table.json.
+        let g = TokenGraph::default().with_relationships(vec![RelationshipRecord {
+            file: PathBuf::from("relationships/table.json"),
+            index: 0,
+            uuid: Some("dddddddd-0000-0000-0000-000000000001".to_string()),
+            raw: json!({
+                "scope": {"component": "table", "part": "row", "property": "hover-opacity"},
+                "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+                "value": "0.07",
+                "uuid": "dddddddd-0000-0000-0000-000000000001",
+                "legacyKey": "table-row-hover-opacity"
+            }),
+        }]);
+
+        let rec = g
+            .resolve_relationship_ref("table-row-hover-opacity")
+            .expect("inline opacity CTR must resolve");
+        assert_eq!(rec.raw["value"], "0.07");
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`figma diff` was reporting 54 component-level opacity tokens (e.g.
`table-row-hover-opacity`, `popover-border-opacity`) as `figma-only`, even
though they already exist as inline-value CTRs in
`packages/design-data/relationships/*.json` and are published in
`@adobe/spectrum-tokens`. This was never a corpus/authoring gap — it was a
resolution-wiring bug: `INLINE_CTR_COMPARABLE_SCHEMAS` in `graph.rs` excluded
`opacity.json`, so `reindex_relationship_tokens` never indexed these CTRs into
`relationship_tokens`, and `resolve_relationship_ref` returned `None` for
them.

- **sdk/core/src/graph.rs**: add `"opacity.json"` to
  `INLINE_CTR_COMPARABLE_SCHEMAS`, mirroring the existing
  dimension/multiplier/gradient-stop handling. Verified the synthesized
  `TokenRecord` retains `$schema: opacity.json` so `record_is_opacity` still
  fires the 0–1 → 0–100 fraction/percent conversion in `diff_against_source`.
  Also verified the fix covers the bare S2.Color-theme alias form (via
  `resolve_alias_target`) and multi-mode opacity (via `diff_multimode` /
  `best_relationship_candidate`).
- Added a unit test resolving an inline opacity CTR
  (`table-row-hover-opacity`) via `resolve_relationship_ref`.

No token/corpus changes, no exporter (`COLLECTION_SPECS`) changes — this is
purely a diff-side resolution fix, and is orthogonal to the upcoming
mode-group collection-model redesign.

## Related Issue

Closes `spectrum-design-data-11k.10.11`. Corrects the premise of
`spectrum-design-data-11k.18`, which had deferred these entries as an
out-of-scope "corpus migration" — they're CTRs, not missing data.

## Motivation and Context

`spectrum-design-data-11k.10` scoped the Figma Variables mapping gap when
`figma diff` reported 2003 `figma-only` entries. Its children collapsed that
to 67 via diff-side resolution fixes; this closes the remaining opacity
subset of that residual (the user explicitly scoped this PR to opacity only —
the 13 non-opacity `figma-only` entries left after this change are the same
class of issue and are filed as a separate follow-up,
`spectrum-design-data-11k.10.12`).

## How Has This Been Tested?

- Added unit test `resolve_relationship_ref_resolves_inline_opacity_ctrs`.
- Ran `figma diff` against the S2-Web baseline before/after:
  `figma-only` dropped **67 → 13** — all 54 opacity entries now resolve
  (mostly `match`; multi-mode opacity lands on the per-scheme path). No new
  `value-mismatch` or `multi-mode-mismatch` entries were introduced (spot
  checked the 5 opacity entries that appear in `multi-mode-mismatch` — they
  were already there before this change, unrelated to it).
- `moon run sdk:test`: 1420/1420 pass (up from 1417 + 1 skipped).
- `cargo clippy --workspace -- -D warnings`: clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`: clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
