### PR TITLE
fix(sdk): resolve multi-hop Layout aliases in figma diff

### DIFF
--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -731,24 +731,28 @@ fn invert_name(figma_name: &str, renames: Option<&HashMap<String, String>>) -> O
 }
 
 /// Resolve a Figma variable that is itself a `VARIABLE_ALIAS` through to the
-/// design-data record its *alias target* maps to. Some collections (Layout,
-/// for one) model every variable as a semantic alias into `.Platform scale`
-/// (e.g. `Alert dialog/Maximum width` -> `platformScale/alert-dialog-maximum-width`)
-/// — the variable's own hierarchical name never inverts to a real legacy key,
-/// but its target's name does via the ordinary [`invert_name`] rules.
+/// design-data record its *alias chain* eventually maps to. Some collections
+/// (Layout, for one) model every variable as a semantic alias into
+/// `.Platform scale` (e.g. `Alert dialog/Maximum width` ->
+/// `platformScale/alert-dialog-maximum-width`) — the variable's own
+/// hierarchical name never inverts to a real legacy key, but a name further
+/// down the chain does via the ordinary [`invert_name`] rules. The
+/// intermediate target itself is sometimes just another alias (e.g. Layout's
+/// `Banner/Gap/Horizontal` -> `platformScale/banner-gap-horizontal` ->
+/// `platformScale/spacing-400`, where only the final hop's name inverts to a
+/// real graph key), so each hop is tried in turn rather than only the first.
 ///
 /// Fallback only: callers try direct name inversion first, so this can only
 /// turn a would-be `figma_only` variable into a match/value-mismatch, never
-/// regress an existing one. Follows a single alias hop — every case observed
-/// against the S2 baseline aliases directly to a resolvable target.
-/// ponytail: one hop, not a chain walk; extend if a deeper chain ever appears.
+/// regress an existing one. Capped at [`MAX_ALIAS_DEPTH`] hops, the same guard
+/// `resolve_figma_value` uses against a cyclic or pathologically deep chain.
 ///
 /// Reads the variable's value from its collection's `default_mode_id` — the
 /// same mode `resolve_figma_value` reads for an alias target — rather than an
 /// arbitrary `HashMap` entry, since a multi-mode variable's iteration order
 /// isn't guaranteed to land on the mode that actually holds the alias.
 /// `renames` is the same reversed name-mapping `diff_values` threads into its
-/// own direct `invert_name` call, applied here to the alias target's name.
+/// own direct `invert_name` call, applied here to each hop's target name.
 fn resolve_alias_target<'a>(
     variable: &FigmaVariable,
     meta: &VariablesMeta,
@@ -758,17 +762,33 @@ fn resolve_alias_target<'a>(
     let collection = meta
         .variable_collections
         .get(&variable.variable_collection_id)?;
-    let value = variable.values_by_mode.get(&collection.default_mode_id)?;
+    let mut value = variable.values_by_mode.get(&collection.default_mode_id)?;
     if !is_alias(value) {
         return None;
     }
-    let target_id = value.get("id").and_then(Value::as_str)?;
-    let target_name = &meta.variables.get(target_id)?.name;
-    let key = invert_name(target_name, renames)?;
-    let record = graph
-        .resolve_alias_key(&key)
-        .or_else(|| graph.resolve_relationship_ref(&key))?;
-    Some((key, record))
+    for _ in 0..MAX_ALIAS_DEPTH {
+        let target_id = value.get("id").and_then(Value::as_str)?;
+        let target = meta.variables.get(target_id)?;
+        if let Some(key) = invert_name(&target.name, renames) {
+            if let Some(record) = graph
+                .resolve_alias_key(&key)
+                .or_else(|| graph.resolve_relationship_ref(&key))
+            {
+                return Some((key, record));
+            }
+        }
+        let target_collection = meta
+            .variable_collections
+            .get(&target.variable_collection_id)?;
+        let next = target
+            .values_by_mode
+            .get(&target_collection.default_mode_id)?;
+        if !is_alias(next) {
+            return None;
+        }
+        value = next;
+    }
+    None
 }
 
 /// Map an atomic Typography-collection Figma name to its exact design-data
@@ -3483,6 +3503,93 @@ mod tests {
             entry.legacy_key.as_deref(),
             Some("standard-dialog-maximum-width-small")
         );
+    }
+
+    #[test]
+    fn diff_values_resolves_alias_two_hops_deep() {
+        // Mirrors the real Layout collection: `Banner/Gap/Horizontal` ->
+        // `platformScale/banner-gap-horizontal` (itself unresolvable — its
+        // structured name has no legacyKey) -> `platformScale/spacing-400`
+        // (resolvable). resolve_alias_target must walk past the first,
+        // unresolvable hop instead of giving up on it.
+        let primitive = mock_variable(
+            "platformScale/spacing-400",
+            "FLOAT",
+            vec![("m-modeless", json!(32.0))],
+        );
+        let intermediate = mock_variable(
+            "platformScale/banner-gap-horizontal",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": primitive.id.clone()}),
+            )],
+        );
+        let alias = mock_variable(
+            "Banner/Gap/Horizontal",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": intermediate.id.clone()}),
+            )],
+        );
+        let meta = mock_meta_modeless(vec![primitive, intermediate, alias]);
+        let graph = mock_graph_with_schema(
+            "spacing-400",
+            "u-spacing-400",
+            json!("32px"),
+            "https://example.com/dimension.json",
+        );
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.name == "Banner/Gap/Horizontal")
+            .unwrap();
+        assert!(
+            matches!(entry.class, DiffClass::Match),
+            "expected Match, got {:?}",
+            entry.class
+        );
+        assert_eq!(entry.legacy_key.as_deref(), Some("spacing-400"));
+    }
+
+    #[test]
+    fn diff_values_alias_chain_cycle_terminates_without_hang() {
+        // Two variables aliasing each other in a loop must not resolve and
+        // must not hang — resolve_alias_target's MAX_ALIAS_DEPTH cap is what
+        // keeps this from spinning forever the way an unbounded chain walk
+        // would on a malformed/cyclic Figma file.
+        let a = mock_variable(
+            "Cycle/A",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": "var-Cycle/B"}),
+            )],
+        );
+        let b = mock_variable(
+            "Cycle/B",
+            "FLOAT",
+            vec![(
+                "m-modeless",
+                json!({"type": "VARIABLE_ALIAS", "id": "var-Cycle/A"}),
+            )],
+        );
+        let meta = mock_meta_modeless(vec![a, b]);
+        let graph = mock_graph_with_schema(
+            "unrelated",
+            "u-unrelated",
+            json!("1px"),
+            "https://example.com/dimension.json",
+        );
+
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        // Neither side of the cycle resolves — both stay figma_only, and the
+        // call returns instead of looping forever.
+        assert_eq!(report.counts.figma_only, 2);
+        assert_eq!(report.counts.matched, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Description

`resolve_alias_target` in the Figma diff resolver only followed a single
`VARIABLE_ALIAS` hop when trying to match a baseline Figma variable back to
a design-data token. The manual "S2 - Web" library's `Layout` collection
often models a variable as an alias into `.Platform scale`, which is itself
sometimes just another alias — e.g. `Banner/Gap/Horizontal` ->
`platformScale/banner-gap-horizontal` -> `platformScale/spacing-400`. Only
the final hop's name inverts to a real design-data legacy key, so these 10
variables were falling through to `figma_only` even though the underlying
tokens exist and match.

This makes `resolve_alias_target` walk the full alias chain (capped at the
existing `MAX_ALIAS_DEPTH`, mirroring the multi-hop `resolve_figma_value`
already used elsewhere in this file) instead of giving up after one hop.

Originally scoped as "add a Layout `CollectionSpec` to the Figma exporter"
(`mapping.rs`). Investigation showed that's a dead end: `figma_only` is
produced entirely in the diff's baseline-variable resolution pass
(`import.rs`) — the exporter's output is never consulted there, so no
`CollectionSpec` change could move any entry out of `figma_only`. Re-scoped
to the actual failing step, confirmed against a live `figma diff` run.

## Related Issue

Closes spectrum-design-data-11k.19. Narrows spectrum-design-data-11k.10.12
(10 of its 13 tracked `figma_only` entries are resolved by this; 3 unrelated
code-font entries remain open there).

## Motivation and Context

Closes the gap between the design-data corpus and the manual S2 Figma
library's `Layout` collection in `figma diff`'s coverage report, without
touching token data or the exporter.

## How Has This Been Tested?

- New unit tests in `sdk/core/src/figma/import.rs`:
  `diff_values_resolves_alias_two_hops_deep` (two-hop chain resolves) and
  `diff_values_alias_chain_cycle_terminates_without_hang` (cyclic alias
  chain terminates instead of hanging).
- `moon run sdk:test` — 1423 passed, 1 skipped.
- `moon run sdk:lint` — clean.
- Ran `design-data figma diff --snapshot core/tests/fixtures/figma/s2-web-variables.baseline.json`
  before/after: all 10 target Layout entries move `figma_only` -> `match`;
  `figma_only` count 13 -> 3 (remaining 3 are the separately-tracked
  code-font entries); every other count byte-identical (no regression).

## Screenshots (if appropriate):

N/A — CLI/library change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
