### PR TITLE
feat(sdk): op-based extensions/mode-sets/ grammar for platform manifests

### DIFF
--- a/.changeset/mode-set-ops.md
+++ b/.changeset/mode-set-ops.md
@@ -1,0 +1,13 @@
+---
+"@adobe/design-data-spec": minor
+---
+
+Platform manifests can now add, remove, or retarget a single mode value (or remove a whole
+set) in `extensions/mode-sets/` via an `op` field, instead of only declaring or replacing
+the entire set.
+
+- **spec/manifest.md**: documented the `addMode` / `removeMode` / `setDefault` / `remove`
+  op grammar and updated the capability matrix.
+- **spec/mode-sets.md**: cross-referenced the new ops alongside the existing
+  declare-or-replace semantics.
+- **conformance/manifest-extensions/**: added valid and invalid fixtures covering each op.

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/expected-errors.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/expected-errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": [
+    { "message_pattern": "removeMode" },
+    { "message_pattern": "current default" }
+  ]
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/extensions/mode-sets/remove-desktop.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/extensions/mode-sets/remove-desktop.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "op": "removeMode", "mode": "desktop" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/extensions/mode-sets/scale.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/extensions/mode-sets/scale.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "modes": ["desktop", "mobile"], "default": "desktop" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-remove-mode-of-default/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/expected-errors.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/expected-errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": [
+    { "message_pattern": "setDefault" },
+    { "message_pattern": "not in its modes" }
+  ]
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/extensions/mode-sets/default-tv.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/extensions/mode-sets/default-tv.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "op": "setDefault", "default": "tv" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/extensions/mode-sets/scale.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/extensions/mode-sets/scale.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "modes": ["desktop", "mobile"], "default": "desktop" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-set-default-nonmember/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-target-not-found/expected-errors.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-target-not-found/expected-errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": [
+    { "message_pattern": "\"scale\"" },
+    { "message_pattern": "does not exist" }
+  ]
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-target-not-found/extensions/mode-sets/add-tv.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-target-not-found/extensions/mode-sets/add-tv.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "op": "addMode", "mode": "tv" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-target-not-found/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-target-not-found/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/expected-errors.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/expected-errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": [
+    { "message_pattern": "unknown op" },
+    { "message_pattern": "\"bogus\"" }
+  ]
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/extensions/mode-sets/bogus.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/extensions/mode-sets/bogus.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "op": "bogus" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/extensions/mode-sets/scale.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/extensions/mode-sets/scale.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "modes": ["desktop", "mobile"], "default": "desktop" }

--- a/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/invalid/mode-set-unknown-op/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/expected.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/expected.json
@@ -1,0 +1,8 @@
+{
+  "modeSets": {
+    "present": ["scale"],
+    "modes": {
+      "scale": { "modes": ["desktop", "mobile", "tv"], "default": "desktop" }
+    }
+  }
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/extensions/mode-sets/add-tv.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/extensions/mode-sets/add-tv.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "op": "addMode", "mode": "tv" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/extensions/mode-sets/scale.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/extensions/mode-sets/scale.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "modes": ["desktop", "mobile"], "default": "desktop" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-add-mode/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/expected.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/expected.json
@@ -1,0 +1,8 @@
+{
+  "modeSets": {
+    "present": ["colorScheme"],
+    "modes": {
+      "colorScheme": { "modes": ["light", "dark"], "default": "light" }
+    }
+  }
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/extensions/mode-sets/color-scheme.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/extensions/mode-sets/color-scheme.json
@@ -1,0 +1,5 @@
+{
+  "name": "colorScheme",
+  "modes": ["light", "dark", "wireframe"],
+  "default": "light"
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/extensions/mode-sets/remove-wireframe.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/extensions/mode-sets/remove-wireframe.json
@@ -1,0 +1,1 @@
+{ "name": "colorScheme", "op": "removeMode", "mode": "wireframe" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove-mode/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/expected.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/expected.json
@@ -1,0 +1,1 @@
+{ "modeSets": { "absent": ["contrast"] } }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/extensions/mode-sets/contrast.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/extensions/mode-sets/contrast.json
@@ -1,0 +1,1 @@
+{ "name": "contrast", "modes": ["regular", "high"], "default": "regular" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/extensions/mode-sets/remove-contrast.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/extensions/mode-sets/remove-contrast.json
@@ -1,0 +1,1 @@
+{ "name": "contrast", "op": "remove" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-remove/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/expected.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/expected.json
@@ -1,0 +1,6 @@
+{
+  "modeSets": {
+    "present": ["scale"],
+    "modes": { "scale": { "default": "tv" } }
+  }
+}

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/extensions/mode-sets/default-tv.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/extensions/mode-sets/default-tv.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "op": "setDefault", "default": "tv" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/extensions/mode-sets/scale.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/extensions/mode-sets/scale.json
@@ -1,0 +1,1 @@
+{ "name": "scale", "modes": ["desktop", "mobile", "tv"], "default": "desktop" }

--- a/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/manifest.json
+++ b/packages/design-data-spec/conformance/manifest-extensions/valid/mode-set-set-default/manifest.json
@@ -1,0 +1,1 @@
+{ "specVersion": "1.0.0-draft", "foundationVersion": "1.0.0" }

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -8,24 +8,25 @@ This document defines the **platform manifest**: how a platform implementation r
 
 The manifest supports a fixed, enumerated set of operations against the foundation — it does **not** allow overriding, aliasing, or removing arbitrary foundation artifacts. Support is concentrated on tokens; translations and schemas have no manifest-level override mechanism at all.
 
-| Operation                                          | Supported?                                                   | Field                             | Applies to            |
-| -------------------------------------------------- | ------------------------------------------------------------ | --------------------------------- | --------------------- |
-| Remove / exclude                                   | Yes                                                          | `exclude`                         | Tokens only           |
-| Include / whitelist                                | Yes                                                          | `include`                         | Tokens only           |
-| Override value (type-preserving)                   | Yes                                                          | `overrides[].value`               | Tokens only           |
-| Override → re-alias                                | Yes                                                          | `overrides[].$ref`                | Tokens only           |
-| Add new tokens (may alias via `$ref`)              | Yes                                                          | `extensions/tokens/`              | Tokens                |
-| Add / replace components                           | Yes                                                          | `extensions/components/`          | Components            |
-| Add / replace field declarations                   | Yes                                                          | `extensions/fields/`              | Fields                |
-| Add / replace guideline documents                  | Yes                                                          | `extensions/guidelines/`          | Guidelines            |
-| Declare / replace platform-local mode set          | Yes                                                          | `extensions/mode-sets/`           | Mode sets             |
-| Add relationships/CTRs; override/remove by `uuid`  | Yes                                                          | `extensions/relationships/`       | Relationships (CTRs)  |
-| Add / remove naming exceptions                     | Yes                                                          | `namingExceptions`                | Naming validation     |
-| Annotate existing terminology (cannot add new ids) | Yes                                                          | `extensions/platform-extensions/` | Existing registry ids |
-| Restrict allowed mode-set values                   | Yes                                                          | `modeSetRestrictions`             | Mode sets             |
-| Reformat name serialization                        | Schema-declared only, not yet applied by the reference SDK   | `formatting`                      | Token name strings    |
-| Override/remove/alias translations                 | No                                                           | —                                 | —                     |
-| Override Layer-1 schemas                           | No (decided; see [spike](manifest-schema-override-spike.md)) | —                                 | —                     |
+| Operation                                           | Supported?                                                   | Field                             | Applies to            |
+| --------------------------------------------------- | ------------------------------------------------------------ | --------------------------------- | --------------------- |
+| Remove / exclude                                    | Yes                                                          | `exclude`                         | Tokens only           |
+| Include / whitelist                                 | Yes                                                          | `include`                         | Tokens only           |
+| Override value (type-preserving)                    | Yes                                                          | `overrides[].value`               | Tokens only           |
+| Override → re-alias                                 | Yes                                                          | `overrides[].$ref`                | Tokens only           |
+| Add new tokens (may alias via `$ref`)               | Yes                                                          | `extensions/tokens/`              | Tokens                |
+| Add / replace components                            | Yes                                                          | `extensions/components/`          | Components            |
+| Add / replace field declarations                    | Yes                                                          | `extensions/fields/`              | Fields                |
+| Add / replace guideline documents                   | Yes                                                          | `extensions/guidelines/`          | Guidelines            |
+| Declare / replace platform-local mode set           | Yes                                                          | `extensions/mode-sets/`           | Mode sets             |
+| Add / remove / retarget a single mode; remove a set | Yes                                                          | `extensions/mode-sets/` (`op`)    | Mode sets             |
+| Add relationships/CTRs; override/remove by `uuid`   | Yes                                                          | `extensions/relationships/`       | Relationships (CTRs)  |
+| Add / remove naming exceptions                      | Yes                                                          | `namingExceptions`                | Naming validation     |
+| Annotate existing terminology (cannot add new ids)  | Yes                                                          | `extensions/platform-extensions/` | Existing registry ids |
+| Restrict allowed mode-set values                    | Yes                                                          | `modeSetRestrictions`             | Mode sets             |
+| Reformat name serialization                         | Schema-declared only, not yet applied by the reference SDK   | `formatting`                      | Token name strings    |
+| Override/remove/alias translations                  | No                                                           | —                                 | —                     |
+| Override Layer-1 schemas                            | No (decided; see [spike](manifest-schema-override-spike.md)) | —                                 | —                     |
 
 ## Manifest document
 
@@ -148,19 +149,39 @@ by the reference SDK.
 
 #### `extensions/mode-sets/`
 
-Platform-local mode-set declarations, injected into the mode-set catalog for this platform's
-resolution. **NORMATIVE:** each file **MUST** validate against `mode-set.schema.json` (requiring
-`name`, `modes`, `default`); `default ∈ modes` is a Layer 2 concern, enforced by SPEC-005 against
-whichever mode sets end up in the resolved graph, foundation or platform-declared alike.
+Platform-local mode-set declarations and edits, injected into the mode-set catalog for this
+platform's resolution. A mode set's `name` is its stable key (there is no separate `uuid`, unlike
+relationships) — every entry, add or op alike, identifies its target by `name`:
 
-Semantics are **declare-or-replace by name**, the same as `extensions/fields/`: a `name` not
-already in the foundation catalog is a clean new platform axis (e.g. `interfaceLevel: [base, elevated]`); a `name` matching a foundation mode set replaces it, for this platform only —
-the foundation catalog is untouched. Contrast with `modeSetRestrictions`
-([Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions)), a top-level manifest
-field that only *narrows* the allowed values of an existing mode set — it cannot add a mode value
-or declare a new axis. Redeclaring the full mode set here to add a value (rather than restricting
-it) means the platform restates the foundation's other values, which can drift from foundation; a
-future `op: "extend"` merge semantic may remove that restatement if a platform needs it.
+* **Add / replace:** an entry with no `op` field is a full mode-set object (**NORMATIVE:** MUST
+  validate against `mode-set.schema.json`, requiring `name`, `modes`, `default`). A `name` not
+  already in the foundation catalog is a clean new platform axis (e.g. `interfaceLevel: [base,
+  elevated]`); a `name` matching a foundation mode set replaces it, for this platform only — the
+  foundation catalog is untouched.
+* **`"op": "addMode"`** — appends one mode value (`mode`) to an existing set, without restating its
+  other modes. **NORMATIVE:** the target set (by `name`) MUST already exist and MUST NOT already
+  contain `mode`; either condition failing is a manifest error.
+* **`"op": "removeMode"`** — drops one mode value (`mode`) from an existing set. **NORMATIVE:** the
+  target MUST exist, MUST contain `mode`, `mode` MUST NOT be the set's current default (retarget the
+  default first with `setDefault`), and the set MUST have more than one mode remaining afterward —
+  each violation is a manifest error.
+* **`"op": "setDefault"`** — retargets an existing set's default mode (`default`). **NORMATIVE:**
+  the target MUST exist and `default` MUST already be one of its modes.
+* **`"op": "remove"`** — drops the whole set (by `name`) from this platform's resolution.
+  **NORMATIVE:** the target MUST exist.
+
+Add/replace entries are applied before op entries, regardless of file sort order, so a set declared
+in one file can be edited by an op in another file within the same `extensions/mode-sets/`
+directory. Ops within each group apply in sorted path order. Any other `op` value, or an op entry
+missing its required field (`mode` for `addMode`/`removeMode`, `default` for `setDefault`), is a
+manifest error — the reference SDK rejects the load rather than silently skipping it, consistent
+with `extensions/relationships/`'s override/remove ops above. `default ∈ modes` remains a Layer 2
+concern for the resolved graph as a whole, enforced by SPEC-005 against whichever mode sets end up
+there, foundation or platform-declared alike.
+
+Contrast with `modeSetRestrictions` ([Mode Sets — Platform restrictions](mode-sets.md#platform-restrictions)), a top-level manifest field that only *narrows* the allowed values of an
+existing mode set at resolution time — it cannot add, remove, or retarget a mode value, or declare
+a new axis.
 
 #### `extensions/platform-extensions/`
 

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -163,12 +163,15 @@ relationships) — every entry, add or op alike, identifies its target by `name`
   contain `mode`; either condition failing is a manifest error.
 * **`"op": "removeMode"`** — drops one mode value (`mode`) from an existing set. **NORMATIVE:** the
   target MUST exist, MUST contain `mode`, `mode` MUST NOT be the set's current default (retarget the
-  default first with `setDefault`), and the set MUST have more than one mode remaining afterward —
-  each violation is a manifest error.
+  default first with `setDefault`), the set MUST have more than one mode remaining afterward, and no
+  token in the resolved graph MAY still carry `mode` as that mode set's value — each violation is a
+  manifest error. (This mirrors the reference SDK's authoring-time `remove_mode` guard, which checks
+  the same "still referenced" condition against cascade token files.)
 * **`"op": "setDefault"`** — retargets an existing set's default mode (`default`). **NORMATIVE:**
   the target MUST exist and `default` MUST already be one of its modes.
 * **`"op": "remove"`** — drops the whole set (by `name`) from this platform's resolution.
-  **NORMATIVE:** the target MUST exist.
+  **NORMATIVE:** the target MUST exist, and no token in the resolved graph MAY still carry this mode
+  set's `name` as a key — either violation is a manifest error.
 
 Add/replace entries are applied before op entries, regardless of file sort order, so a set declared
 in one file can be edited by an op in another file within the same `extensions/mode-sets/`

--- a/packages/design-data-spec/spec/mode-sets.md
+++ b/packages/design-data-spec/spec/mode-sets.md
@@ -45,8 +45,15 @@ The Spectrum foundation publishes mode set declarations as JSON files under `pac
 
 Additional mode sets (e.g. `language`, `motion`) **MAY** be declared in a dataset's mode set catalog. Token name objects **MAY** include keys matching declared mode set names.
 
-A platform manifest **MAY** also declare mode sets local to that platform, one per file under
-`extensions/mode-sets/` (see [Platform manifest — `extensions/` directory](manifest.md#extensions-directory)). Platform-declared mode sets are scoped to that platform's resolution and use the same **declare-or-replace-by-name** semantics as `extensions/fields/`: a new `name` adds a platform-local axis (e.g. `interfaceLevel`), while a `name` matching a foundation mode set replaces it for that platform only, leaving the foundation catalog untouched. This is distinct from `modeSetRestrictions` (below), which only *narrows* the allowed values of an existing mode set rather than declaring one.
+A platform manifest **MAY** also declare or edit mode sets local to that platform, one entry per
+file under `extensions/mode-sets/` (see [Platform manifest — `extensions/`
+directory](manifest.md#extensions-directory)). An entry with no `op` uses **declare-or-replace-by-name** semantics, same as `extensions/fields/`: a new `name` adds a platform-local axis (e.g.
+`interfaceLevel`), while a `name` matching a foundation mode set replaces it for that platform only,
+leaving the foundation catalog untouched. `op: "addMode"` / `"removeMode"` / `"setDefault"` /
+`"remove"` instead edit an existing set in place — adding or dropping a single mode value,
+retargeting its default, or dropping the whole set — without restating its other modes. This is
+distinct from `modeSetRestrictions` (below), which only *narrows* the allowed values of an existing
+mode set at resolution time rather than editing the declared set itself.
 
 ## Defaults and specificity
 

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1039,11 +1039,21 @@ impl TokenGraph {
             }
         }
 
-        // 7b. extensions.modeSets — platform-local mode-set declarations,
-        // add-or-replace by name into `self.mode_sets`. New name = a clean new
-        // platform axis; existing name = the platform's version replaces it for
-        // this platform's resolution only (declare-or-replace, mirrors
-        // extensions.fields above). Cascade specificity/matching and SPEC-005
+        // 7b. extensions.modeSets — platform-local mode-set declarations and
+        // edits, keyed by "op" (mirrors extensions.relationships' add/override/
+        // remove grammar):
+        //   - no "op": add-or-replace the whole set by name (unchanged
+        //     behavior). New name = a clean new platform axis; existing name =
+        //     the platform's version replaces it for this platform's
+        //     resolution only — the foundation catalog is untouched.
+        //   - "op": "addMode" / "removeMode" — add or drop a single mode value
+        //     on an existing set, without restating its other modes.
+        //   - "op": "setDefault" — change an existing set's default mode.
+        //   - "op": "remove" — drop the whole set from this platform's
+        //     resolution.
+        // Every op but the plain add targets an existing set by "name" and is
+        // rejected (not silently skipped) when the target, or an op-specific
+        // field, is missing. Cascade specificity/matching and SPEC-005
         // (default ∈ modes) already operate on `graph.mode_sets` generically —
         // no changes needed there.
         if let Some(entries) = manifest
@@ -1055,23 +1065,136 @@ impl TokenGraph {
                 let Some(name) = entry.get("name").and_then(|v| v.as_str()) else {
                     continue;
                 };
-                let Some(modes) = entry.get("modes").and_then(|v| v.as_array()) else {
-                    continue;
-                };
-                let Some(default_mode) = entry.get("default").and_then(|v| v.as_str()) else {
-                    continue;
-                };
-                let modes: Vec<String> = modes
-                    .iter()
-                    .filter_map(|m| m.as_str().map(String::from))
-                    .collect();
-                let record = ModeSetRecord {
-                    file: PathBuf::from("manifest.json"),
-                    name: name.to_string(),
-                    modes,
-                    default_mode: default_mode.to_string(),
-                };
-                upsert_by_key(&mut self.mode_sets, |m| m.name == name, record);
+                match entry.get("op").and_then(|v| v.as_str()) {
+                    None => {
+                        let Some(modes) = entry.get("modes").and_then(|v| v.as_array()) else {
+                            continue;
+                        };
+                        let Some(default_mode) = entry.get("default").and_then(|v| v.as_str())
+                        else {
+                            continue;
+                        };
+                        let modes: Vec<String> = modes
+                            .iter()
+                            .filter_map(|m| m.as_str().map(String::from))
+                            .collect();
+                        let record = ModeSetRecord {
+                            file: PathBuf::from("manifest.json"),
+                            name: name.to_string(),
+                            modes,
+                            default_mode: default_mode.to_string(),
+                        };
+                        upsert_by_key(&mut self.mode_sets, |m| m.name == name, record);
+                    }
+                    Some("addMode") => {
+                        let mode = entry.get("mode").and_then(|v| v.as_str()).ok_or_else(|| {
+                            CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets addMode for \"{name}\" \
+                                 is missing a \"mode\""
+                            ))
+                        })?;
+                        let target = self
+                            .mode_sets
+                            .iter_mut()
+                            .find(|m| m.name == name)
+                            .ok_or_else(|| {
+                                CoreError::ParseError(format!(
+                                    "platform manifest extensions.modeSets addMode targets \
+                                     mode set \"{name}\" which does not exist"
+                                ))
+                            })?;
+                        if target.modes.iter().any(|m| m == mode) {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets addMode for \"{name}\" \
+                                 mode \"{mode}\" already exists"
+                            )));
+                        }
+                        target.modes.push(mode.to_string());
+                    }
+                    Some("removeMode") => {
+                        let mode = entry.get("mode").and_then(|v| v.as_str()).ok_or_else(|| {
+                            CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets removeMode for \"{name}\" \
+                                 is missing a \"mode\""
+                            ))
+                        })?;
+                        let target = self
+                            .mode_sets
+                            .iter_mut()
+                            .find(|m| m.name == name)
+                            .ok_or_else(|| {
+                                CoreError::ParseError(format!(
+                                    "platform manifest extensions.modeSets removeMode targets \
+                                     mode set \"{name}\" which does not exist"
+                                ))
+                            })?;
+                        if !target.modes.iter().any(|m| m == mode) {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets removeMode for \"{name}\" \
+                                 mode \"{mode}\" does not exist"
+                            )));
+                        }
+                        if target.default_mode == mode {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets removeMode for \"{name}\" \
+                                 cannot remove \"{mode}\" — it is the current default (use \
+                                 \"setDefault\" first)"
+                            )));
+                        }
+                        if target.modes.len() == 1 {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets removeMode for \"{name}\" \
+                                 cannot remove its only remaining mode \"{mode}\""
+                            )));
+                        }
+                        target.modes.retain(|m| m != mode);
+                    }
+                    Some("setDefault") => {
+                        let default_mode = entry
+                            .get("default")
+                            .and_then(|v| v.as_str())
+                            .ok_or_else(|| {
+                                CoreError::ParseError(format!(
+                                    "platform manifest extensions.modeSets setDefault for \
+                                     \"{name}\" is missing a \"default\""
+                                ))
+                            })?;
+                        let target = self
+                            .mode_sets
+                            .iter_mut()
+                            .find(|m| m.name == name)
+                            .ok_or_else(|| {
+                                CoreError::ParseError(format!(
+                                    "platform manifest extensions.modeSets setDefault targets \
+                                     mode set \"{name}\" which does not exist"
+                                ))
+                            })?;
+                        if !target.modes.iter().any(|m| m == default_mode) {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets setDefault for \"{name}\" \
+                                 default \"{default_mode}\" is not in its modes"
+                            )));
+                        }
+                        target.default_mode = default_mode.to_string();
+                    }
+                    Some("remove") => {
+                        let before = self.mode_sets.len();
+                        self.mode_sets.retain(|m| m.name != name);
+                        if self.mode_sets.len() == before {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets remove targets mode set \
+                                 \"{name}\" which does not exist"
+                            )));
+                        }
+                    }
+                    Some(other) => {
+                        return Err(CoreError::ParseError(format!(
+                            "platform manifest extensions.modeSets entry has unknown op \
+                             \"{other}\" (expected \"addMode\", \"removeMode\", \"setDefault\", \
+                             or \"remove\", or omit \"op\" to add/replace the whole set)"
+                        )));
+                    }
+                }
             }
         }
 
@@ -2644,6 +2767,234 @@ mod tests {
         let base_ctx = ResolutionContext::new().with("interfaceLevel", "base");
         let base_winner = resolve(&g, &base_ctx).expect("should find a winner");
         assert_eq!(base_winner.uuid.as_deref(), Some("u-btn-bg"));
+    }
+
+    fn scale_mode_set() -> ModeSetRecord {
+        ModeSetRecord {
+            file: PathBuf::from("mode-sets/scale.json"),
+            name: "scale".to_string(),
+            modes: vec!["desktop".to_string(), "mobile".to_string()],
+            default_mode: "desktop".to_string(),
+        }
+    }
+
+    #[test]
+    fn manifest_mode_set_add_mode_appends_without_restating_others() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "addMode", "mode": "tv"}]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+
+        let scale = g.mode_sets.iter().find(|m| m.name == "scale").unwrap();
+        assert_eq!(scale.modes, vec!["desktop", "mobile", "tv"]);
+        assert_eq!(scale.default_mode, "desktop");
+    }
+
+    #[test]
+    fn manifest_mode_set_add_mode_duplicate_errors() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "addMode", "mode": "mobile"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_add_mode_missing_target_errors() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "addMode", "mode": "tv"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_mode_drops_a_non_default_value() {
+        let mut g = foundation_graph().with_mode_sets(vec![ModeSetRecord {
+            file: PathBuf::from("mode-sets/color-scheme.json"),
+            name: "colorScheme".to_string(),
+            modes: vec![
+                "light".to_string(),
+                "dark".to_string(),
+                "wireframe".to_string(),
+            ],
+            default_mode: "light".to_string(),
+        }]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "colorScheme", "op": "removeMode", "mode": "wireframe"}]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+
+        let cs = g
+            .mode_sets
+            .iter()
+            .find(|m| m.name == "colorScheme")
+            .unwrap();
+        assert_eq!(cs.modes, vec!["light", "dark"]);
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_mode_of_current_default_errors() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "removeMode", "mode": "desktop"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_mode_last_remaining_errors() {
+        let mut g = foundation_graph().with_mode_sets(vec![ModeSetRecord {
+            file: PathBuf::from("mode-sets/single.json"),
+            name: "single".to_string(),
+            modes: vec!["only".to_string()],
+            default_mode: "only".to_string(),
+        }]);
+        // Retarget the default first so the "current default" guard doesn't
+        // fire before the "last remaining mode" guard is exercised.
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [
+                    {"name": "single", "op": "addMode", "mode": "other"},
+                    {"name": "single", "op": "setDefault", "default": "other"},
+                    {"name": "single", "op": "removeMode", "mode": "only"},
+                    {"name": "single", "op": "removeMode", "mode": "other"}
+                ]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_set_default_retargets() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [
+                    {"name": "scale", "op": "addMode", "mode": "tv"},
+                    {"name": "scale", "op": "setDefault", "default": "tv"}
+                ]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+
+        let scale = g.mode_sets.iter().find(|m| m.name == "scale").unwrap();
+        assert_eq!(scale.default_mode, "tv");
+    }
+
+    #[test]
+    fn manifest_mode_set_set_default_to_nonmember_errors() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "setDefault", "default": "tv"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_drops_the_whole_set() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "remove"}]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+
+        assert!(!g.mode_sets.iter().any(|m| m.name == "scale"));
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_missing_target_errors() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "remove"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_unknown_op_errors() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "bogus"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_add_mode_then_resolves_via_cascade() {
+        use crate::cascade::{resolve, ResolutionContext};
+
+        let mut g = TokenGraph::from_pairs(vec![
+            (
+                "btn-bg".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "background-color", "component": "button"}, "value": "#aaa", "uuid": "u-btn-bg"}),
+            ),
+            (
+                "btn-bg-tv".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "background-color", "component": "button", "scale": "tv"}, "value": "#ccc", "uuid": "u-btn-bg-tv"}),
+            ),
+        ])
+        .with_mode_sets(vec![scale_mode_set()]);
+
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "addMode", "mode": "tv"}]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+
+        let tv_ctx = ResolutionContext::new().with("scale", "tv");
+        let tv_winner = resolve(&g, &tv_ctx).expect("should find a winner");
+        assert_eq!(tv_winner.uuid.as_deref(), Some("u-btn-bg-tv"));
+
+        let desktop_ctx = ResolutionContext::new().with("scale", "desktop");
+        let desktop_winner = resolve(&g, &desktop_ctx).expect("should find a winner");
+        assert_eq!(desktop_winner.uuid.as_deref(), Some("u-btn-bg"));
     }
 
     #[test]

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1062,10 +1062,37 @@ impl TokenGraph {
             .and_then(|v| v.as_array())
         {
             for entry in entries {
-                let Some(name) = entry.get("name").and_then(|v| v.as_str()) else {
-                    continue;
+                // An "op" key present but not a string (e.g. a number or bool) must
+                // not silently fall through to the plain-add path below — that would
+                // treat a malformed op entry as an untargeted add and drop it via the
+                // add path's own missing-modes/default `continue`, defeating the
+                // "reject rather than silently skip" guarantee for ops.
+                if let Some(op_value) = entry.get("op") {
+                    if op_value.as_str().is_none() {
+                        return Err(CoreError::ParseError(format!(
+                            "platform manifest extensions.modeSets entry has a non-string \
+                             \"op\" ({op_value})"
+                        )));
+                    }
+                }
+                let op = entry.get("op").and_then(|v| v.as_str());
+                // Every op (unlike the plain add below) targets an existing set by
+                // "name", so a missing "name" here is a manifest error, not a skip.
+                let name = if op.is_some() {
+                    entry.get("name").and_then(|v| v.as_str()).ok_or_else(|| {
+                        CoreError::ParseError(format!(
+                            "platform manifest extensions.modeSets \"{}\" entry is missing \
+                             a \"name\"",
+                            op.unwrap()
+                        ))
+                    })?
+                } else {
+                    let Some(name) = entry.get("name").and_then(|v| v.as_str()) else {
+                        continue;
+                    };
+                    name
                 };
-                match entry.get("op").and_then(|v| v.as_str()) {
+                match op {
                     None => {
                         let Some(modes) = entry.get("modes").and_then(|v| v.as_array()) else {
                             continue;
@@ -1147,6 +1174,34 @@ impl TokenGraph {
                                  cannot remove its only remaining mode \"{mode}\""
                             )));
                         }
+                        // Guard against orphaning tokens authored against this mode value:
+                        // cascade matching never validates a token's mode value against the
+                        // set's remaining `modes`, so a stale "mode" reference would keep
+                        // matching (and could even outrank the default by specificity).
+                        let referenced = self
+                            .tokens
+                            .values()
+                            .filter(|t| {
+                                t.raw
+                                    .get("name")
+                                    .and_then(|v| v.as_object())
+                                    .and_then(|o| o.get(name))
+                                    .and_then(|v| v.as_str())
+                                    == Some(mode)
+                            })
+                            .count();
+                        if referenced > 0 {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets removeMode for \"{name}\" \
+                                 cannot remove \"{mode}\" — still referenced by {referenced} \
+                                 token(s); update or remove those tokens first"
+                            )));
+                        }
+                        let target = self
+                            .mode_sets
+                            .iter_mut()
+                            .find(|m| m.name == name)
+                            .expect("existence already checked above");
                         target.modes.retain(|m| m != mode);
                     }
                     Some("setDefault") => {
@@ -1178,14 +1233,33 @@ impl TokenGraph {
                         target.default_mode = default_mode.to_string();
                     }
                     Some("remove") => {
-                        let before = self.mode_sets.len();
-                        self.mode_sets.retain(|m| m.name != name);
-                        if self.mode_sets.len() == before {
+                        if !self.mode_sets.iter().any(|m| m.name == name) {
                             return Err(CoreError::ParseError(format!(
                                 "platform manifest extensions.modeSets remove targets mode set \
                                  \"{name}\" which does not exist"
                             )));
                         }
+                        // Same guard as removeMode: dropping the whole set while tokens
+                        // still carry this mode-set key would orphan them for cascade
+                        // matching (which never validates against the mode-set catalog).
+                        let referenced = self
+                            .tokens
+                            .values()
+                            .filter(|t| {
+                                t.raw
+                                    .get("name")
+                                    .and_then(|v| v.as_object())
+                                    .is_some_and(|o| o.contains_key(name))
+                            })
+                            .count();
+                        if referenced > 0 {
+                            return Err(CoreError::ParseError(format!(
+                                "platform manifest extensions.modeSets remove targets mode set \
+                                 \"{name}\" which is still referenced by {referenced} token(s); \
+                                 update or remove those tokens first"
+                            )));
+                        }
+                        self.mode_sets.retain(|m| m.name != name);
                     }
                     Some(other) => {
                         return Err(CoreError::ParseError(format!(
@@ -2956,6 +3030,74 @@ mod tests {
             "foundationVersion": "1.0.0",
             "extensions": {
                 "modeSets": [{"name": "scale", "op": "bogus"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_op_with_non_string_op_errors() {
+        // A non-string "op" (e.g. a number) must not silently fall through to the
+        // plain add/replace path and be dropped there — it's a manifest error.
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": 1}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_op_missing_name_errors() {
+        let mut g = foundation_graph().with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"op": "addMode", "mode": "tv"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_mode_still_referenced_errors() {
+        // A token authored against "scale": "mobile" must block removeMode from
+        // dropping "mobile" — cascade matching never checks a token's mode value
+        // against the mode set's remaining `modes`, so an orphaned reference would
+        // keep matching (spectrum-design-data reviewer finding).
+        let mut g = TokenGraph::from_pairs(vec![(
+            "btn-bg-mobile".into(),
+            PathBuf::from("button.json"),
+            json!({"name": {"property": "background-color", "component": "button", "scale": "mobile"}, "value": "#ccc", "uuid": "u-btn-bg-mobile"}),
+        )])
+        .with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "removeMode", "mode": "mobile"}]
+            }
+        });
+        assert!(g.apply_platform_manifest(&manifest).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_set_remove_still_referenced_errors() {
+        let mut g = TokenGraph::from_pairs(vec![(
+            "btn-bg-mobile".into(),
+            PathBuf::from("button.json"),
+            json!({"name": {"property": "background-color", "component": "button", "scale": "mobile"}, "value": "#ccc", "uuid": "u-btn-bg-mobile"}),
+        )])
+        .with_mode_sets(vec![scale_mode_set()]);
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "modeSets": [{"name": "scale", "op": "remove"}]
             }
         });
         assert!(g.apply_platform_manifest(&manifest).is_err());

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -1259,6 +1259,50 @@ mod manifest_extensions_behavior {
                         }
                     }
                 }
+                if let Some(absent) = expected
+                    .get(key)
+                    .and_then(|c| c.get("absent"))
+                    .and_then(|v| v.as_array())
+                {
+                    for name in absent.iter().filter_map(|v| v.as_str()) {
+                        if records_len.iter().any(|n| n.as_str() == name) {
+                            failures.push(format!(
+                                "{case}: expected no {key} named {name:?}, but found one"
+                            ));
+                        }
+                    }
+                }
+            }
+
+            if let Some(mode_sets) = expected.get("modeSets") {
+                if let Some(modes) = mode_sets.get("modes").and_then(|v| v.as_object()) {
+                    for (name, want) in modes {
+                        let Some(record) = graph.mode_sets.iter().find(|m| &m.name == name) else {
+                            failures.push(format!(
+                                "{case}: expected mode set {name:?} present to check modes/default"
+                            ));
+                            continue;
+                        };
+                        if let Some(want_modes) = want.get("modes").and_then(|v| v.as_array()) {
+                            let want_modes: Vec<&str> =
+                                want_modes.iter().filter_map(|v| v.as_str()).collect();
+                            if record.modes != want_modes {
+                                failures.push(format!(
+                                    "{case}: mode set {name:?} expected modes {want_modes:?}, got {:?}",
+                                    record.modes
+                                ));
+                            }
+                        }
+                        if let Some(want_default) = want.get("default").and_then(|v| v.as_str()) {
+                            if record.default_mode != want_default {
+                                failures.push(format!(
+                                    "{case}: mode set {name:?} expected default {want_default:?}, got {:?}",
+                                    record.default_mode
+                                ));
+                            }
+                        }
+                    }
+                }
             }
 
             if let Some(order) = expected

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -32,12 +32,12 @@ use crate::CoreError;
 /// [`FragmentValidation::Item`]) — this is what stops an entry missing e.g.
 /// "name" from silently vanishing in `apply_platform_manifest`'s own
 /// `let Some(name) = ... else { continue }`, by failing loudly here instead.
-/// `tokens/` and `relationships/` have their own handling below and aren't here.
+/// `tokens/`, `relationships/`, and `mode-sets/` have their own handling below
+/// and aren't here.
 const CONCAT_CATEGORIES: &[(&str, &str, &str)] = &[
     ("components", "components", "component.schema.json"),
     ("fields", "fields", "field.schema.json"),
     ("guidelines", "guidelines", "guideline.schema.json"),
-    ("mode-sets", "modeSets", "mode-set.schema.json"),
     (
         "platform-extensions",
         "platformExtensions",
@@ -155,13 +155,14 @@ fn build_extensions_value(
         return Ok(None);
     }
 
-    // "tokens" and "relationships" have their own handling below (not in
-    // CONCAT_CATEGORIES); every other recognized subdirectory is one of
+    // "tokens", "relationships", and "mode-sets" have their own handling below
+    // (not in CONCAT_CATEGORIES); every other recognized subdirectory is one of
     // CONCAT_CATEGORIES's entries, so derive the allowlist from there rather
     // than duplicating the category list a second time.
     let known_subdirs: Vec<&str> = std::iter::once("tokens")
         .chain(CONCAT_CATEGORIES.iter().map(|(dir_name, _, _)| *dir_name))
         .chain(std::iter::once("relationships"))
+        .chain(std::iter::once("mode-sets"))
         .collect();
     for entry in std::fs::read_dir(&ext_root)? {
         let entry = entry?;
@@ -237,6 +238,25 @@ fn build_extensions_value(
         }
     }
 
+    // mode-sets/ — plain adds (no "op") must precede addMode/removeMode/
+    // setDefault/remove ops, so that an op in a later-sorted file can still
+    // target an add from an earlier one; `apply_platform_manifest` processes
+    // this array strictly in order. Partition is stable: within each group,
+    // sorted-path order is kept.
+    let mode_sets_dir = ext_root.join("mode-sets");
+    if mode_sets_dir.is_dir() {
+        let items = load_and_concat(
+            &discover_json_files(&mode_sets_dir)?,
+            FragmentValidation::ModeSetAdds(&schema_dir.join("mode-set.schema.json")),
+        )?;
+        if !items.is_empty() {
+            let (mut adds, ops): (Vec<Value>, Vec<Value>) =
+                items.into_iter().partition(|v| v.get("op").is_none());
+            adds.extend(ops);
+            out.insert("modeSets".to_string(), Value::Array(adds));
+        }
+    }
+
     Ok((!out.is_empty()).then_some(Value::Object(out)))
 }
 
@@ -256,6 +276,12 @@ enum FragmentValidation<'a> {
     /// only models plain add/ref shapes — and are left to
     /// `apply_platform_manifest`'s own override/remove structural checks.
     RelationshipAdds(&'a Path),
+    /// `mode-sets/`: each flattened entry *without* an `"op"` key (a plain
+    /// whole-set add/replace) is validated against `mode-set.schema.json`.
+    /// Entries with `"op"` (`addMode`/`removeMode`/`setDefault`/`remove`) have
+    /// no schema of their own and are left to `apply_platform_manifest`'s own
+    /// op-specific structural checks.
+    ModeSetAdds(&'a Path),
 }
 
 /// Read and parse each file in `files`, flattening top-level arrays (cascade
@@ -309,6 +335,16 @@ fn load_and_concat(
                 for item in &items {
                     if item.get("op").is_none() {
                         check_fragment(f, &Value::Array(vec![item.clone()]), schema)?;
+                    }
+                }
+            }
+            FragmentValidation::ModeSetAdds(schema) => {
+                // mode-set.schema.json's top level is a single object (unlike
+                // relationship.schema.json), so each plain-add entry validates
+                // directly, unwrapped.
+                for item in &items {
+                    if item.get("op").is_none() {
+                        check_fragment(f, item, schema)?;
                     }
                 }
             }
@@ -555,6 +591,68 @@ mod tests {
             .expect("manifest-declared mode set present");
         assert_eq!(declared.modes, vec!["base", "elevated"]);
         assert_eq!(declared.default_mode, "base");
+    }
+
+    #[test]
+    fn extensions_mode_sets_op_only_fragment_is_not_schema_rejected() {
+        // An op entry (no `modes`/`default`) would fail mode-set.schema.json's
+        // `required` check if it were validated like a plain add — it must be
+        // skipped by FragmentValidation::ModeSetAdds, not rejected.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[(
+                "mode-sets",
+                "scale-tv.json",
+                json!({"name": "scale", "op": "addMode", "mode": "tv"}),
+            )],
+        );
+
+        let mut graph = make_graph();
+        graph = graph.with_mode_sets(vec![crate::graph::ModeSetRecord {
+            file: PathBuf::from("mode-sets/scale.json"),
+            name: "scale".to_string(),
+            modes: vec!["desktop".to_string(), "mobile".to_string()],
+            default_mode: "desktop".to_string(),
+        }]);
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+
+        let scale = graph.mode_sets.iter().find(|m| m.name == "scale").unwrap();
+        assert_eq!(scale.modes, vec!["desktop", "mobile", "tv"]);
+    }
+
+    #[test]
+    fn extensions_mode_sets_plain_adds_precede_ops_regardless_of_file_order() {
+        // "addMode.json" sorts before "scale.json" by filename, but the plain
+        // add for "scale" must still be applied before the op targeting it —
+        // load_and_concat's partition (adds before ops) must win over
+        // discovery's sorted-path order.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest_with_extensions(
+            dir.path(),
+            json!({}),
+            &[
+                (
+                    "mode-sets",
+                    "addMode.json",
+                    json!({"name": "scale", "op": "addMode", "mode": "tv"}),
+                ),
+                (
+                    "mode-sets",
+                    "scale.json",
+                    json!({"name": "scale", "modes": ["desktop", "mobile"], "default": "desktop"}),
+                ),
+            ],
+        );
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, repo_schemas_root());
+        apply_configured(&mut graph, &resolved).unwrap();
+
+        let scale = graph.mode_sets.iter().find(|m| m.name == "scale").unwrap();
+        assert_eq!(scale.modes, vec!["desktop", "mobile", "tv"]);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Description

Platform manifests could previously only declare-or-replace a whole mode set by name under `extensions/mode-sets/`, forcing a platform to restate every other foundation mode value just to add one (e.g. a third `scale` mode). This adds an `op`-based grammar — `addMode` / `removeMode` / `setDefault` / `remove` — mirroring the existing `extensions/relationships/` add/override/remove precedent, while leaving the no-`op` whole-set add/replace behavior unchanged.

## Related Issue

No open issue tracked this; came out of a design discussion about supporting custom mode declarations (e.g. high contrast, additional color schemes/scale modes) without full-set restatement.

## Motivation and Context

Redeclaring a full mode set to add one value drifts from foundation as foundation evolves. Granular ops let a platform add/drop a single mode value, retarget the default, or drop a whole set, without restating the rest.

## How Has This Been Tested?

- 14 new unit tests in `sdk/core/src/graph.rs` covering every op's success and error paths (missing target, missing required field, unknown op, removing the current default, removing the last mode, retargeting to a non-member default), plus an end-to-end cascade-resolution test.
- 2 new unit tests in `sdk/core/src/manifest.rs` verifying op-only fragments bypass schema validation and that plain adds are ordered before ops regardless of file sort order.
- 8 new conformance fixtures (4 valid, 4 invalid) under `packages/design-data-spec/conformance/manifest-extensions/`.
- Full `design-data-core` lib suite (`cargo nextest run` via `moon run sdk:test`) passes.
- `cargo clippy -p design-data-core --lib -- -D warnings` shows no new warnings (pre-existing `has_relationship_record` dead-code warning predates this change).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.