### PR TITLE
fix(sdk): resolve code-font-family CTR in figma diff

### DIFF
--- a/.changeset/figma-code-font-family-ctr-resolution.md
+++ b/.changeset/figma-code-font-family-ctr-resolution.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Resolve the remaining code-font `figma_only` entries in `figma diff` (closes #11k.10.12).
+
+- **sdk/core/src/graph.rs**: added `font-family.json` to `INLINE_CTR_COMPARABLE_SCHEMAS`
+  so the inline `code-font-family` CTR resolves, letting `Code/Font family`,
+  `platformScale/code-cjk-font-family`, and `platformScale/code-font-family` match
+  against their Figma STRING values instead of showing as `figma_only`.

--- a/sdk/core/src/figma/import.rs
+++ b/sdk/core/src/figma/import.rs
@@ -2210,6 +2210,43 @@ mod tests {
     }
 
     #[test]
+    fn font_family_verbatim_value_agrees() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/code-font-family",
+            "STRING",
+            vec![("m-desktop", json!("Source Code Pro"))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "code-font-family",
+            "u-code-font-family",
+            json!("Source Code Pro"),
+            "https://example.com/font-family.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.matched, 1);
+        assert_eq!(report.counts.value_mismatch, 0);
+    }
+
+    /// Unlike font-weight/style, family names compare verbatim — no casing or
+    /// punctuation normalization, so a genuinely different family mismatches.
+    #[test]
+    fn font_family_genuine_difference_mismatches() {
+        let meta = mock_meta(vec![mock_variable(
+            "platformScale/code-font-family",
+            "STRING",
+            vec![("m-desktop", json!("Fira Code"))],
+        )]);
+        let graph = mock_graph_with_schema(
+            "code-font-family",
+            "u-code-font-family",
+            json!("Source Code Pro"),
+            "https://example.com/font-family.json",
+        );
+        let report = diff_values(&meta, &graph, &[], None).unwrap();
+        assert_eq!(report.counts.value_mismatch, 1);
+    }
+
+    #[test]
     fn dp_unit_agrees_with_bare_figma_number() {
         let meta = mock_meta(vec![mock_variable(
             "platformScale/android-elevation",

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1462,9 +1462,10 @@ impl TokenGraph {
     }
 
     /// Schemas whose inline CTR `value` is a plain literal directly comparable
-    /// to a Figma value — unlike `font-family.json`, whose inline CTR value is
-    /// a bare family-name string with no schema-driven comparison rule, so it
-    /// deliberately stays unresolved here (see `resolve_relationship_ref`).
+    /// to a Figma value. `font-family.json`'s inline value is a bare
+    /// family-name string, compared verbatim against a Figma `STRING`
+    /// variable by `diff_against_source`'s `"STRING"` branch — same rule as
+    /// any other literal here, no font-specific normalization.
     ///
     /// Not derived from `figma::import::diff_against_source`'s Figma-side
     /// `resolved_type` match (`COLOR`/`FLOAT`/`STRING`) — that classifies by
@@ -1472,11 +1473,12 @@ impl TokenGraph {
     /// shared enum between them. Adding a schema here that isn't actually
     /// FLOAT/STRING-comparable on the Figma side needs a matching look at
     /// `diff_against_source`.
-    const INLINE_CTR_COMPARABLE_SCHEMAS: [&'static str; 4] = [
+    const INLINE_CTR_COMPARABLE_SCHEMAS: [&'static str; 5] = [
         "dimension.json",
         "multiplier.json",
         "gradient-stop.json",
         "opacity.json",
+        "font-family.json",
     ];
 
     /// Rebuild `relationship_tokens` from `self.relationships`: for every CTR
@@ -3032,11 +3034,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_relationship_ref_stays_unresolved_through_font_family_chain() {
+    fn resolve_relationship_ref_resolves_through_font_family_chain() {
         // code-cjk-font-family's real shape: its $ref targets
-        // code-font-family, an inline font-family CTR deliberately excluded
-        // from INLINE_CTR_COMPARABLE_SCHEMAS. The chain must stay unresolved
-        // rather than surfacing that inline value.
+        // code-font-family, an inline font-family CTR in
+        // INLINE_CTR_COMPARABLE_SCHEMAS. The chain must resolve to the
+        // inline value, same as dimension/multiplier/opacity CTR chains.
         let g = TokenGraph::default().with_relationships(vec![
             RelationshipRecord {
                 file: PathBuf::from("relationships/code.json"),
@@ -3044,6 +3046,7 @@ mod tests {
                 uuid: Some("22222222-0000-0000-0000-000000000001".to_string()),
                 raw: json!({
                     "legacyKey": "code-font-family",
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
                     "value": "Source Code Pro",
                     "uuid": "22222222-0000-0000-0000-000000000001"
                 }),
@@ -3060,7 +3063,10 @@ mod tests {
             },
         ]);
 
-        assert!(g.resolve_relationship_ref("code-cjk-font-family").is_none());
+        let rec = g
+            .resolve_relationship_ref("code-cjk-font-family")
+            .expect("font-family CTR chain must resolve");
+        assert_eq!(rec.raw["value"], "Source Code Pro");
     }
 
     #[test]


### PR DESCRIPTION
## Description

`figma diff` against the "S2 - Web" baseline
(`sdk/core/tests/fixtures/figma/s2-web-variables.baseline.json`) reported 3
remaining Layout/code-font tokens `figma_only`:

- `Code/Font family`
- `platformScale/code-cjk-font-family`
- `platformScale/code-font-family`

10 of the original 13 figma-only entries in this family were fixed in #1445
(multi-hop alias-chain resolution). These 3 are a different root cause: not
alias depth (they're 0-1 hop, well within #1445's fix), but a resolution-wiring
gap — `INLINE_CTR_COMPARABLE_SCHEMAS` in `graph.rs` deliberately excluded
`font-family.json`, so the inline `code-font-family` CTR
(`packages/design-data/relationships/code.json`, value `"Source Code Pro"`)
never indexed into `relationship_tokens`, and `resolve_relationship_ref`
returned `None` for it and its aliasing siblings.

- **sdk/core/src/graph.rs**: add `"font-family.json"` to
  `INLINE_CTR_COMPARABLE_SCHEMAS`, mirroring the existing
  dimension/multiplier/gradient-stop/opacity handling. `code-font-family` is
  the only inline font-family CTR in the corpus, so blast radius is contained
  to these 3 tokens.
- The Figma-side `"STRING"` branch in `diff_against_source`
  (`sdk/core/src/figma/import.rs`) already compares font-family values
  verbatim — no new comparison rule, no font-name normalization added (that
  stays scoped to font-weight/style via `record_is_font_name`).
- Updated the stale test that asserted the old "stays unresolved" contract
  (`resolve_relationship_ref_stays_unresolved_through_font_family_chain` ->
  `resolve_relationship_ref_resolves_through_font_family_chain`).
- Added `figma::import::tests` coverage: verbatim match and a genuine mismatch
  case for an inline font-family CTR.

No exporter (`mapping.rs`) changes — `figma_only` comes from the reverse pass,
which never consults the exporter (same as #1445).

## Related Issue

Closes `spectrum-design-data-11k.10.12`.

## Motivation and Context

Closes out the last of the code-font `figma_only` gaps tracked under
`spectrum-design-data-11k.10` (figma export: extend Variables mapping beyond
`.Color theme` / `.Platform scale`).

## How Has This Been Tested?

- `moon run sdk:test`: 1425 tests run, 1425 passed, 1 skipped.
- `moon run sdk:lint`: clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`: clean.
- End-to-end: ran
  `cargo run -p design-data-cli -- figma diff --snapshot core/tests/fixtures/figma/s2-web-variables.baseline.json --format json`
  and confirmed all 3 entries moved from `figma_only` to `match`, with
  `figma_only: 0` and no new `value_mismatch` entries (the 1 pre-existing
  `value_mismatch` is unrelated and unchanged).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
