### PR TITLE
fix(sdk): stop counting all-uncovered multi-mode entries as mismatches

### DIFF
--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -186,9 +186,11 @@ fn multimode_name_field<'g>(graph: &'g TokenGraph, mode_name: &str) -> Option<&'
 /// its Light/Dark/Wireframe modes diverge, so requiring universal agreement
 /// discards nearly 60% of that collection as `skipped-uncovered` today.
 ///
-/// Rolls up to a plain [`DiffClass::Match`] when every mode agrees, else
-/// [`DiffClass::MultiModeMismatch`] listing every mode's own classification
-/// (matches included, for context).
+/// Rolls up to a plain [`DiffClass::Match`] when every mode agrees, to
+/// [`DiffClass::SkippedUncovered`] when every mode is uncovered (no
+/// design-data value to compare in any mode — a coverage gap, not a
+/// divergence), else [`DiffClass::MultiModeMismatch`] listing every mode's
+/// own classification (matches included, for context).
 fn diff_multimode(
     variable: &FigmaVariable,
     meta: &VariablesMeta,
@@ -296,6 +298,16 @@ fn diff_multimode(
 
     if modes.iter().all(|m| matches!(m.class, DiffClass::Match)) {
         DiffClass::Match
+    } else if modes
+        .iter()
+        .all(|m| matches!(m.class, DiffClass::SkippedUncovered { .. }))
+    {
+        // No mode resolved to a design-data value at all: the concept isn't
+        // covered per color-scheme, which is a coverage gap, not a per-mode
+        // divergence — don't inflate MultiModeMismatch with it.
+        DiffClass::SkippedUncovered {
+            reason: "multimode-uncovered".to_string(),
+        }
     } else {
         DiffClass::MultiModeMismatch { modes }
     }
@@ -564,6 +576,7 @@ pub fn diff_values(
             let class = diff_multimode(variable, meta, graph, &legacy_key, record, leaf);
             match &class {
                 DiffClass::Match => counts.matched += 1,
+                DiffClass::SkippedUncovered { .. } => counts.skipped_uncovered += 1,
                 _ => counts.multi_mode_mismatch += 1,
             }
             entries.push(DiffEntry {
@@ -2644,6 +2657,60 @@ mod tests {
                 }
             }
             other => panic!("expected MultiModeMismatch, got {other:?}"),
+        }
+    }
+
+    /// The `accent-color-100`-shaped bug: a `.Color theme` variable whose
+    /// design-data concept has no member for *any* of Light/Dark/Wireframe
+    /// (a plain single-scheme alias, not a genuinely per-scheme set) rolls
+    /// up to `SkippedUncovered`, not `MultiModeMismatch` — "nothing to
+    /// compare in any mode" is a coverage gap, not a divergence.
+    #[test]
+    fn color_theme_all_modes_uncovered_reports_skipped_not_mismatch() {
+        let var = mock_variable(
+            "colorTheme/accent-color-100",
+            "COLOR",
+            vec![
+                ("m-light", json!({"r": 1.0, "g": 0.5, "b": 0.0, "a": 1.0})),
+                ("m-dark", json!({"r": 1.0, "g": 0.5, "b": 0.0, "a": 1.0})),
+                (
+                    "m-wireframe",
+                    json!({"r": 1.0, "g": 0.5, "b": 0.0, "a": 1.0}),
+                ),
+            ],
+        );
+        let meta = mock_meta_color_theme(var);
+        // A plain single-scheme alias, not a real per-scheme set: one member,
+        // no `colorScheme` field at all, so a light/dark/wireframe lookup
+        // never finds a match — every mode is genuinely uncovered.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!([
+                {
+                    "$schema": "https://example.com/color.json",
+                    "name": {"colorRole": "accent", "legacyKey": "accent-color-100"},
+                    "value": "#ff8000",
+                    "uuid": "u-accent-color-100",
+                    "conceptId": "su-accent-color-100",
+                },
+            ])
+        )
+        .unwrap();
+        let graph = with_real_mode_sets(TokenGraph::from_json_dir(dir.path()).unwrap());
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.multi_mode_mismatch, 0);
+        assert_eq!(report.counts.skipped_uncovered, 1);
+        assert_eq!(report.counts.matched, 0);
+        match &report.entries[0].class {
+            DiffClass::SkippedUncovered { reason } => {
+                assert_eq!(reason, "multimode-uncovered");
+            }
+            other => panic!("expected SkippedUncovered, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Description

`figma diff` was classifying 242 `colorTheme/*` variables as `multi_mode_mismatch`
against the `s2-web-variables.baseline.json` snapshot. Inspecting the JSON output
showed 241 of them had *every* mode (Light/Dark/Wireframe) classified as
`skipped-uncovered` — design-data has no per-color-scheme member to compare against
in any mode (a plain single-scheme alias like `accent-color-100`, not a real
per-scheme set) — not an actual mismatch. Only 1 entry was a genuine 3-mode
divergence.

`diff_multimode`'s rollup (and its caller's counter) in
`sdk/core/src/figma/import.rs` treated "every mode uncovered" the same as "some mode
diverged," both collapsing to `MultiModeMismatch`. The per-mode "uncovered" result
itself is correct and deliberate — for a CTR-backed key, `diff_multimode` refuses to
fall back to the context-free leaf/`conceptId` value, since that would silently
compare against an arbitrary wrong color-scheme sibling. So this is purely a
rollup/counting bug, not an entry-gate bug — the gate that routes tokens into
`diff_multimode` is unchanged.

**Fix**: the rollup gains a third arm — when every mode is `SkippedUncovered`, roll
up to `SkippedUncovered{reason: "multimode-uncovered"}` instead of
`MultiModeMismatch`; the caller counts by the returned class instead of
Match-vs-everything-else. Genuinely mixed/divergent entries are unaffected.

## Related Issue

Closes spectrum-design-data-pna2 (beads issue; pre-existing behavior, confirmed
unrelated to #1442 via git stash before/after — identical count both sides).

## Motivation and Context

`figma diff` is meant to surface real value drift between Figma and design-data.
Miscounting 241 coverage gaps as mismatches makes the report noisy and hides the
one real mismatch among false positives.

## How Has This Been Tested?

- Added `color_theme_all_modes_uncovered_reports_skipped_not_mismatch`, reproducing
  the `accent-color-100` shape (single-scheme alias, no per-scheme siblings).
- `cargo test -p design-data-core --lib --features figma figma::import::` — 52
  passed, 0 failed.
- `moon run sdk:test` — full suite, 1421 passed, 1 skipped.
- `moon run sdk:lint` — clean.
- Ran `figma diff --snapshot sdk/core/tests/fixtures/figma/s2-web-variables.baseline.json --format json`
  before/after: `multi_mode_mismatch` 242 → 1, `skipped_uncovered` 0 → 241, all
  other counts unchanged. Diffed all 3353 entries before/after: exactly the 241
  `multi-mode-mismatch` → `skipped-uncovered` transitions occurred, nothing else
  changed.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
